### PR TITLE
Add condition_cache_build table function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(${TARGET_NAME})
 
 if(UNIX OR APPLE)
   set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} -Wno-c++17-extensions -Wunused-variable -Wunused-function"
+      "${CMAKE_CXX_FLAGS} -Wno-c++17-extensions -Wno-c++20-extensions -Wunused-variable -Wunused-function"
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 include_directories(src/include)
 
 set(EXTENSION_SOURCES src/query_condition_cache_extension.cpp
+                      src/query_condition_cache_functions.cpp
                       src/query_condition_cache_state.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})

--- a/src/include/query_condition_cache_functions.hpp
+++ b/src/include/query_condition_cache_functions.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/function/table_function.hpp"
+
+namespace duckdb {
+
+class DuckTableEntry;
+class Expression;
+
+// Scan all rows in the table, evaluate bound_expr, and build a ConditionCacheEntry
+// recording which vectors contain qualifying rows.
+// Modifies bound_expr in-place (remaps column indices to scan positions).
+shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTableEntry &table_entry,
+                                                Expression &bound_expr, idx_t &total_qualifying_rows);
+
+TableFunction ConditionCacheBuildFunction();
+
+} // namespace duckdb

--- a/src/include/query_condition_cache_functions.hpp
+++ b/src/include/query_condition_cache_functions.hpp
@@ -14,7 +14,7 @@ class Expression;
 // recording which vectors contain qualifying rows.
 // Modifies bound_expr in-place (remaps column indices to scan positions).
 shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTableEntry &table_entry,
-                                                Expression &bound_expr, idx_t &total_qualifying_rows);
+                                                Expression &bound_expr);
 
 struct CacheEntryStats {
 	idx_t qualifying_vectors;

--- a/src/include/query_condition_cache_functions.hpp
+++ b/src/include/query_condition_cache_functions.hpp
@@ -9,11 +9,22 @@ namespace duckdb {
 class DuckTableEntry;
 class Expression;
 
+// TODO: Exposed for future reuse and C++ unit testing.
 // Scan all rows in the table, evaluate bound_expr, and build a ConditionCacheEntry
 // recording which vectors contain qualifying rows.
 // Modifies bound_expr in-place (remaps column indices to scan positions).
 shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTableEntry &table_entry,
                                                 Expression &bound_expr, idx_t &total_qualifying_rows);
+
+struct CacheEntryStats {
+	idx_t qualifying_vectors;
+	idx_t total_vectors;
+	idx_t qualifying_row_groups;
+	idx_t total_row_groups;
+};
+
+// TODO: Exposed for future reuse. 
+CacheEntryStats ComputeCacheEntryStats(const ConditionCacheEntry &entry, idx_t total_rows);
 
 TableFunction ConditionCacheBuildFunction();
 

--- a/src/include/query_condition_cache_functions.hpp
+++ b/src/include/query_condition_cache_functions.hpp
@@ -23,7 +23,7 @@ struct CacheEntryStats {
 	idx_t total_row_groups;
 };
 
-// TODO: Exposed for future reuse. 
+// TODO: Exposed for future reuse.
 CacheEntryStats ComputeCacheEntryStats(const ConditionCacheEntry &entry, idx_t total_rows);
 
 TableFunction ConditionCacheBuildFunction();

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -26,6 +26,7 @@ struct RowGroupFilter {
 	// Each index must be in [0, VECTORS_PER_ROW_GROUP). Duplicates are allowed.
 	explicit RowGroupFilter(const vector<idx_t> &qualifying_vectors);
 
+	void SetVector(idx_t vector_index);
 	bool VectorHasRows(idx_t vector_index) const;
 	bool IsEmpty() const;
 };

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -1,14 +1,11 @@
 #define DUCKDB_EXTENSION_MAIN
 
 #include "query_condition_cache_extension.hpp"
+#include "query_condition_cache_functions.hpp"
 
-#include "duckdb/function/table_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
 namespace duckdb {
-
-// Defined in query_condition_cache_functions.cpp
-TableFunction ConditionCacheBuildFunction();
 
 namespace {
 void LoadInternal(ExtensionLoader &loader) {

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -2,13 +2,17 @@
 
 #include "query_condition_cache_extension.hpp"
 
+#include "duckdb/function/table_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
 namespace duckdb {
 
+// Defined in query_condition_cache_functions.cpp
+TableFunction ConditionCacheBuildFunction();
+
 namespace {
 void LoadInternal(ExtensionLoader &loader) {
-	// Functions and optimizer will be registered in subsequent PRs.
+	loader.RegisterFunction(ConditionCacheBuildFunction());
 }
 } // namespace
 

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -1,9 +1,9 @@
 #define DUCKDB_EXTENSION_MAIN
 
 #include "query_condition_cache_extension.hpp"
-#include "query_condition_cache_functions.hpp"
 
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "query_condition_cache_functions.hpp"
 
 namespace duckdb {
 

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -33,7 +33,7 @@ struct ConditionCacheBuildBindData : public TableFunctionData {
 	string table;
 	string predicate_sql;
 	idx_t table_oid;
-	idx_t total_rows;
+	idx_t total_rows; // total number of rows in the table
 };
 
 struct ConditionCacheBuildState : public GlobalTableFunctionState {
@@ -48,9 +48,9 @@ unique_ptr<FunctionData> ConditionCacheBuildBind(ClientContext &context, TableFu
 	// Parse qualified table name (supports "table", "schema.table", "catalog.schema.table")
 	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
 	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
-	result->catalog = qname.catalog;
-	result->schema = qname.schema;
-	result->table = qname.name;
+	result->catalog = std::move(qname.catalog);
+	result->schema = std::move(qname.schema);
+	result->table = std::move(qname.name);
 
 	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, result->catalog, result->schema, result->table);
 	result->table_oid = table_entry.oid;
@@ -66,20 +66,32 @@ unique_ptr<GlobalTableFunctionState> ConditionCacheBuildInit(ClientContext &cont
 	return make_uniq<ConditionCacheBuildState>();
 }
 
+// Collect all column OIDs referenced by bound expressions (BoundReferenceExpression).
+void CollectReferencedColumns(Expression &expr, unordered_set<column_t> &column_oids) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
+		auto &ref = expr.Cast<BoundReferenceExpression>();
+		column_oids.insert(ref.index);
+	}
+	ExpressionIterator::EnumerateChildren(expr,
+	                                      [&](Expression &child) { CollectReferencedColumns(child, column_oids); });
+}
+
 // After binding, column indices refer to StorageOid which may not match the scan order.
 // Remap them to the actual DataChunk column positions.
-void RemapColumnIndices(Expression &expr, const unordered_map<idx_t, idx_t> &mapping) {
+void RemapColumnIndices(Expression &expr, const unordered_map<column_t, idx_t> &mapping) {
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
 		auto &ref = expr.Cast<BoundReferenceExpression>();
 		auto it = mapping.find(ref.index);
-		if (it != mapping.end()) {
-			ref.index = it->second;
-		}
+		D_ASSERT(it != mapping.end());
+		ref.index = it->second;
 	}
-	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) {
-		RemapColumnIndices(child, mapping);
-	});
+	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) { RemapColumnIndices(child, mapping); });
 }
+
+struct ScanColumn {
+	StorageIndex index;
+	LogicalType type;
+};
 
 } // namespace
 
