### PR TITLE
Add cache state data structures

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       duckdb_version: v1.4.4
       ci_tools_version: v1.4.4
-      extension_name: quack
+      extension_name: query_condition_cache
 
   code-quality-check:
     name: Code Quality Check
@@ -26,5 +26,5 @@ jobs:
     with:
       duckdb_version: v1.4.4
       ci_tools_version: v1.4.4
-      extension_name: quack
+      extension_name: query_condition_cache
       format_checks: 'format;tidy'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,13 @@ set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
 project(${TARGET_NAME})
+
+if(UNIX OR APPLE)
+  set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} -Wno-c++17-extensions -Wunused-variable -Wunused-function"
+  )
+endif()
+
 include_directories(src/include)
 
 set(EXTENSION_SOURCES src/query_condition_cache_extension.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 project(${TARGET_NAME})
 include_directories(src/include)
 
-set(EXTENSION_SOURCES src/query_condition_cache_extension.cpp)
+set(EXTENSION_SOURCES src/query_condition_cache_extension.cpp
+                      src/query_condition_cache_state.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})

--- a/src/include/query_condition_cache_extension.hpp
+++ b/src/include/query_condition_cache_extension.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "duckdb.hpp"
+#include "duckdb/main/extension.hpp"
 
 namespace duckdb {
 

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -8,69 +8,34 @@
 namespace duckdb {
 
 // Derived from DuckDB's compile-time configurable constants
-static constexpr idx_t VECTORS_PER_ROW_GROUP = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
-static constexpr idx_t BITVECTOR_WORDS = (VECTORS_PER_ROW_GROUP + 63) / 64;
-static_assert(VECTORS_PER_ROW_GROUP > 0, "VECTORS_PER_ROW_GROUP must be positive");
+inline constexpr idx_t VECTORS_PER_ROW_GROUP = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
+inline constexpr idx_t BITVECTOR_WORDS = (VECTORS_PER_ROW_GROUP + 63) / 64;
+static_assert(DEFAULT_ROW_GROUP_SIZE % STANDARD_VECTOR_SIZE == 0,
+              "DEFAULT_ROW_GROUP_SIZE must be divisible by STANDARD_VECTOR_SIZE");
 
 // Per row-group bitvector: bit[i] = 1 means vector i has at least one qualifying row,
 // for 0 <= i < VECTORS_PER_ROW_GROUP. Callers must not pass out-of-range indices;
+// D_ASSERT enforces this in debug builds only.
 // Backed by array<uint64_t, N> to support configurable row group / vector sizes.
 struct RowGroupBitvector {
 	array<uint64_t, BITVECTOR_WORDS> words = {};
 
-	bool VectorHasRows(idx_t vector_index) const {
-		D_ASSERT(vector_index < VECTORS_PER_ROW_GROUP);
-		return (words[vector_index / 64] >> (vector_index % 64)) & 1ULL;
-	}
-
-	void SetVector(idx_t vector_index) {
-		D_ASSERT(vector_index < VECTORS_PER_ROW_GROUP);
-		words[vector_index / 64] |= (1ULL << (vector_index % 64));
-	}
-
-	bool IsEmpty() const {
-		for (auto &w : words) {
-			if (w != 0) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	idx_t CountSetBits() const {
-		idx_t count = 0;
-		for (auto &w : words) {
-			count += static_cast<idx_t>(__builtin_popcountll(w));
-		}
-		return count;
-	}
+	bool VectorHasRows(idx_t vector_index) const;
+	void SetVector(idx_t vector_index);
+	bool IsEmpty() const;
+	idx_t CountSetBits() const;
 };
 
-// A single cache entry: the bitvectors for one (table, predicate) combination
+// A single cache entry: the bitvectors for one (table, predicate) combination.
+// table_oid is used for lookup within a session.
 struct ConditionCacheEntry {
-	string table_name;
+	idx_t table_oid;
 	string filter_key;
 	unordered_map<idx_t, RowGroupBitvector> bitvectors; // rg_idx -> bitvector
 	idx_t total_qualifying_rows = 0;
 };
 
-// Thread-local state for capturing filter key during query_condition_cache_build
-struct BuildCaptureState {
-	bool active = false;
-	string target_table;
-	string captured_filter_key;
-};
-
-// TODO: Replace thread_local variables with ClientContextState to avoid non-trivial thread_local types.
-
-// Global thread-local build capture state
-extern thread_local BuildCaptureState tl_build_capture;
-
-// Pre-optimize match: table_index -> cache entry to inject in the post-optimize pass.
-// Populated by PreOptimizeFunction, consumed and cleared by OptimizeFunction.
-extern thread_local unordered_map<idx_t, shared_ptr<ConditionCacheEntry>> tl_lookup_pending;
-
-// Stored in DuckDB's per-database ObjectCache, non-evictable
+// Stored in DuckDB's per-database ObjectCache
 class ConditionCacheStore : public ObjectCacheEntry {
 public:
 	static constexpr const char *CACHE_KEY = "query_condition_cache_store";
@@ -86,16 +51,16 @@ public:
 	// Lookup by filter key
 	shared_ptr<ConditionCacheEntry> Lookup(const string &filter_key);
 
-	// Lookup all entries for a table
-	vector<shared_ptr<ConditionCacheEntry>> LookupByTable(const string &table_name);
+	// Lookup all entries for a table by OID
+	vector<shared_ptr<ConditionCacheEntry>> LookupByTable(idx_t table_oid);
 
-	// Insert an entry
+	// Insert or update an entry
 	void Insert(shared_ptr<ConditionCacheEntry> entry);
 
 	// Clear all entries
 	void Clear();
 
-	// Get all entries (for query_condition_cache_info)
+	// Get all entries
 	vector<shared_ptr<ConditionCacheEntry>> GetAll();
 
 	// Get or create the store from a client context

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "duckdb/common/array.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/storage/object_cache.hpp"
+
+namespace duckdb {
+
+// Derived from DuckDB's compile-time configurable constants
+static constexpr idx_t VECTORS_PER_ROW_GROUP = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
+static constexpr idx_t BITVECTOR_WORDS = (VECTORS_PER_ROW_GROUP + 63) / 64;
+
+// Per row-group bitvector: bit[i] = 1 means vector i has at least one qualifying row.
+// Backed by array<uint64_t, N> to support configurable row group / vector sizes.
+struct RowGroupBitvector {
+	array<uint64_t, BITVECTOR_WORDS> words = {};
+
+	bool VectorHasRows(idx_t vector_index) const {
+		D_ASSERT(vector_index < VECTORS_PER_ROW_GROUP);
+		return (words[vector_index / 64] >> (vector_index % 64)) & 1ULL;
+	}
+
+	void SetVector(idx_t vector_index) {
+		D_ASSERT(vector_index < VECTORS_PER_ROW_GROUP);
+		words[vector_index / 64] |= (1ULL << (vector_index % 64));
+	}
+
+	bool IsEmpty() const {
+		for (auto &w : words) {
+			if (w != 0) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	idx_t CountSetBits() const {
+		idx_t count = 0;
+		for (auto &w : words) {
+			uint64_t v = w;
+			while (v) {
+				count += v & 1ULL;
+				v >>= 1;
+			}
+		}
+		return count;
+	}
+};
+
+// A single cache entry: the bitvectors for one (table, predicate) combination
+struct ConditionCacheEntry {
+	string table_name;
+	string filter_key;
+	unordered_map<idx_t, RowGroupBitvector> bitvectors; // rg_idx -> bitvector
+	idx_t total_qualifying_rows = 0;
+};
+
+// Thread-local state for capturing filter key during query_condition_cache_build
+struct BuildCaptureState {
+	bool active = false;
+	string target_table;
+	string captured_filter_key;
+};
+
+// TODO: Replace thread_local variables with ClientContextState to avoid non-trivial thread_local types.
+
+// Global thread-local build capture state
+extern thread_local BuildCaptureState tl_build_capture;
+
+// Pre-optimize match: table_index -> cache entry to inject in the post-optimize pass.
+// Populated by PreOptimizeFunction, consumed and cleared by OptimizeFunction.
+extern thread_local unordered_map<idx_t, shared_ptr<ConditionCacheEntry>> tl_lookup_pending;
+
+// Stored in DuckDB's per-database ObjectCache, non-evictable
+class ConditionCacheStore : public ObjectCacheEntry {
+public:
+	static constexpr const char *CACHE_KEY = "query_condition_cache_store";
+
+	static string ObjectType() {
+		return "query_condition_cache_store";
+	}
+
+	string GetObjectType() override {
+		return ObjectType();
+	}
+
+	// Lookup by filter key
+	shared_ptr<ConditionCacheEntry> Lookup(const string &filter_key);
+
+	// Lookup all entries for a table
+	vector<shared_ptr<ConditionCacheEntry>> LookupByTable(const string &table_name);
+
+	// Insert an entry
+	void Insert(shared_ptr<ConditionCacheEntry> entry);
+
+	// Clear all entries
+	void Clear();
+
+	// Get all entries (for query_condition_cache_info)
+	vector<shared_ptr<ConditionCacheEntry>> GetAll();
+
+	// Get or create the store from a client context
+	static shared_ptr<ConditionCacheStore> GetOrCreate(ClientContext &context);
+
+private:
+	mutex cache_lock;
+	// filter_key -> entry
+	unordered_map<string, shared_ptr<ConditionCacheEntry>> entries;
+};
+
+} // namespace duckdb

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -10,8 +10,10 @@ namespace duckdb {
 // Derived from DuckDB's compile-time configurable constants
 static constexpr idx_t VECTORS_PER_ROW_GROUP = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
 static constexpr idx_t BITVECTOR_WORDS = (VECTORS_PER_ROW_GROUP + 63) / 64;
+static_assert(VECTORS_PER_ROW_GROUP > 0, "VECTORS_PER_ROW_GROUP must be positive");
 
-// Per row-group bitvector: bit[i] = 1 means vector i has at least one qualifying row.
+// Per row-group bitvector: bit[i] = 1 means vector i has at least one qualifying row,
+// for 0 <= i < VECTORS_PER_ROW_GROUP. Callers must not pass out-of-range indices;
 // Backed by array<uint64_t, N> to support configurable row group / vector sizes.
 struct RowGroupBitvector {
 	array<uint64_t, BITVECTOR_WORDS> words = {};
@@ -38,11 +40,7 @@ struct RowGroupBitvector {
 	idx_t CountSetBits() const {
 		idx_t count = 0;
 		for (auto &w : words) {
-			uint64_t v = w;
-			while (v) {
-				count += v & 1ULL;
-				v >>= 1;
-			}
+			count += static_cast<idx_t>(__builtin_popcountll(w));
 		}
 		return count;
 	}

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -46,12 +46,6 @@ struct CacheKeyHashFunction {
 	}
 };
 
-struct CacheKeyEquality {
-	bool operator()(const CacheKey &a, const CacheKey &b) const {
-		return a == b;
-	}
-};
-
 // A single cache entry: the bitvectors for one (table, predicate) combination.
 struct ConditionCacheEntry {
 	unordered_map<idx_t, RowGroupFilter> bitvectors; // rg_idx -> bitvector
@@ -88,7 +82,7 @@ public:
 private:
 	mutex cache_lock;
 	// TODO: Consider sharding for scalability
-	unordered_map<CacheKey, shared_ptr<ConditionCacheEntry>, CacheKeyHashFunction, CacheKeyEquality> entries;
+	unordered_map<CacheKey, shared_ptr<ConditionCacheEntry>, CacheKeyHashFunction> entries;
 };
 
 } // namespace duckdb

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -9,16 +9,15 @@ namespace duckdb {
 
 // Derived from DuckDB's compile-time configurable constants
 inline constexpr idx_t VECTORS_PER_ROW_GROUP = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
-inline constexpr idx_t BITVECTOR_WORDS = (VECTORS_PER_ROW_GROUP + 63) / 64;
+inline constexpr idx_t BITVECTOR_ARRAY_SIZE = (VECTORS_PER_ROW_GROUP + 63) / 64;
 static_assert(DEFAULT_ROW_GROUP_SIZE % STANDARD_VECTOR_SIZE == 0,
               "DEFAULT_ROW_GROUP_SIZE must be divisible by STANDARD_VECTOR_SIZE");
 
 // Per row-group bitvector: bit[i] = 1 means vector i has at least one qualifying row,
-// for 0 <= i < VECTORS_PER_ROW_GROUP. Callers must not pass out-of-range indices;
-// D_ASSERT enforces this in debug builds only.
+// for 0 <= i < VECTORS_PER_ROW_GROUP.
 // Backed by array<uint64_t, N> to support configurable row group / vector sizes.
 struct RowGroupBitvector {
-	array<uint64_t, BITVECTOR_WORDS> words = {};
+	array<uint64_t, BITVECTOR_ARRAY_SIZE> matching_vectors = {};
 
 	bool VectorHasRows(idx_t vector_index) const;
 	void SetVector(idx_t vector_index);
@@ -30,9 +29,7 @@ struct RowGroupBitvector {
 // table_oid is used for lookup within a session.
 struct ConditionCacheEntry {
 	idx_t table_oid;
-	string filter_key;
 	unordered_map<idx_t, RowGroupBitvector> bitvectors; // rg_idx -> bitvector
-	idx_t total_qualifying_rows = 0;
 };
 
 // Stored in DuckDB's per-database ObjectCache
@@ -55,7 +52,7 @@ public:
 	vector<shared_ptr<ConditionCacheEntry>> LookupByTable(idx_t table_oid);
 
 	// Insert or update an entry
-	void Insert(shared_ptr<ConditionCacheEntry> entry);
+	void Insert(const string &filter_key, shared_ptr<ConditionCacheEntry> entry);
 
 	// Clear all entries
 	void Clear();
@@ -68,8 +65,11 @@ public:
 
 private:
 	mutex cache_lock;
+	// TODO: Consider sharding for scalability
 	// filter_key -> entry
 	unordered_map<string, shared_ptr<ConditionCacheEntry>> entries;
+	// table_oid -> filter_keys (for efficient lookup by table)
+	unordered_map<idx_t, vector<string>> entries_by_table;
 };
 
 } // namespace duckdb

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/array.hpp"
 #include "duckdb/common/mutex.hpp"
+#include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/storage/object_cache.hpp"
 
@@ -16,20 +17,44 @@ static_assert(DEFAULT_ROW_GROUP_SIZE % STANDARD_VECTOR_SIZE == 0,
 // Per row-group bitvector: bit[i] = 1 means vector i has at least one qualifying row,
 // for 0 <= i < VECTORS_PER_ROW_GROUP.
 // Backed by array<uint64_t, N> to support configurable row group / vector sizes.
-struct RowGroupBitvector {
+struct RowGroupFilter {
 	array<uint64_t, BITVECTOR_ARRAY_SIZE> matching_vectors = {};
 
+	RowGroupFilter() = default;
+
+	// Construct from vector indices that contain at least one qualifying row.
+	// Each index must be in [0, VECTORS_PER_ROW_GROUP). Duplicates are allowed.
+	explicit RowGroupFilter(const vector<idx_t> &qualifying_vectors);
+
 	bool VectorHasRows(idx_t vector_index) const;
-	void SetVector(idx_t vector_index);
 	bool IsEmpty() const;
-	idx_t CountSetBits() const;
+};
+
+// Composite key for cache lookup: (table_oid, filter_key)
+struct CacheKey {
+	idx_t table_oid;
+	string filter_key;
+
+	bool operator==(const CacheKey &other) const {
+		return table_oid == other.table_oid && filter_key == other.filter_key;
+	}
+};
+
+struct CacheKeyHashFunction {
+	uint64_t operator()(const CacheKey &key) const {
+		return CombineHash(Hash<idx_t>(key.table_oid), Hash(key.filter_key.c_str()));
+	}
+};
+
+struct CacheKeyEquality {
+	bool operator()(const CacheKey &a, const CacheKey &b) const {
+		return a == b;
+	}
 };
 
 // A single cache entry: the bitvectors for one (table, predicate) combination.
-// table_oid is used for lookup within a session.
 struct ConditionCacheEntry {
-	idx_t table_oid;
-	unordered_map<idx_t, RowGroupBitvector> bitvectors; // rg_idx -> bitvector
+	unordered_map<idx_t, RowGroupFilter> bitvectors; // rg_idx -> bitvector
 };
 
 // Stored in DuckDB's per-database ObjectCache
@@ -45,14 +70,11 @@ public:
 		return ObjectType();
 	}
 
-	// Lookup by filter key
-	shared_ptr<ConditionCacheEntry> Lookup(const string &filter_key);
+	// Lookup by cache key; returns nullptr if not found
+	shared_ptr<ConditionCacheEntry> Lookup(const CacheKey &key);
 
-	// Lookup all entries for a table by OID
-	vector<shared_ptr<ConditionCacheEntry>> LookupByTable(idx_t table_oid);
-
-	// Insert or update an entry
-	void Insert(const string &filter_key, shared_ptr<ConditionCacheEntry> entry);
+	// Upsert an entry
+	void Upsert(const CacheKey &key, shared_ptr<ConditionCacheEntry> entry);
 
 	// Clear all entries
 	void Clear();
@@ -66,10 +88,7 @@ public:
 private:
 	mutex cache_lock;
 	// TODO: Consider sharding for scalability
-	// filter_key -> entry
-	unordered_map<string, shared_ptr<ConditionCacheEntry>> entries;
-	// table_oid -> filter_keys (for efficient lookup by table)
-	unordered_map<idx_t, vector<string>> entries_by_table;
+	unordered_map<CacheKey, shared_ptr<ConditionCacheEntry>, CacheKeyHashFunction, CacheKeyEquality> entries;
 };
 
 } // namespace duckdb

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -2,6 +2,8 @@
 
 #include "query_condition_cache_extension.hpp"
 
+#include "duckdb/main/extension/extension_loader.hpp"
+
 namespace duckdb {
 
 namespace {

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -2,8 +2,6 @@
 
 #include "query_condition_cache_extension.hpp"
 
-#include "duckdb.hpp"
-
 namespace duckdb {
 
 namespace {

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -2,11 +2,40 @@
 
 namespace duckdb {
 
-// Thread-local build capture state
-thread_local BuildCaptureState tl_build_capture;
+// ------- ROW_GROUP_BITVECTOR -------
 
-// Thread-local pending cache injections (pre-optimize → post-optimize handoff)
-thread_local unordered_map<idx_t, shared_ptr<ConditionCacheEntry>> tl_lookup_pending;
+bool RowGroupBitvector::VectorHasRows(idx_t vector_index) const {
+	D_ASSERT(vector_index < VECTORS_PER_ROW_GROUP);
+	return (words[vector_index / 64] >> (vector_index % 64)) & 1ULL;
+}
+
+void RowGroupBitvector::SetVector(idx_t vector_index) {
+	D_ASSERT(vector_index < VECTORS_PER_ROW_GROUP);
+	words[vector_index / 64] |= (1ULL << (vector_index % 64));
+}
+
+bool RowGroupBitvector::IsEmpty() const {
+	for (auto &w : words) {
+		if (w != 0) {
+			return false;
+		}
+	}
+	return true;
+}
+
+idx_t RowGroupBitvector::CountSetBits() const {
+	idx_t count = 0;
+	for (auto &w : words) {
+		uint64_t v = w;
+		while (v) {
+			v &= v - 1;
+			++count;
+		}
+	}
+	return count;
+}
+
+// ------- CONDITION_CACHE_STORE -------
 
 shared_ptr<ConditionCacheEntry> ConditionCacheStore::Lookup(const string &filter_key) {
 	lock_guard<mutex> guard(cache_lock);
@@ -17,11 +46,11 @@ shared_ptr<ConditionCacheEntry> ConditionCacheStore::Lookup(const string &filter
 	return nullptr;
 }
 
-vector<shared_ptr<ConditionCacheEntry>> ConditionCacheStore::LookupByTable(const string &table_name) {
+vector<shared_ptr<ConditionCacheEntry>> ConditionCacheStore::LookupByTable(idx_t table_oid) {
 	lock_guard<mutex> guard(cache_lock);
 	vector<shared_ptr<ConditionCacheEntry>> result;
 	for (auto &pair : entries) {
-		if (pair.second->table_name == table_name) {
+		if (pair.second->table_oid == table_oid) {
 			result.push_back(pair.second);
 		}
 	}
@@ -30,7 +59,10 @@ vector<shared_ptr<ConditionCacheEntry>> ConditionCacheStore::LookupByTable(const
 
 void ConditionCacheStore::Insert(shared_ptr<ConditionCacheEntry> entry) {
 	lock_guard<mutex> guard(cache_lock);
-	entries[entry->filter_key] = std::move(entry);
+	auto result = entries.emplace(entry->filter_key, entry);
+	if (!result.second) {
+		result.first->second = std::move(entry);
+	}
 }
 
 void ConditionCacheStore::Clear() {
@@ -39,11 +71,13 @@ void ConditionCacheStore::Clear() {
 }
 
 vector<shared_ptr<ConditionCacheEntry>> ConditionCacheStore::GetAll() {
-	lock_guard<mutex> guard(cache_lock);
 	vector<shared_ptr<ConditionCacheEntry>> result;
-	result.reserve(entries.size());
-	for (auto &pair : entries) {
-		result.push_back(pair.second);
+	{
+		lock_guard<mutex> guard(cache_lock);
+		result.reserve(entries.size());
+		for (auto &pair : entries) {
+			result.push_back(pair.second);
+		}
 	}
 	return result;
 }

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -1,5 +1,7 @@
 #include "query_condition_cache_state.hpp"
 
+#include "duckdb/common/exception.hpp"
+
 namespace duckdb {
 
 // ------- ROW_GROUP_FILTER -------
@@ -35,6 +37,9 @@ shared_ptr<ConditionCacheEntry> ConditionCacheStore::Lookup(const CacheKey &key)
 }
 
 void ConditionCacheStore::Upsert(const CacheKey &key, shared_ptr<ConditionCacheEntry> entry) {
+	if (!entry) {
+		throw InvalidInputException("ConditionCacheStore::Upsert: entry must not be null");
+	}
 	lock_guard<mutex> guard(cache_lock);
 	auto result = entries.emplace(key, entry);
 	if (!result.second) {

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -1,0 +1,56 @@
+#include "query_condition_cache_state.hpp"
+
+namespace duckdb {
+
+// Thread-local build capture state
+thread_local BuildCaptureState tl_build_capture;
+
+// Thread-local pending cache injections (pre-optimize → post-optimize handoff)
+thread_local unordered_map<idx_t, shared_ptr<ConditionCacheEntry>> tl_lookup_pending;
+
+shared_ptr<ConditionCacheEntry> ConditionCacheStore::Lookup(const string &filter_key) {
+	lock_guard<mutex> guard(cache_lock);
+	auto it = entries.find(filter_key);
+	if (it != entries.end()) {
+		return it->second;
+	}
+	return nullptr;
+}
+
+vector<shared_ptr<ConditionCacheEntry>> ConditionCacheStore::LookupByTable(const string &table_name) {
+	lock_guard<mutex> guard(cache_lock);
+	vector<shared_ptr<ConditionCacheEntry>> result;
+	for (auto &pair : entries) {
+		if (pair.second->table_name == table_name) {
+			result.push_back(pair.second);
+		}
+	}
+	return result;
+}
+
+void ConditionCacheStore::Insert(shared_ptr<ConditionCacheEntry> entry) {
+	lock_guard<mutex> guard(cache_lock);
+	entries[entry->filter_key] = std::move(entry);
+}
+
+void ConditionCacheStore::Clear() {
+	lock_guard<mutex> guard(cache_lock);
+	entries.clear();
+}
+
+vector<shared_ptr<ConditionCacheEntry>> ConditionCacheStore::GetAll() {
+	lock_guard<mutex> guard(cache_lock);
+	vector<shared_ptr<ConditionCacheEntry>> result;
+	result.reserve(entries.size());
+	for (auto &pair : entries) {
+		result.push_back(pair.second);
+	}
+	return result;
+}
+
+shared_ptr<ConditionCacheStore> ConditionCacheStore::GetOrCreate(ClientContext &context) {
+	auto &cache = ObjectCache::GetObjectCache(context);
+	return cache.GetOrCreate<ConditionCacheStore>(CACHE_KEY);
+}
+
+} // namespace duckdb

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -5,17 +5,15 @@ namespace duckdb {
 // ------- ROW_GROUP_BITVECTOR -------
 
 bool RowGroupBitvector::VectorHasRows(idx_t vector_index) const {
-	D_ASSERT(vector_index < VECTORS_PER_ROW_GROUP);
-	return (words[vector_index / 64] >> (vector_index % 64)) & 1ULL;
+	return (matching_vectors.at(vector_index / 64) >> (vector_index % 64)) & 1ULL;
 }
 
 void RowGroupBitvector::SetVector(idx_t vector_index) {
-	D_ASSERT(vector_index < VECTORS_PER_ROW_GROUP);
-	words[vector_index / 64] |= (1ULL << (vector_index % 64));
+	matching_vectors.at(vector_index / 64) |= (1ULL << (vector_index % 64));
 }
 
 bool RowGroupBitvector::IsEmpty() const {
-	for (auto &w : words) {
+	for (const auto &w : matching_vectors) {
 		if (w != 0) {
 			return false;
 		}
@@ -25,7 +23,7 @@ bool RowGroupBitvector::IsEmpty() const {
 
 idx_t RowGroupBitvector::CountSetBits() const {
 	idx_t count = 0;
-	for (auto &w : words) {
+	for (const auto &w : matching_vectors) {
 		uint64_t v = w;
 		while (v) {
 			v &= v - 1;
@@ -49,25 +47,34 @@ shared_ptr<ConditionCacheEntry> ConditionCacheStore::Lookup(const string &filter
 vector<shared_ptr<ConditionCacheEntry>> ConditionCacheStore::LookupByTable(idx_t table_oid) {
 	lock_guard<mutex> guard(cache_lock);
 	vector<shared_ptr<ConditionCacheEntry>> result;
-	for (auto &pair : entries) {
-		if (pair.second->table_oid == table_oid) {
-			result.push_back(pair.second);
+	auto it = entries_by_table.find(table_oid);
+	if (it != entries_by_table.end()) {
+		result.reserve(it->second.size());
+		for (const auto &key : it->second) {
+			auto entry_it = entries.find(key);
+			if (entry_it != entries.end()) {
+				result.push_back(entry_it->second);
+			}
 		}
 	}
 	return result;
 }
 
-void ConditionCacheStore::Insert(shared_ptr<ConditionCacheEntry> entry) {
+void ConditionCacheStore::Insert(const string &filter_key, shared_ptr<ConditionCacheEntry> entry) {
 	lock_guard<mutex> guard(cache_lock);
-	auto result = entries.emplace(entry->filter_key, entry);
+	const auto table_oid = entry->table_oid;
+	auto result = entries.emplace(filter_key, entry);
 	if (!result.second) {
 		result.first->second = std::move(entry);
+	} else {
+		entries_by_table[table_oid].push_back(filter_key);
 	}
 }
 
 void ConditionCacheStore::Clear() {
 	lock_guard<mutex> guard(cache_lock);
 	entries.clear();
+	entries_by_table.clear();
 }
 
 vector<shared_ptr<ConditionCacheEntry>> ConditionCacheStore::GetAll() {
@@ -75,7 +82,7 @@ vector<shared_ptr<ConditionCacheEntry>> ConditionCacheStore::GetAll() {
 	{
 		lock_guard<mutex> guard(cache_lock);
 		result.reserve(entries.size());
-		for (auto &pair : entries) {
+		for (const auto &pair : entries) {
 			result.push_back(pair.second);
 		}
 	}

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -2,17 +2,19 @@
 
 namespace duckdb {
 
-// ------- ROW_GROUP_BITVECTOR -------
+// ------- ROW_GROUP_FILTER -------
 
-bool RowGroupBitvector::VectorHasRows(idx_t vector_index) const {
+RowGroupFilter::RowGroupFilter(const vector<idx_t> &qualifying_vectors) {
+	for (const auto &vec_idx : qualifying_vectors) {
+		matching_vectors.at(vec_idx / 64) |= (1ULL << (vec_idx % 64));
+	}
+}
+
+bool RowGroupFilter::VectorHasRows(idx_t vector_index) const {
 	return (matching_vectors.at(vector_index / 64) >> (vector_index % 64)) & 1ULL;
 }
 
-void RowGroupBitvector::SetVector(idx_t vector_index) {
-	matching_vectors.at(vector_index / 64) |= (1ULL << (vector_index % 64));
-}
-
-bool RowGroupBitvector::IsEmpty() const {
+bool RowGroupFilter::IsEmpty() const {
 	for (const auto &w : matching_vectors) {
 		if (w != 0) {
 			return false;
@@ -21,60 +23,28 @@ bool RowGroupBitvector::IsEmpty() const {
 	return true;
 }
 
-idx_t RowGroupBitvector::CountSetBits() const {
-	idx_t count = 0;
-	for (const auto &w : matching_vectors) {
-		uint64_t v = w;
-		while (v) {
-			v &= v - 1;
-			++count;
-		}
-	}
-	return count;
-}
-
 // ------- CONDITION_CACHE_STORE -------
 
-shared_ptr<ConditionCacheEntry> ConditionCacheStore::Lookup(const string &filter_key) {
+shared_ptr<ConditionCacheEntry> ConditionCacheStore::Lookup(const CacheKey &key) {
 	lock_guard<mutex> guard(cache_lock);
-	auto it = entries.find(filter_key);
+	auto it = entries.find(key);
 	if (it != entries.end()) {
 		return it->second;
 	}
 	return nullptr;
 }
 
-vector<shared_ptr<ConditionCacheEntry>> ConditionCacheStore::LookupByTable(idx_t table_oid) {
+void ConditionCacheStore::Upsert(const CacheKey &key, shared_ptr<ConditionCacheEntry> entry) {
 	lock_guard<mutex> guard(cache_lock);
-	vector<shared_ptr<ConditionCacheEntry>> result;
-	auto it = entries_by_table.find(table_oid);
-	if (it != entries_by_table.end()) {
-		result.reserve(it->second.size());
-		for (const auto &key : it->second) {
-			auto entry_it = entries.find(key);
-			if (entry_it != entries.end()) {
-				result.push_back(entry_it->second);
-			}
-		}
-	}
-	return result;
-}
-
-void ConditionCacheStore::Insert(const string &filter_key, shared_ptr<ConditionCacheEntry> entry) {
-	lock_guard<mutex> guard(cache_lock);
-	const auto table_oid = entry->table_oid;
-	auto result = entries.emplace(filter_key, entry);
+	auto result = entries.emplace(key, entry);
 	if (!result.second) {
 		result.first->second = std::move(entry);
-	} else {
-		entries_by_table[table_oid].push_back(filter_key);
 	}
 }
 
 void ConditionCacheStore::Clear() {
 	lock_guard<mutex> guard(cache_lock);
 	entries.clear();
-	entries_by_table.clear();
 }
 
 vector<shared_ptr<ConditionCacheEntry>> ConditionCacheStore::GetAll() {

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -5,7 +5,8 @@ include_directories(${CMAKE_SOURCE_DIR}/src/include)
 include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
-set(QUERY_CACHE_UNITTEST_OBJECTS main.cpp test_bitvector.cpp)
+set(QUERY_CACHE_UNITTEST_OBJECTS main.cpp test_bitvector.cpp
+                                 test_cache_store.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})
 

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${CMAKE_SOURCE_DIR}/src/include)
 include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
-set(QUERY_CACHE_UNITTEST_OBJECTS main.cpp)
+set(QUERY_CACHE_UNITTEST_OBJECTS main.cpp test_bitvector.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})
 

--- a/test/unittest/test_bitvector.cpp
+++ b/test/unittest/test_bitvector.cpp
@@ -3,47 +3,47 @@
 
 using namespace duckdb;
 
-TEST_CASE("RowGroupBitvector - basic operations", "[bitvector]") {
-	RowGroupBitvector bv;
+TEST_CASE("RowGroupFilter - basic operations", "[bitvector]") {
 
-	SECTION("initially empty") {
+	SECTION("default constructor is empty") {
+		RowGroupFilter bv;
 		REQUIRE(bv.IsEmpty());
-		REQUIRE(bv.CountSetBits() == 0);
 		for (idx_t i = 0; i < VECTORS_PER_ROW_GROUP; ++i) {
 			REQUIRE_FALSE(bv.VectorHasRows(i));
 		}
 	}
 
-	SECTION("set and query single vector") {
-		bv.SetVector(0);
+	SECTION("construct with single vector") {
+		RowGroupFilter bv({0});
 		REQUIRE_FALSE(bv.IsEmpty());
 		REQUIRE(bv.VectorHasRows(0));
 		REQUIRE_FALSE(bv.VectorHasRows(1));
-		REQUIRE(bv.CountSetBits() == 1);
 	}
 
-	SECTION("set multiple vectors") {
-		bv.SetVector(0);
-		bv.SetVector(10);
-		bv.SetVector(59);
-		REQUIRE(bv.CountSetBits() == 3);
+	SECTION("construct with multiple vectors") {
+		RowGroupFilter bv({0, 10, 59});
 		REQUIRE(bv.VectorHasRows(0));
 		REQUIRE(bv.VectorHasRows(10));
 		REQUIRE(bv.VectorHasRows(59));
 		REQUIRE_FALSE(bv.VectorHasRows(1));
 	}
 
-	SECTION("set all vectors") {
+	SECTION("construct with all vectors") {
+		vector<idx_t> all;
+		all.reserve(VECTORS_PER_ROW_GROUP);
 		for (idx_t i = 0; i < VECTORS_PER_ROW_GROUP; ++i) {
-			bv.SetVector(i);
+			all.push_back(i);
 		}
-		REQUIRE(bv.CountSetBits() == VECTORS_PER_ROW_GROUP);
+		RowGroupFilter bv(all);
 		REQUIRE_FALSE(bv.IsEmpty());
+		for (idx_t i = 0; i < VECTORS_PER_ROW_GROUP; ++i) {
+			REQUIRE(bv.VectorHasRows(i));
+		}
 	}
 
-	SECTION("SetVector is idempotent") {
-		bv.SetVector(5);
-		bv.SetVector(5);
-		REQUIRE(bv.CountSetBits() == 1);
+	SECTION("duplicate indices are handled correctly") {
+		RowGroupFilter bv({5, 5});
+		REQUIRE(bv.VectorHasRows(5));
+		REQUIRE_FALSE(bv.VectorHasRows(6));
 	}
 }

--- a/test/unittest/test_bitvector.cpp
+++ b/test/unittest/test_bitvector.cpp
@@ -1,0 +1,49 @@
+#include "catch/catch.hpp"
+#include "query_condition_cache_state.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("RowGroupBitvector - basic operations", "[bitvector]") {
+	RowGroupBitvector bv;
+
+	SECTION("initially empty") {
+		REQUIRE(bv.IsEmpty());
+		REQUIRE(bv.CountSetBits() == 0);
+		for (idx_t i = 0; i < VECTORS_PER_ROW_GROUP; ++i) {
+			REQUIRE_FALSE(bv.VectorHasRows(i));
+		}
+	}
+
+	SECTION("set and query single vector") {
+		bv.SetVector(0);
+		REQUIRE_FALSE(bv.IsEmpty());
+		REQUIRE(bv.VectorHasRows(0));
+		REQUIRE_FALSE(bv.VectorHasRows(1));
+		REQUIRE(bv.CountSetBits() == 1);
+	}
+
+	SECTION("set multiple vectors") {
+		bv.SetVector(0);
+		bv.SetVector(10);
+		bv.SetVector(59);
+		REQUIRE(bv.CountSetBits() == 3);
+		REQUIRE(bv.VectorHasRows(0));
+		REQUIRE(bv.VectorHasRows(10));
+		REQUIRE(bv.VectorHasRows(59));
+		REQUIRE_FALSE(bv.VectorHasRows(1));
+	}
+
+	SECTION("set all vectors") {
+		for (idx_t i = 0; i < VECTORS_PER_ROW_GROUP; ++i) {
+			bv.SetVector(i);
+		}
+		REQUIRE(bv.CountSetBits() == VECTORS_PER_ROW_GROUP);
+		REQUIRE_FALSE(bv.IsEmpty());
+	}
+
+	SECTION("SetVector is idempotent") {
+		bv.SetVector(5);
+		bv.SetVector(5);
+		REQUIRE(bv.CountSetBits() == 1);
+	}
+}

--- a/test/unittest/test_cache_store.cpp
+++ b/test/unittest/test_cache_store.cpp
@@ -1,0 +1,89 @@
+#include "catch/catch.hpp"
+#include "query_condition_cache_state.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("ConditionCacheStore - basic operations", "[cache_store]") {
+	ConditionCacheStore store;
+
+	SECTION("lookup empty store returns nullptr") {
+		auto result = store.Lookup("nonexistent");
+		REQUIRE(result == nullptr);
+	}
+
+	SECTION("insert and lookup by filter key") {
+		auto entry = make_shared_ptr<ConditionCacheEntry>();
+		entry->table_oid = 1;
+		store.Insert("col:>5", entry);
+
+		auto found = store.Lookup("col:>5");
+		REQUIRE(found != nullptr);
+		REQUIRE(found->table_oid == 1);
+
+		auto not_found = store.Lookup("col:<10");
+		REQUIRE(not_found == nullptr);
+	}
+
+	SECTION("insert and lookup by table OID") {
+		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
+		entry1->table_oid = 42;
+		store.Insert("col:>5", entry1);
+
+		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
+		entry2->table_oid = 42;
+		store.Insert("col:<10", entry2);
+
+		auto entry3 = make_shared_ptr<ConditionCacheEntry>();
+		entry3->table_oid = 99;
+		store.Insert("val:=1", entry3);
+
+		auto results = store.LookupByTable(42);
+		REQUIRE(results.size() == 2);
+
+		auto results_other = store.LookupByTable(99);
+		REQUIRE(results_other.size() == 1);
+		REQUIRE(results_other[0]->table_oid == 99);
+
+		auto results_empty = store.LookupByTable(0);
+		REQUIRE(results_empty.empty());
+	}
+
+	SECTION("insert duplicate filter key updates entry") {
+		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
+		entry1->table_oid = 1;
+		store.Insert("col:>5", entry1);
+
+		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
+		entry2->table_oid = 2;
+		store.Insert("col:>5", entry2);
+
+		auto found = store.Lookup("col:>5");
+		REQUIRE(found != nullptr);
+		REQUIRE(found->table_oid == 2);
+	}
+
+	SECTION("clear removes all entries") {
+		auto entry = make_shared_ptr<ConditionCacheEntry>();
+		entry->table_oid = 1;
+		store.Insert("col:>5", entry);
+
+		store.Clear();
+
+		REQUIRE(store.Lookup("col:>5") == nullptr);
+		REQUIRE(store.LookupByTable(1).empty());
+		REQUIRE(store.GetAll().empty());
+	}
+
+	SECTION("get all returns all entries") {
+		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
+		entry1->table_oid = 1;
+		store.Insert("col:>5", entry1);
+
+		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
+		entry2->table_oid = 2;
+		store.Insert("col:<10", entry2);
+
+		auto all = store.GetAll();
+		REQUIRE(all.size() == 2);
+	}
+}

--- a/test/unittest/test_cache_store.cpp
+++ b/test/unittest/test_cache_store.cpp
@@ -1,6 +1,8 @@
 #include "catch/catch.hpp"
 #include "query_condition_cache_state.hpp"
 
+#include "duckdb/common/exception.hpp"
+
 using namespace duckdb;
 
 TEST_CASE("ConditionCacheStore - basic operations", "[cache_store]") {
@@ -67,5 +69,9 @@ TEST_CASE("ConditionCacheStore - basic operations", "[cache_store]") {
 
 		auto all = store.GetAll();
 		REQUIRE(all.size() == 2);
+	}
+
+	SECTION("upsert null entry throws") {
+		REQUIRE_THROWS_AS(store.Upsert({1, "col:>5"}, nullptr), InvalidInputException);
 	}
 }

--- a/test/unittest/test_cache_store.cpp
+++ b/test/unittest/test_cache_store.cpp
@@ -7,81 +7,63 @@ TEST_CASE("ConditionCacheStore - basic operations", "[cache_store]") {
 	ConditionCacheStore store;
 
 	SECTION("lookup empty store returns nullptr") {
-		auto result = store.Lookup("nonexistent");
+		auto result = store.Lookup({1, "nonexistent"});
 		REQUIRE(result == nullptr);
 	}
 
-	SECTION("insert and lookup by filter key") {
+	SECTION("upsert and lookup by cache key") {
 		auto entry = make_shared_ptr<ConditionCacheEntry>();
-		entry->table_oid = 1;
-		store.Insert("col:>5", entry);
+		store.Upsert({1, "col:>5"}, entry);
 
-		auto found = store.Lookup("col:>5");
+		auto found = store.Lookup({1, "col:>5"});
 		REQUIRE(found != nullptr);
-		REQUIRE(found->table_oid == 1);
 
-		auto not_found = store.Lookup("col:<10");
+		auto not_found = store.Lookup({1, "col:<10"});
 		REQUIRE(not_found == nullptr);
+
+		auto wrong_oid = store.Lookup({2, "col:>5"});
+		REQUIRE(wrong_oid == nullptr);
 	}
 
-	SECTION("insert and lookup by table OID") {
+	SECTION("upsert duplicate key updates entry") {
 		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
-		entry1->table_oid = 42;
-		store.Insert("col:>5", entry1);
+		store.Upsert({1, "col:>5"}, entry1);
 
 		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
-		entry2->table_oid = 42;
-		store.Insert("col:<10", entry2);
+		store.Upsert({1, "col:>5"}, entry2);
 
-		auto entry3 = make_shared_ptr<ConditionCacheEntry>();
-		entry3->table_oid = 99;
-		store.Insert("val:=1", entry3);
-
-		auto results = store.LookupByTable(42);
-		REQUIRE(results.size() == 2);
-
-		auto results_other = store.LookupByTable(99);
-		REQUIRE(results_other.size() == 1);
-		REQUIRE(results_other[0]->table_oid == 99);
-
-		auto results_empty = store.LookupByTable(0);
-		REQUIRE(results_empty.empty());
-	}
-
-	SECTION("insert duplicate filter key updates entry") {
-		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
-		entry1->table_oid = 1;
-		store.Insert("col:>5", entry1);
-
-		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
-		entry2->table_oid = 2;
-		store.Insert("col:>5", entry2);
-
-		auto found = store.Lookup("col:>5");
+		auto found = store.Lookup({1, "col:>5"});
 		REQUIRE(found != nullptr);
-		REQUIRE(found->table_oid == 2);
+		REQUIRE(found == entry2);
+	}
+
+	SECTION("different oid same filter_key are separate entries") {
+		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
+		store.Upsert({1, "col:>5"}, entry1);
+
+		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
+		store.Upsert({2, "col:>5"}, entry2);
+
+		REQUIRE(store.Lookup({1, "col:>5"}) == entry1);
+		REQUIRE(store.Lookup({2, "col:>5"}) == entry2);
 	}
 
 	SECTION("clear removes all entries") {
 		auto entry = make_shared_ptr<ConditionCacheEntry>();
-		entry->table_oid = 1;
-		store.Insert("col:>5", entry);
+		store.Upsert({1, "col:>5"}, entry);
 
 		store.Clear();
 
-		REQUIRE(store.Lookup("col:>5") == nullptr);
-		REQUIRE(store.LookupByTable(1).empty());
+		REQUIRE(store.Lookup({1, "col:>5"}) == nullptr);
 		REQUIRE(store.GetAll().empty());
 	}
 
 	SECTION("get all returns all entries") {
 		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
-		entry1->table_oid = 1;
-		store.Insert("col:>5", entry1);
+		store.Upsert({1, "col:>5"}, entry1);
 
 		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
-		entry2->table_oid = 2;
-		store.Insert("col:<10", entry2);
+		store.Upsert({2, "col:<10"}, entry2);
 
 		auto all = store.GetAll();
 		REQUIRE(all.size() == 2);


### PR DESCRIPTION
## Summary

This PR add the data structures for the query condition cache extension:

- RowGroupBitvector: Per-row-group bitmap tracking which vectors
    contain qualifying rows. Uses `array<uint64_t, N>` where N is
    computed at compile time from `DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE`.

- ConditionCacheEntry: A single cache entry for a (table, predicate)
    pair. Uses table OID for lookup to survive renames within a session.
    Stores serialized filter key, a map of row group index to bitvector,
    and total qualifying row count.

- ConditionCacheStore: In-memory cache store backed by DuckDB's
    per-database `ObjectCache`. Supports lookup by filter key or table OID,
    insert, clear, and get-all operations, all protected by a mutex.