@@ -90,23 +102,34 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 	auto &storage = table_entry.GetStorage();
 	auto &columns = table_entry.GetColumns();
 
-	// Scan all physical columns (needed by the predicate expression) plus rowid
-	vector<pair<StorageIndex, LogicalType>> scan_columns;
-	unordered_map<idx_t, idx_t> storage_to_scan_idx;
+	// Only scan columns referenced by the predicate, plus rowid
+	unordered_set<column_t> referenced_oids;
+	CollectReferencedColumns(bound_expr, referenced_oids);
+
+	vector<ScanColumn> scan_columns;
+	// Maps storage column OID to scan position in DataChunk
+	unordered_map<column_t, idx_t> storage_to_scan_idx;
+
+	scan_columns.reserve(referenced_oids.size() + 1);
 
 	idx_t scan_pos = 0;
-	for (auto &col : columns.Physical()) {
-		scan_columns.emplace_back(StorageIndex(col.Oid()), col.Type());
+	for (const auto &col : columns.Physical()) {
+		if (referenced_oids.count(col.Oid()) == 0) {
+			continue;
+		}
+		scan_columns.push_back({StorageIndex(col.Oid()), col.Type()});
 		storage_to_scan_idx[col.Oid()] = scan_pos++;
 	}
 	const idx_t rowid_col_idx = scan_pos;
-	scan_columns.emplace_back(StorageIndex(COLUMN_IDENTIFIER_ROW_ID), LogicalType::ROW_TYPE);
+	scan_columns.push_back({StorageIndex(COLUMN_IDENTIFIER_ROW_ID), LogicalType {LogicalType::ROW_TYPE}});
 
 	vector<StorageIndex> column_ids;
 	vector<LogicalType> scan_types;
-	for (const auto &[id, type] : scan_columns) {
-		column_ids.push_back(id);
-		scan_types.push_back(type);
+	column_ids.reserve(scan_columns.size());
+	scan_types.reserve(scan_columns.size());
+	for (const auto &sc : scan_columns) {
+		column_ids.push_back(sc.index);
+		scan_types.push_back(sc.type);
 	}
 
 	RemapColumnIndices(bound_expr, storage_to_scan_idx);
@@ -119,7 +142,7 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 	// Scan and evaluate predicate
 	ExpressionExecutor executor(context, bound_expr);
 
-	unordered_map<idx_t, unordered_set<idx_t>> row_group_vec_indices;
+	auto entry = make_shared_ptr<ConditionCacheEntry>();
 
 	while (true) {
 		DataChunk chunk;
@@ -137,24 +160,18 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 		rowid_vec.ToUnifiedFormat(chunk.size(), rowid_data);
 		auto rowids = UnifiedVectorFormat::GetData<row_t>(rowid_data);
 
-		for (idx_t i = 0; i < match_count; ++i) {
-			auto rid_idx = rowid_data.sel->get_index(sel.get_index(i));
-			if (!rowid_data.validity.RowIsValid(rid_idx)) {
+		for (idx_t idx = 0; idx < match_count; ++idx) {
+			auto rowid_entry = rowid_data.sel->get_index(sel.get_index(idx));
+			if (!rowid_data.validity.RowIsValid(rowid_entry)) {
 				continue;
 			}
-			auto row_id = NumericCast<idx_t>(rowids[rid_idx]);
+			auto row_id = NumericCast<idx_t>(rowids[rowid_entry]);
 			idx_t row_group_idx = row_id / DEFAULT_ROW_GROUP_SIZE;
 			idx_t vector_idx = (row_id % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
-			row_group_vec_indices[row_group_idx].insert(vector_idx);
+			entry->bitvectors[row_group_idx].SetVector(vector_idx);
 		}
 	}
 
-	// Build cache entry from collected indices
-	auto entry = make_shared_ptr<ConditionCacheEntry>();
-	for (const auto &pair : row_group_vec_indices) {
-		vector<idx_t> indices(pair.second.begin(), pair.second.end());
-		entry->bitvectors.emplace(pair.first, RowGroupFilter(indices));
-	}
 	return entry;
 }
 
@@ -180,7 +197,12 @@ CacheEntryStats ComputeCacheEntryStats(const ConditionCacheEntry &entry, idx_t t
 	idx_t qualifying_row_groups = entry.bitvectors.size();
 	idx_t total_row_groups = (total_rows + DEFAULT_ROW_GROUP_SIZE - 1) / DEFAULT_ROW_GROUP_SIZE;
 
-	return {qualifying_vectors, total_vectors, qualifying_row_groups, total_row_groups};
+	CacheEntryStats stats;
+	stats.qualifying_vectors = qualifying_vectors;
+	stats.total_vectors = total_vectors;
+	stats.qualifying_row_groups = qualifying_row_groups;
+	stats.total_row_groups = total_row_groups;
+	return stats;
 }
 
 void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
@@ -211,12 +233,9 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	CheckBinder check_binder(*binder, context, bind_data.table, table_entry.GetColumns(), bound_columns);
 	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-	// CheckBinder sets target_type = INTEGER, so all expressions get cast to INTEGER.
-	// Re-cast to BOOLEAN for SelectExpression.
-	if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
-		bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
-		                                               LogicalType {LogicalTypeId::BOOLEAN});
-	}
+	// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN for SelectExpression.
+	bound_expr =
+	    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
 
 	auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 	auto stats = ComputeCacheEntryStats(*entry, bind_data.total_rows);
@@ -229,17 +248,16 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	store->Upsert(key, std::move(entry));
 
 	output.SetCardinality(1);
-	output.data[0].SetValue(
-	    0, StringUtil::Format("Cache Built: %llu/%llu vectors, %llu/%llu row groups",
-	                          stats.qualifying_vectors, stats.total_vectors,
-	                          stats.qualifying_row_groups, stats.total_row_groups));
+	output.data[0].SetValue(0, StringUtil::Format("Cache Built: %llu/%llu vectors, %llu/%llu row groups",
+	                                              stats.qualifying_vectors, stats.total_vectors,
+	                                              stats.qualifying_row_groups, stats.total_row_groups));
 }
 
 TableFunction ConditionCacheBuildFunction() {
-	TableFunction func("condition_cache_build",
-	                   {LogicalType {LogicalTypeId::VARCHAR} /*table*/,
-	                    LogicalType {LogicalTypeId::VARCHAR} /*predicate_sql*/},
-	                   ConditionCacheBuildExecute, ConditionCacheBuildBind, ConditionCacheBuildInit);
+	TableFunction func(
+	    "condition_cache_build",
+	    {LogicalType {LogicalTypeId::VARCHAR} /*table*/, LogicalType {LogicalTypeId::VARCHAR} /*predicate_sql*/},
+	    ConditionCacheBuildExecute, ConditionCacheBuildBind, ConditionCacheBuildInit);
 	return func;
 }
 

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -197,12 +197,12 @@ CacheEntryStats ComputeCacheEntryStats(const ConditionCacheEntry &entry, idx_t t
 	idx_t qualifying_row_groups = entry.bitvectors.size();
 	idx_t total_row_groups = (total_rows + DEFAULT_ROW_GROUP_SIZE - 1) / DEFAULT_ROW_GROUP_SIZE;
 
-	CacheEntryStats stats;
-	stats.qualifying_vectors = qualifying_vectors;
-	stats.total_vectors = total_vectors;
-	stats.qualifying_row_groups = qualifying_row_groups;
-	stats.total_row_groups = total_row_groups;
-	return stats;
+	return CacheEntryStats {
+	    .qualifying_vectors = qualifying_vectors,
+	    .total_vectors = total_vectors,
+	    .qualifying_row_groups = qualifying_row_groups,
+	    .total_row_groups = total_row_groups,
+	};
 }
 
 void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -1,5 +1,4 @@
 #include "query_condition_cache_functions.hpp"
-#include "query_condition_cache_state.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
@@ -21,6 +20,7 @@
 #include "duckdb/storage/storage_index.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
+#include "query_condition_cache_state.hpp"
 
 namespace duckdb {
 namespace {
@@ -30,7 +30,7 @@ namespace {
 struct ConditionCacheBuildBindData : public TableFunctionData {
 	string catalog;
 	string schema;
-	string table_name;
+	string table;
 	string predicate_sql;
 	idx_t table_oid;
 	idx_t total_rows;
@@ -50,9 +50,9 @@ unique_ptr<FunctionData> ConditionCacheBuildBind(ClientContext &context, TableFu
 	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
 	result->catalog = qname.catalog;
 	result->schema = qname.schema;
-	result->table_name = qname.name;
+	result->table = qname.name;
 
-	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, result->catalog, result->schema, result->table_name);
+	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, result->catalog, result->schema, result->table);
 	result->table_oid = table_entry.oid;
 	result->total_rows = table_entry.GetStorage().GetTotalRows();
 
@@ -91,19 +91,23 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 	auto &columns = table_entry.GetColumns();
 
 	// Scan all physical columns (needed by the predicate expression) plus rowid
-	vector<StorageIndex> column_ids;
-	vector<LogicalType> scan_types;
+	vector<pair<StorageIndex, LogicalType>> scan_columns;
 	unordered_map<idx_t, idx_t> storage_to_scan_idx;
 
 	idx_t scan_pos = 0;
 	for (auto &col : columns.Physical()) {
-		column_ids.push_back(StorageIndex(col.Oid()));
-		scan_types.push_back(col.Type());
+		scan_columns.emplace_back(StorageIndex(col.Oid()), col.Type());
 		storage_to_scan_idx[col.Oid()] = scan_pos++;
 	}
 	idx_t rowid_col_idx = scan_pos;
-	column_ids.push_back(StorageIndex(COLUMN_IDENTIFIER_ROW_ID));
-	scan_types.push_back(LogicalType::ROW_TYPE);
+	scan_columns.emplace_back(StorageIndex(COLUMN_IDENTIFIER_ROW_ID), LogicalType::ROW_TYPE);
+
+	vector<StorageIndex> column_ids;
+	vector<LogicalType> scan_types;
+	for (auto &[id, type] : scan_columns) {
+		column_ids.push_back(id);
+		scan_types.push_back(type);
+	}
 
 	RemapColumnIndices(bound_expr, storage_to_scan_idx);
 
@@ -113,15 +117,14 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 	storage.InitializeScan(context, transaction, scan_state, column_ids);
 
 	// Scan and evaluate predicate
-	DataChunk chunk;
-	chunk.Initialize(Allocator::Get(context), scan_types);
 	ExpressionExecutor executor(context, bound_expr);
 
 	unordered_map<idx_t, unordered_set<idx_t>> row_group_vec_indices;
 	total_qualifying_rows = 0;
 
 	while (true) {
-		chunk.Reset();
+		DataChunk chunk;
+		chunk.Initialize(Allocator::Get(context), scan_types);
 		storage.Scan(transaction, chunk, scan_state);
 		if (chunk.size() == 0) {
 			break;
@@ -167,19 +170,26 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	const auto &bind_data = data_p.bind_data->Cast<ConditionCacheBuildBindData>();
 
 	auto &table_entry =
-	    Catalog::GetEntry<DuckTableEntry>(context, bind_data.catalog, bind_data.schema, bind_data.table_name);
+	    Catalog::GetEntry<DuckTableEntry>(context, bind_data.catalog, bind_data.schema, bind_data.table);
 
 	// Parse predicate SQL and bind column references to table columns
 	auto parsed_exprs = Parser::ParseExpressionList(bind_data.predicate_sql);
 	if (parsed_exprs.empty()) {
 		throw InvalidInputException("condition_cache_build: failed to parse predicate");
 	}
+	// Reject bare column references (e.g. predicate = 'val')
+	if (parsed_exprs[0]->GetExpressionClass() == ExpressionClass::COLUMN_REF) {
+		throw InvalidInputException(
+		    "condition_cache_build: predicate must be a boolean expression, not a column reference");
+	}
+
 	auto binder = Binder::CreateBinder(context);
 	physical_index_set_t bound_columns;
-	CheckBinder check_binder(*binder, context, bind_data.table_name, table_entry.GetColumns(), bound_columns);
+	CheckBinder check_binder(*binder, context, bind_data.table, table_entry.GetColumns(), bound_columns);
 	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-	// SelectExpression requires BOOLEAN return type
+	// CheckBinder sets target_type = INTEGER, so all expressions get cast to INTEGER.
+	// Re-cast to BOOLEAN for SelectExpression.
 	if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
 		bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
 		                                               LogicalType {LogicalTypeId::BOOLEAN});
@@ -225,7 +235,7 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 
 TableFunction ConditionCacheBuildFunction() {
 	TableFunction func("condition_cache_build",
-	                   {LogicalType {LogicalTypeId::VARCHAR} /*table_name*/,
+	                   {LogicalType {LogicalTypeId::VARCHAR} /*table*/,
 	                    LogicalType {LogicalTypeId::VARCHAR} /*predicate_sql*/},
 	                   ConditionCacheBuildExecute, ConditionCacheBuildBind, ConditionCacheBuildInit);
 	return func;

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -99,12 +99,12 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 		scan_columns.emplace_back(StorageIndex(col.Oid()), col.Type());
 		storage_to_scan_idx[col.Oid()] = scan_pos++;
 	}
-	idx_t rowid_col_idx = scan_pos;
+	const idx_t rowid_col_idx = scan_pos;
 	scan_columns.emplace_back(StorageIndex(COLUMN_IDENTIFIER_ROW_ID), LogicalType::ROW_TYPE);
 
 	vector<StorageIndex> column_ids;
 	vector<LogicalType> scan_types;
-	for (auto &[id, type] : scan_columns) {
+	for (const auto &[id, type] : scan_columns) {
 		column_ids.push_back(id);
 		scan_types.push_back(type);
 	}
@@ -160,6 +160,31 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 	return entry;
 }
 
+CacheEntryStats ComputeCacheEntryStats(const ConditionCacheEntry &entry, idx_t total_rows) {
+	constexpr idx_t vectors_per_row_group = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
+
+	idx_t qualifying_vectors = 0;
+	for (const auto &bitvector_pair : entry.bitvectors) {
+		for (idx_t v = 0; v < vectors_per_row_group; ++v) {
+			if (bitvector_pair.second.VectorHasRows(v)) {
+				++qualifying_vectors;
+			}
+		}
+	}
+
+	idx_t full_row_groups = total_rows / DEFAULT_ROW_GROUP_SIZE;
+	idx_t remaining_rows = total_rows % DEFAULT_ROW_GROUP_SIZE;
+	idx_t total_vectors = full_row_groups * vectors_per_row_group;
+	if (remaining_rows > 0) {
+		total_vectors += (remaining_rows + STANDARD_VECTOR_SIZE - 1) / STANDARD_VECTOR_SIZE;
+	}
+
+	idx_t qualifying_row_groups = entry.bitvectors.size();
+	idx_t total_row_groups = (total_rows + DEFAULT_ROW_GROUP_SIZE - 1) / DEFAULT_ROW_GROUP_SIZE;
+
+	return {qualifying_vectors, total_vectors, qualifying_row_groups, total_row_groups};
+}
+
 void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &gstate = data_p.global_state->Cast<ConditionCacheBuildState>();
 	if (gstate.done) {
@@ -198,26 +223,7 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	idx_t total_qualifying_rows = 0;
 	auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
 
-	// Compute statistics
-	constexpr idx_t vectors_per_row_group = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
-	idx_t qualifying_row_groups = entry->bitvectors.size();
-	idx_t total_row_groups = (bind_data.total_rows + DEFAULT_ROW_GROUP_SIZE - 1) / DEFAULT_ROW_GROUP_SIZE;
-
-	idx_t qualifying_vectors = 0;
-	for (const auto &bitvector_pair : entry->bitvectors) {
-		for (idx_t v = 0; v < vectors_per_row_group; ++v) {
-			if (bitvector_pair.second.VectorHasRows(v)) {
-				++qualifying_vectors;
-			}
-		}
-	}
-
-	idx_t full_row_groups = bind_data.total_rows / DEFAULT_ROW_GROUP_SIZE;
-	idx_t remaining_rows = bind_data.total_rows % DEFAULT_ROW_GROUP_SIZE;
-	idx_t total_vectors = full_row_groups * vectors_per_row_group;
-	if (remaining_rows > 0) {
-		total_vectors += (remaining_rows + STANDARD_VECTOR_SIZE - 1) / STANDARD_VECTOR_SIZE;
-	}
+	auto stats = ComputeCacheEntryStats(*entry, bind_data.total_rows);
 
 	// Store in cache
 	// TODO: Use canonical predicate key (sorted expressions) so that "a AND b" and "b AND a" hit same entry
@@ -229,8 +235,8 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	output.SetCardinality(1);
 	output.data[0].SetValue(
 	    0, StringUtil::Format("Cache Built: %llu qualifying rows, %llu/%llu vectors, %llu/%llu row groups",
-	                          total_qualifying_rows, qualifying_vectors, total_vectors, qualifying_row_groups,
-	                          total_row_groups));
+	                          total_qualifying_rows, stats.qualifying_vectors, stats.total_vectors,
+	                          stats.qualifying_row_groups, stats.total_row_groups));
 }
 
 TableFunction ConditionCacheBuildFunction() {

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -1,16 +1,26 @@
+#include "query_condition_cache_functions.hpp"
 #include "query_condition_cache_state.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/common/allocator.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/table_function.hpp"
-#include "duckdb/main/connection.hpp"
-#include "duckdb/main/database.hpp"
-#include "duckdb/parser/keyword_helper.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/qualified_name.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/expression_binder/check_binder.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/storage/storage_index.hpp"
+#include "duckdb/storage/table/scan_state.hpp"
+#include "duckdb/transaction/duck_transaction.hpp"
 
 namespace duckdb {
 namespace {
@@ -18,6 +28,8 @@ namespace {
 // ------- condition_cache_build(table_name VARCHAR, predicate VARCHAR) -------
 
 struct ConditionCacheBuildBindData : public TableFunctionData {
+	string catalog;
+	string schema;
 	string table_name;
 	string predicate_sql;
 	idx_t table_oid;
@@ -31,11 +43,16 @@ struct ConditionCacheBuildState : public GlobalTableFunctionState {
 unique_ptr<FunctionData> ConditionCacheBuildBind(ClientContext &context, TableFunctionBindInput &input,
                                                  vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_uniq<ConditionCacheBuildBindData>();
-	result->table_name = input.inputs[0].GetValue<string>();
 	result->predicate_sql = input.inputs[1].GetValue<string>();
 
-	// Resolve table to get OID and total rows; throws if table doesn't exist
-	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, result->table_name);
+	// Parse qualified table name (supports "table", "schema.table", "catalog.schema.table")
+	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
+	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
+	result->catalog = qname.catalog;
+	result->schema = qname.schema;
+	result->table_name = qname.name;
+
+	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, result->catalog, result->schema, result->table_name);
 	result->table_oid = table_entry.oid;
 	result->total_rows = table_entry.GetStorage().GetTotalRows();
 
@@ -49,47 +66,81 @@ unique_ptr<GlobalTableFunctionState> ConditionCacheBuildInit(ClientContext &cont
 	return make_uniq<ConditionCacheBuildState>();
 }
 
-void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-	auto &gstate = data_p.global_state->Cast<ConditionCacheBuildState>();
-	if (gstate.done) {
-		return;
+// After binding, column indices refer to StorageOid which may not match the scan order.
+// Remap them to the actual DataChunk column positions.
+void RemapColumnIndices(Expression &expr, const unordered_map<idx_t, idx_t> &mapping) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
+		auto &ref = expr.Cast<BoundReferenceExpression>();
+		auto it = mapping.find(ref.index);
+		if (it != mapping.end()) {
+			ref.index = it->second;
+		}
 	}
-	gstate.done = true;
+	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) {
+		RemapColumnIndices(child, mapping);
+	});
+}
 
-	const auto &bind_data = data_p.bind_data->Cast<ConditionCacheBuildBindData>();
+} // namespace
 
-	// Run SELECT rowid on a new connection
-	string quoted_table = KeywordHelper::WriteQuoted(bind_data.table_name, '"');
-	string query = StringUtil::Format("SELECT rowid FROM %s WHERE %s", quoted_table, bind_data.predicate_sql);
-	auto &db = DatabaseInstance::GetDatabase(context);
-	Connection con(db);
-	auto result = con.Query(query);
+// Scan all rows, evaluate predicate, and build a ConditionCacheEntry.
+// Modifies bound_expr in-place (remaps column indices to scan positions).
+shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTableEntry &table_entry,
+                                                Expression &bound_expr, idx_t &total_qualifying_rows) {
+	auto &storage = table_entry.GetStorage();
+	auto &columns = table_entry.GetColumns();
 
-	if (result->HasError()) {
-		throw InvalidInputException("condition_cache_build: query failed: %s", result->GetError());
+	// Scan all physical columns (needed by the predicate expression) plus rowid
+	vector<StorageIndex> column_ids;
+	vector<LogicalType> scan_types;
+	unordered_map<idx_t, idx_t> storage_to_scan_idx;
+
+	idx_t scan_pos = 0;
+	for (auto &col : columns.Physical()) {
+		column_ids.push_back(StorageIndex(col.Oid()));
+		scan_types.push_back(col.Type());
+		storage_to_scan_idx[col.Oid()] = scan_pos++;
 	}
+	idx_t rowid_col_idx = scan_pos;
+	column_ids.push_back(StorageIndex(COLUMN_IDENTIFIER_ROW_ID));
+	scan_types.push_back(LogicalType::ROW_TYPE);
 
-	// Collect qualifying vector indices per row group
+	RemapColumnIndices(bound_expr, storage_to_scan_idx);
+
+	// Direct table scan with predicate evaluation via ExpressionExecutor
+	auto &transaction = DuckTransaction::Get(context, table_entry.ParentCatalog().GetAttached());
+	TableScanState scan_state;
+	storage.InitializeScan(context, transaction, scan_state, column_ids);
+
+	// Scan and evaluate predicate
+	DataChunk chunk;
+	chunk.Initialize(Allocator::Get(context), scan_types);
+	ExpressionExecutor executor(context, bound_expr);
+
 	unordered_map<idx_t, unordered_set<idx_t>> row_group_vec_indices;
-	idx_t total_qualifying_rows = 0;
+	total_qualifying_rows = 0;
 
 	while (true) {
-		auto chunk = result->Fetch();
-		if (!chunk || chunk->size() == 0) {
+		chunk.Reset();
+		storage.Scan(transaction, chunk, scan_state);
+		if (chunk.size() == 0) {
 			break;
 		}
 
-		auto &rowid_vec = chunk->data[0];
-		UnifiedVectorFormat vector_data;
-		rowid_vec.ToUnifiedFormat(chunk->size(), vector_data);
-		auto rowids = UnifiedVectorFormat::GetData<int64_t>(vector_data);
+		SelectionVector sel(chunk.size());
+		idx_t match_count = executor.SelectExpression(chunk, sel);
 
-		for (idx_t i = 0; i < chunk->size(); ++i) {
-			auto idx = vector_data.sel->get_index(i);
-			if (!vector_data.validity.RowIsValid(idx)) {
+		auto &rowid_vec = chunk.data[rowid_col_idx];
+		UnifiedVectorFormat rowid_data;
+		rowid_vec.ToUnifiedFormat(chunk.size(), rowid_data);
+		auto rowids = UnifiedVectorFormat::GetData<row_t>(rowid_data);
+
+		for (idx_t i = 0; i < match_count; ++i) {
+			auto rid_idx = rowid_data.sel->get_index(sel.get_index(i));
+			if (!rowid_data.validity.RowIsValid(rid_idx)) {
 				continue;
 			}
-			auto row_id = NumericCast<idx_t>(rowids[idx]);
+			auto row_id = NumericCast<idx_t>(rowids[rid_idx]);
 			idx_t row_group_idx = row_id / DEFAULT_ROW_GROUP_SIZE;
 			idx_t vector_idx = (row_id % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
 			row_group_vec_indices[row_group_idx].insert(vector_idx);
@@ -103,10 +154,43 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 		vector<idx_t> indices(pair.second.begin(), pair.second.end());
 		entry->bitvectors.emplace(pair.first, RowGroupFilter(indices));
 	}
+	return entry;
+}
+
+void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &gstate = data_p.global_state->Cast<ConditionCacheBuildState>();
+	if (gstate.done) {
+		return;
+	}
+	gstate.done = true;
+
+	const auto &bind_data = data_p.bind_data->Cast<ConditionCacheBuildBindData>();
+
+	auto &table_entry =
+	    Catalog::GetEntry<DuckTableEntry>(context, bind_data.catalog, bind_data.schema, bind_data.table_name);
+
+	// Parse predicate SQL and bind column references to table columns
+	auto parsed_exprs = Parser::ParseExpressionList(bind_data.predicate_sql);
+	if (parsed_exprs.empty()) {
+		throw InvalidInputException("condition_cache_build: failed to parse predicate");
+	}
+	auto binder = Binder::CreateBinder(context);
+	physical_index_set_t bound_columns;
+	CheckBinder check_binder(*binder, context, bind_data.table_name, table_entry.GetColumns(), bound_columns);
+	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+
+	// SelectExpression requires BOOLEAN return type
+	if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
+		bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
+		                                               LogicalType {LogicalTypeId::BOOLEAN});
+	}
+
+	idx_t total_qualifying_rows = 0;
+	auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
 
 	// Compute statistics
 	constexpr idx_t vectors_per_row_group = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
-	idx_t qualifying_row_groups = row_group_vec_indices.size();
+	idx_t qualifying_row_groups = entry->bitvectors.size();
 	idx_t total_row_groups = (bind_data.total_rows + DEFAULT_ROW_GROUP_SIZE - 1) / DEFAULT_ROW_GROUP_SIZE;
 
 	idx_t qualifying_vectors = 0;
@@ -127,8 +211,7 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 
 	// Store in cache
 	// TODO: Use canonical predicate key (sorted expressions) so that "a AND b" and "b AND a" hit same entry
-	// TODO: Invalidate cache on table modification (INSERT/DELETE/UPDATE/VACUUM), need to implement invalidation
-	// mechanism
+	// TODO: Invalidate cache on table modification (INSERT/DELETE/UPDATE/VACUUM)
 	CacheKey key {bind_data.table_oid, bind_data.predicate_sql};
 	auto store = ConditionCacheStore::GetOrCreate(context);
 	store->Upsert(key, std::move(entry));
@@ -140,11 +223,10 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	                          total_row_groups));
 }
 
-} // namespace
-
 TableFunction ConditionCacheBuildFunction() {
 	TableFunction func("condition_cache_build",
-	                   {LogicalType {LogicalTypeId::VARCHAR}, LogicalType {LogicalTypeId::VARCHAR}},
+	                   {LogicalType {LogicalTypeId::VARCHAR} /*table_name*/,
+	                    LogicalType {LogicalTypeId::VARCHAR} /*predicate_sql*/},
 	                   ConditionCacheBuildExecute, ConditionCacheBuildBind, ConditionCacheBuildInit);
 	return func;
 }

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -86,7 +86,7 @@ void RemapColumnIndices(Expression &expr, const unordered_map<idx_t, idx_t> &map
 // Scan all rows, evaluate predicate, and build a ConditionCacheEntry.
 // Modifies bound_expr in-place (remaps column indices to scan positions).
 shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTableEntry &table_entry,
-                                                Expression &bound_expr, idx_t &total_qualifying_rows) {
+                                                Expression &bound_expr) {
 	auto &storage = table_entry.GetStorage();
 	auto &columns = table_entry.GetColumns();
 
@@ -120,7 +120,6 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 	ExpressionExecutor executor(context, bound_expr);
 
 	unordered_map<idx_t, unordered_set<idx_t>> row_group_vec_indices;
-	total_qualifying_rows = 0;
 
 	while (true) {
 		DataChunk chunk;
@@ -147,7 +146,6 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 			idx_t row_group_idx = row_id / DEFAULT_ROW_GROUP_SIZE;
 			idx_t vector_idx = (row_id % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
 			row_group_vec_indices[row_group_idx].insert(vector_idx);
-			++total_qualifying_rows;
 		}
 	}
 
@@ -220,9 +218,7 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 		                                               LogicalType {LogicalTypeId::BOOLEAN});
 	}
 
-	idx_t total_qualifying_rows = 0;
-	auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
-
+	auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 	auto stats = ComputeCacheEntryStats(*entry, bind_data.total_rows);
 
 	// Store in cache
@@ -234,8 +230,8 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 
 	output.SetCardinality(1);
 	output.data[0].SetValue(
-	    0, StringUtil::Format("Cache Built: %llu qualifying rows, %llu/%llu vectors, %llu/%llu row groups",
-	                          total_qualifying_rows, stats.qualifying_vectors, stats.total_vectors,
+	    0, StringUtil::Format("Cache Built: %llu/%llu vectors, %llu/%llu row groups",
+	                          stats.qualifying_vectors, stats.total_vectors,
 	                          stats.qualifying_row_groups, stats.total_row_groups));
 }
 

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -1,0 +1,152 @@
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/unordered_set.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/parser/keyword_helper.hpp"
+
+namespace duckdb {
+namespace {
+
+// ------- condition_cache_build(table_name VARCHAR, predicate VARCHAR) -------
+
+struct ConditionCacheBuildBindData : public TableFunctionData {
+	string table_name;
+	string predicate_sql;
+	idx_t table_oid;
+	idx_t total_rows;
+};
+
+struct ConditionCacheBuildState : public GlobalTableFunctionState {
+	bool done = false;
+};
+
+unique_ptr<FunctionData> ConditionCacheBuildBind(ClientContext &context, TableFunctionBindInput &input,
+                                                 vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_uniq<ConditionCacheBuildBindData>();
+	result->table_name = input.inputs[0].GetValue<string>();
+	result->predicate_sql = input.inputs[1].GetValue<string>();
+
+	// Resolve table to get OID and total rows; throws if table doesn't exist
+	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, result->table_name);
+	result->table_oid = table_entry.oid;
+	result->total_rows = table_entry.GetStorage().GetTotalRows();
+
+	names.emplace_back("status");
+	return_types.emplace_back(LogicalType {LogicalTypeId::VARCHAR});
+
+	return result;
+}
+
+unique_ptr<GlobalTableFunctionState> ConditionCacheBuildInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_uniq<ConditionCacheBuildState>();
+}
+
+void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &gstate = data_p.global_state->Cast<ConditionCacheBuildState>();
+	if (gstate.done) {
+		return;
+	}
+	gstate.done = true;
+
+	const auto &bind_data = data_p.bind_data->Cast<ConditionCacheBuildBindData>();
+
+	// Run SELECT rowid on a new connection
+	string quoted_table = KeywordHelper::WriteQuoted(bind_data.table_name, '"');
+	string query = StringUtil::Format("SELECT rowid FROM %s WHERE %s", quoted_table, bind_data.predicate_sql);
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection con(db);
+	auto result = con.Query(query);
+
+	if (result->HasError()) {
+		throw InvalidInputException("condition_cache_build: query failed: %s", result->GetError());
+	}
+
+	// Collect qualifying vector indices per row group
+	unordered_map<idx_t, unordered_set<idx_t>> row_group_vec_indices;
+	idx_t total_qualifying_rows = 0;
+
+	while (true) {
+		auto chunk = result->Fetch();
+		if (!chunk || chunk->size() == 0) {
+			break;
+		}
+
+		auto &rowid_vec = chunk->data[0];
+		UnifiedVectorFormat vector_data;
+		rowid_vec.ToUnifiedFormat(chunk->size(), vector_data);
+		auto rowids = UnifiedVectorFormat::GetData<int64_t>(vector_data);
+
+		for (idx_t i = 0; i < chunk->size(); ++i) {
+			auto idx = vector_data.sel->get_index(i);
+			if (!vector_data.validity.RowIsValid(idx)) {
+				continue;
+			}
+			auto row_id = NumericCast<idx_t>(rowids[idx]);
+			idx_t row_group_idx = row_id / DEFAULT_ROW_GROUP_SIZE;
+			idx_t vector_idx = (row_id % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
+			row_group_vec_indices[row_group_idx].insert(vector_idx);
+			++total_qualifying_rows;
+		}
+	}
+
+	// Build cache entry from collected indices
+	auto entry = make_shared_ptr<ConditionCacheEntry>();
+	for (const auto &pair : row_group_vec_indices) {
+		vector<idx_t> indices(pair.second.begin(), pair.second.end());
+		entry->bitvectors.emplace(pair.first, RowGroupFilter(indices));
+	}
+
+	// Compute statistics
+	constexpr idx_t vectors_per_row_group = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
+	idx_t qualifying_row_groups = row_group_vec_indices.size();
+	idx_t total_row_groups = (bind_data.total_rows + DEFAULT_ROW_GROUP_SIZE - 1) / DEFAULT_ROW_GROUP_SIZE;
+
+	idx_t qualifying_vectors = 0;
+	for (const auto &bitvector_pair : entry->bitvectors) {
+		for (idx_t v = 0; v < vectors_per_row_group; ++v) {
+			if (bitvector_pair.second.VectorHasRows(v)) {
+				++qualifying_vectors;
+			}
+		}
+	}
+
+	idx_t full_row_groups = bind_data.total_rows / DEFAULT_ROW_GROUP_SIZE;
+	idx_t remaining_rows = bind_data.total_rows % DEFAULT_ROW_GROUP_SIZE;
+	idx_t total_vectors = full_row_groups * vectors_per_row_group;
+	if (remaining_rows > 0) {
+		total_vectors += (remaining_rows + STANDARD_VECTOR_SIZE - 1) / STANDARD_VECTOR_SIZE;
+	}
+
+	// Store in cache
+	// TODO: Use canonical predicate key (sorted expressions) so that "a AND b" and "b AND a" hit same entry
+	// TODO: Invalidate cache on table modification (INSERT/DELETE/UPDATE/VACUUM), need to implement invalidation
+	// mechanism
+	CacheKey key {bind_data.table_oid, bind_data.predicate_sql};
+	auto store = ConditionCacheStore::GetOrCreate(context);
+	store->Upsert(key, std::move(entry));
+
+	output.SetCardinality(1);
+	output.data[0].SetValue(
+	    0, StringUtil::Format("Cache Built: %llu qualifying rows, %llu/%llu vectors, %llu/%llu row groups",
+	                          total_qualifying_rows, qualifying_vectors, total_vectors, qualifying_row_groups,
+	                          total_row_groups));
+}
+
+} // namespace
+
+TableFunction ConditionCacheBuildFunction() {
+	TableFunction func("condition_cache_build",
+	                   {LogicalType {LogicalTypeId::VARCHAR}, LogicalType {LogicalTypeId::VARCHAR}},
+	                   ConditionCacheBuildExecute, ConditionCacheBuildBind, ConditionCacheBuildInit);
+	return func;
+}
+
+} // namespace duckdb

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -222,12 +222,6 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	if (parsed_exprs.empty()) {
 		throw InvalidInputException("condition_cache_build: failed to parse predicate");
 	}
-	// Reject bare column references (e.g. predicate = 'val')
-	if (parsed_exprs[0]->GetExpressionClass() == ExpressionClass::COLUMN_REF) {
-		throw InvalidInputException(
-		    "condition_cache_build: predicate must be a boolean expression, not a column reference");
-	}
-
 	auto binder = Binder::CreateBinder(context);
 	physical_index_set_t bound_columns;
 	CheckBinder check_binder(*binder, context, bind_data.table, table_entry.GetColumns(), bound_columns);

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -12,6 +12,10 @@ RowGroupFilter::RowGroupFilter(const vector<idx_t> &qualifying_vectors) {
 	}
 }
 
+void RowGroupFilter::SetVector(idx_t vector_index) {
+	matching_vectors.at(vector_index / 64) |= (1ULL << (vector_index % 64));
+}
+
 bool RowGroupFilter::VectorHasRows(idx_t vector_index) const {
 	return (matching_vectors.at(vector_index / 64) >> (vector_index % 64)) & 1ULL;
 }

--- a/test/sql/condition_cache_build.test
+++ b/test/sql/condition_cache_build.test
@@ -12,19 +12,19 @@ CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i);
 query I
 SELECT status FROM condition_cache_build('t', 'val = 42');
 ----
-Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+Cache Built: 245/245 vectors, 5/5 row groups
 
 # Build with selective predicate (only hits RG0, 2 vectors)
 query I
 SELECT status FROM condition_cache_build('t', 'id < 3000');
 ----
-Cache Built: 3000 qualifying rows, 2/245 vectors, 1/5 row groups
+Cache Built: 2/245 vectors, 1/5 row groups
 
 # Build same predicate again (upsert, no error)
 query I
 SELECT status FROM condition_cache_build('t', 'val = 42');
 ----
-Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+Cache Built: 245/245 vectors, 5/5 row groups
 
 # Non-BOOLEAN predicate throws error
 statement error
@@ -48,13 +48,13 @@ does not contain column invalid_col
 query I
 SELECT status FROM condition_cache_build('main.t', 'val = 42');
 ----
-Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+Cache Built: 245/245 vectors, 5/5 row groups
 
 # Fully qualified table name (catalog.schema.table)
 query I
 SELECT status FROM condition_cache_build('memory.main.t', 'val = 42');
 ----
-Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+Cache Built: 245/245 vectors, 5/5 row groups
 
 # Invalid schema name
 statement error

--- a/test/sql/condition_cache_build.test
+++ b/test/sql/condition_cache_build.test
@@ -26,6 +26,12 @@ SELECT status FROM condition_cache_build('t', 'val = 42');
 ----
 Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
 
+# Non-BOOLEAN predicate throws error
+statement error
+SELECT * FROM condition_cache_build('t', 'val');
+----
+predicate must be a boolean expression
+
 # Nonexistent table throws error
 statement error
 SELECT * FROM condition_cache_build('nonexistent', 'val = 42');
@@ -49,3 +55,15 @@ query I
 SELECT status FROM condition_cache_build('memory.main.t', 'val = 42');
 ----
 Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+
+# Invalid schema name
+statement error
+SELECT * FROM condition_cache_build('bad_schema.t', 'val = 42');
+----
+Table with name t does not exist
+
+# Invalid database name
+statement error
+SELECT * FROM condition_cache_build('bad_catalog.main.t', 'val = 42');
+----
+Catalog "bad_catalog" does not exist

--- a/test/sql/condition_cache_build.test
+++ b/test/sql/condition_cache_build.test
@@ -1,0 +1,39 @@
+# name: test/sql/condition_cache_build.test
+# description: Test condition_cache_build table function
+# group: [sql]
+
+require query_condition_cache
+
+# Create table with multiple row groups (>122880 rows)
+statement ok
+CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i);
+
+# Build cache for simple equality predicate
+query I
+SELECT status FROM condition_cache_build('t', 'val = 42');
+----
+Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+
+# Build with selective predicate (only hits RG0, 2 vectors)
+query I
+SELECT status FROM condition_cache_build('t', 'id < 3000');
+----
+Cache Built: 3000 qualifying rows, 2/245 vectors, 1/5 row groups
+
+# Build same predicate again (upsert, no error)
+query I
+SELECT status FROM condition_cache_build('t', 'val = 42');
+----
+Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+
+# Nonexistent table throws error
+statement error
+SELECT * FROM condition_cache_build('nonexistent', 'val = 42');
+----
+Table with name nonexistent does not exist
+
+# Invalid predicate throws error
+statement error
+SELECT * FROM condition_cache_build('t', 'invalid_col = 42');
+----
+not found in FROM clause

--- a/test/sql/condition_cache_build.test
+++ b/test/sql/condition_cache_build.test
@@ -26,12 +26,6 @@ SELECT status FROM condition_cache_build('t', 'val = 42');
 ----
 Cache Built: 245/245 vectors, 5/5 row groups
 
-# Non-BOOLEAN predicate throws error
-statement error
-SELECT * FROM condition_cache_build('t', 'val');
-----
-predicate must be a boolean expression
-
 # Nonexistent table throws error
 statement error
 SELECT * FROM condition_cache_build('nonexistent', 'val = 42');
@@ -67,3 +61,12 @@ statement error
 SELECT * FROM condition_cache_build('bad_catalog.main.t', 'val = 42');
 ----
 Catalog "bad_catalog" does not exist
+
+# Non-castable column as predicate throws error
+statement ok
+CREATE TABLE t_str AS SELECT 'hello' AS name;
+
+statement error
+SELECT * FROM condition_cache_build('t_str', 'name');
+----
+Could not convert string

--- a/test/sql/condition_cache_build.test
+++ b/test/sql/condition_cache_build.test
@@ -36,4 +36,16 @@ Table with name nonexistent does not exist
 statement error
 SELECT * FROM condition_cache_build('t', 'invalid_col = 42');
 ----
-not found in FROM clause
+does not contain column invalid_col
+
+# Qualified table name with schema
+query I
+SELECT status FROM condition_cache_build('main.t', 'val = 42');
+----
+Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+
+# Fully qualified table name (catalog.schema.table)
+query I
+SELECT status FROM condition_cache_build('memory.main.t', 'val = 42');
+----
+Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
 set(QUERY_CACHE_UNITTEST_OBJECTS main.cpp test_bitvector.cpp
+                                 test_build_cache_entry.cpp
                                  test_cache_store.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -5,9 +5,8 @@ include_directories(${CMAKE_SOURCE_DIR}/src/include)
 include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
-set(QUERY_CACHE_UNITTEST_OBJECTS main.cpp test_bitvector.cpp
-                                 test_build_cache_entry.cpp
-                                 test_cache_store.cpp)
+set(QUERY_CACHE_UNITTEST_OBJECTS
+    main.cpp test_bitvector.cpp test_build_cache_entry.cpp test_cache_store.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})
 

--- a/test/unittest/test_build_cache_entry.cpp
+++ b/test/unittest/test_build_cache_entry.cpp
@@ -35,11 +35,9 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 			                                               LogicalType {LogicalTypeId::BOOLEAN});
 		}
 
-		idx_t total_qualifying_rows = 0;
-		auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
+		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
 		REQUIRE(entry != nullptr);
-		REQUIRE(total_qualifying_rows == 5000);
 		REQUIRE(entry->bitvectors.size() == 5); // 5 row groups
 	}
 
@@ -55,11 +53,9 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 			                                               LogicalType {LogicalTypeId::BOOLEAN});
 		}
 
-		idx_t total_qualifying_rows = 0;
-		auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
+		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
 		REQUIRE(entry != nullptr);
-		REQUIRE(total_qualifying_rows == 3000);
 		REQUIRE(entry->bitvectors.size() == 1); // only row group 0
 	}
 
@@ -75,11 +71,9 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 			                                               LogicalType {LogicalTypeId::BOOLEAN});
 		}
 
-		idx_t total_qualifying_rows = 0;
-		auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
+		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
 		REQUIRE(entry != nullptr);
-		REQUIRE(total_qualifying_rows == 0);
 		REQUIRE(entry->bitvectors.empty());
 	}
 }

--- a/test/unittest/test_build_cache_entry.cpp
+++ b/test/unittest/test_build_cache_entry.cpp
@@ -30,10 +30,9 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
 		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-		if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
-			bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
-			                                               LogicalType {LogicalTypeId::BOOLEAN});
-		}
+		// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN
+		bound_expr =
+		    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
 
 		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
@@ -48,15 +47,32 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
 		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-		if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
-			bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
-			                                               LogicalType {LogicalTypeId::BOOLEAN});
-		}
+		// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN
+		bound_expr =
+		    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
 
 		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
 		REQUIRE(entry != nullptr);
 		REQUIRE(entry->bitvectors.size() == 1); // only row group 0
+	}
+
+	SECTION("odd values pass, even values don't") {
+		auto parsed_exprs = Parser::ParseExpressionList("val % 2 = 1");
+		auto binder = Binder::CreateBinder(context);
+		physical_index_set_t bound_columns;
+		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
+		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+
+		// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN
+		bound_expr =
+		    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
+
+		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
+
+		REQUIRE(entry != nullptr);
+		// Odd values exist in every row group, so all 5 row groups should be present
+		REQUIRE(entry->bitvectors.size() == 5);
 	}
 
 	SECTION("no matching rows") {
@@ -66,10 +82,9 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
 		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-		if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
-			bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
-			                                               LogicalType {LogicalTypeId::BOOLEAN});
-		}
+		// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN
+		bound_expr =
+		    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
 
 		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 

--- a/test/unittest/test_build_cache_entry.cpp
+++ b/test/unittest/test_build_cache_entry.cpp
@@ -1,0 +1,85 @@
+#include "catch/catch.hpp"
+#include "query_condition_cache_functions.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression_binder/check_binder.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	// Create table with enough rows to span multiple row groups
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+
+	auto &context = *con.context;
+	con.BeginTransaction();
+	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, "t");
+
+	SECTION("equality predicate") {
+		auto parsed_exprs = Parser::ParseExpressionList("val = 42");
+		auto binder = Binder::CreateBinder(context);
+		physical_index_set_t bound_columns;
+		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
+		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+
+		if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
+			bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
+			                                               LogicalType {LogicalTypeId::BOOLEAN});
+		}
+
+		idx_t total_qualifying_rows = 0;
+		auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
+
+		REQUIRE(entry != nullptr);
+		REQUIRE(total_qualifying_rows == 5000);
+		REQUIRE(entry->bitvectors.size() == 5); // 5 row groups
+	}
+
+	SECTION("selective predicate") {
+		auto parsed_exprs = Parser::ParseExpressionList("id < 3000");
+		auto binder = Binder::CreateBinder(context);
+		physical_index_set_t bound_columns;
+		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
+		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+
+		if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
+			bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
+			                                               LogicalType {LogicalTypeId::BOOLEAN});
+		}
+
+		idx_t total_qualifying_rows = 0;
+		auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
+
+		REQUIRE(entry != nullptr);
+		REQUIRE(total_qualifying_rows == 3000);
+		REQUIRE(entry->bitvectors.size() == 1); // only row group 0
+	}
+
+	SECTION("no matching rows") {
+		auto parsed_exprs = Parser::ParseExpressionList("id < 0");
+		auto binder = Binder::CreateBinder(context);
+		physical_index_set_t bound_columns;
+		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
+		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+
+		if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
+			bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
+			                                               LogicalType {LogicalTypeId::BOOLEAN});
+		}
+
+		idx_t total_qualifying_rows = 0;
+		auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
+
+		REQUIRE(entry != nullptr);
+		REQUIRE(total_qualifying_rows == 0);
+		REQUIRE(entry->bitvectors.empty());
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds a table function `condition_cache_build(table_name, predicate_sql)` for users to create the condition cache manually. Internally, the table is resolved by OID and supports qualified table names (`schema.table`, `catalog.schema.table`). Cache was builded by using storage-layer APIs directly. 

## Note

This PR has two open TODOs to be addressed in the future:
- Cache invalidation mechanism — see #4 
- Canonical predicate key extraction — see #5 
