### PR TITLE
[Demo] Add logical and physical cache invalidation operators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,13 @@ endif()
 
 include_directories(src/include)
 
-set(EXTENSION_SOURCES
-    src/query_condition_cache_extension.cpp
-    src/query_condition_cache_filter.cpp
-    src/query_condition_cache_functions.cpp
-    src/query_condition_cache_optimizer.cpp
-    src/query_condition_cache_state.cpp)
+set(EXTENSION_SOURCES src/logical_cache_invalidator.cpp
+                      src/physical_cache_invalidator.cpp
+                      src/query_condition_cache_extension.cpp
+                      src/query_condition_cache_filter.cpp
+                      src/query_condition_cache_functions.cpp
+                      src/query_condition_cache_optimizer.cpp
+                      src/query_condition_cache_state.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})

--- a/src/include/logical_cache_invalidator.hpp
+++ b/src/include/logical_cache_invalidator.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "duckdb/planner/operator/logical_extension_operator.hpp"
+#include "physical_cache_invalidator.hpp"
+
+namespace duckdb {
+
+struct LogicalCacheInvalidator : public LogicalExtensionOperator {
+	idx_t table_oid;
+	CacheInvalidatorMode mode;
+	idx_t row_id_column_index;  // for ROW_ID mode
+	bool row_id_is_last_column; // for UPDATE (resolve in CreatePlan)
+	idx_t pre_insert_row_count; // for INSERT/MERGE modes
+
+	// For DELETE: pass the row_id expression to be resolved during column binding.
+	LogicalCacheInvalidator(idx_t table_oid, unique_ptr<Expression> row_id_expr);
+
+	// For UPDATE: row_id is always the last column of the child output.
+	explicit LogicalCacheInvalidator(idx_t table_oid);
+
+	// For INSERT: count rows and compute affected range.
+	LogicalCacheInvalidator(idx_t table_oid, idx_t pre_insert_row_count);
+
+	// For MERGE: hybrid — track row IDs (at row_id_column_index) for matched rows
+	// and count unmatched rows for the insert range.
+	LogicalCacheInvalidator(idx_t table_oid, idx_t row_id_column_index, idx_t pre_insert_row_count);
+
+	PhysicalOperator &CreatePlan(ClientContext &context, PhysicalPlanGenerator &planner) override;
+	vector<ColumnBinding> GetColumnBindings() override;
+
+protected:
+	void ResolveTypes() override;
+};
+
+} // namespace duckdb

--- a/src/include/physical_cache_invalidator.hpp
+++ b/src/include/physical_cache_invalidator.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "duckdb/execution/physical_operator.hpp"
+
+namespace duckdb {
+
+enum class CacheInvalidatorMode : uint8_t {
+	// DELETE/UPDATE: observe row IDs at row_id_column_index
+	ROW_ID,
+	// INSERT: count rows and compute affected range from pre_insert_row_count
+	INSERT,
+	// MERGE: hybrid — track row IDs for matched rows (UPDATE/DELETE) and count
+	// unmatched rows (INSERT) to compute the insert range
+	MERGE
+};
+
+struct CacheInvalidatorGlobalState : public GlobalOperatorState {
+	mutex lock;
+	unordered_set<idx_t> affected_row_groups;
+	idx_t inserted_row_count = 0; // used in INSERT and MERGE modes
+};
+
+class PhysicalCacheInvalidator : public PhysicalOperator {
+public:
+	PhysicalCacheInvalidator(PhysicalPlan &physical_plan, idx_t table_oid, CacheInvalidatorMode mode,
+	                         idx_t row_id_column_index, idx_t pre_insert_row_count, vector<LogicalType> types,
+	                         idx_t estimated_cardinality);
+
+	idx_t table_oid;
+	CacheInvalidatorMode mode;
+	idx_t row_id_column_index;
+	idx_t pre_insert_row_count;
+
+	unique_ptr<GlobalOperatorState> GetGlobalOperatorState(ClientContext &context) const override;
+	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+	                           GlobalOperatorState &gstate, OperatorState &state) const override;
+	OperatorFinalResultType OperatorFinalize(Pipeline &pipeline, Event &event, ClientContext &context,
+	                                         OperatorFinalizeInput &input) const override;
+	bool RequiresOperatorFinalize() const override;
+	bool ParallelOperator() const override;
+	string GetName() const override;
+	InsertionOrderPreservingMap<string> ParamsToString() const override;
+};
+
+} // namespace duckdb

--- a/src/include/query_condition_cache_functions.hpp
+++ b/src/include/query_condition_cache_functions.hpp
@@ -27,5 +27,6 @@ struct CacheEntryStats {
 CacheEntryStats ComputeCacheEntryStats(const ConditionCacheEntry &entry, idx_t total_rows);
 
 TableFunction ConditionCacheBuildFunction();
+TableFunction ConditionCacheInfoFunction();
 
 } // namespace duckdb

--- a/src/include/query_condition_cache_optimizer.hpp
+++ b/src/include/query_condition_cache_optimizer.hpp
@@ -38,4 +38,16 @@ private:
 	static void InjectCacheFilter(unique_ptr<LogicalOperator> &get_plan, shared_ptr<ConditionCacheEntry> entry);
 };
 
+class CacheInvalidationOptimizer : public OptimizerExtension {
+public:
+	CacheInvalidationOptimizer();
+
+	//! Post-optimize: walk the plan and inject cache invalidation operators for DML statements
+	static void OptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
+
+private:
+	//! Walk plan to find DML operators (INSERT/UPDATE/DELETE/MERGE) and inject invalidation
+	static void WalkPlanForDML(ClientContext &context, unique_ptr<LogicalOperator> &op);
+};
+
 } // namespace duckdb

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/storage/object_cache.hpp"
 
 namespace duckdb {
@@ -76,6 +77,12 @@ public:
 
 	// Get all entries
 	vector<shared_ptr<ConditionCacheEntry>> GetAll();
+
+	// Remove specific row groups from all entries for a table. Returns count of row groups removed.
+	idx_t RemoveRowGroupsForTable(idx_t table_oid, const unordered_set<idx_t> &row_group_indices);
+
+	// Remove ALL entries for a table (used for INSERT invalidation). Returns count of entries removed.
+	idx_t RemoveByTable(idx_t table_oid);
 
 	// Get or create the store from a client context
 	static shared_ptr<ConditionCacheStore> GetOrCreate(ClientContext &context);

--- a/src/logical_cache_invalidator.cpp
+++ b/src/logical_cache_invalidator.cpp
@@ -1,0 +1,60 @@
+#include "logical_cache_invalidator.hpp"
+
+#include "duckdb/execution/physical_plan_generator.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+
+namespace duckdb {
+
+// DELETE mode: row_id expression stored in expressions[0], resolved during column binding
+LogicalCacheInvalidator::LogicalCacheInvalidator(idx_t table_oid, unique_ptr<Expression> row_id_expr)
+    : table_oid(table_oid), mode(CacheInvalidatorMode::ROW_ID), row_id_column_index(0), row_id_is_last_column(false),
+      pre_insert_row_count(0) {
+	expressions.push_back(std::move(row_id_expr));
+}
+
+// UPDATE mode: row_id is always the last column
+LogicalCacheInvalidator::LogicalCacheInvalidator(idx_t table_oid)
+    : table_oid(table_oid), mode(CacheInvalidatorMode::ROW_ID), row_id_column_index(0), row_id_is_last_column(true),
+      pre_insert_row_count(0) {
+}
+
+// INSERT mode: count rows, no row_id tracking
+LogicalCacheInvalidator::LogicalCacheInvalidator(idx_t table_oid, idx_t pre_insert_row_count)
+    : table_oid(table_oid), mode(CacheInvalidatorMode::INSERT), row_id_column_index(0), row_id_is_last_column(false),
+      pre_insert_row_count(pre_insert_row_count) {
+}
+
+// MERGE mode: track row IDs + count unmatched (inserted) rows
+LogicalCacheInvalidator::LogicalCacheInvalidator(idx_t table_oid, idx_t row_id_column_index, idx_t pre_insert_row_count)
+    : table_oid(table_oid), mode(CacheInvalidatorMode::MERGE), row_id_column_index(row_id_column_index),
+      row_id_is_last_column(false), pre_insert_row_count(pre_insert_row_count) {
+}
+
+PhysicalOperator &LogicalCacheInvalidator::CreatePlan(ClientContext &context, PhysicalPlanGenerator &planner) {
+	auto &child_plan = planner.CreatePlan(*children[0]);
+
+	idx_t resolved_row_id_col = row_id_column_index;
+	if (mode == CacheInvalidatorMode::ROW_ID) {
+		if (row_id_is_last_column) {
+			resolved_row_id_col = child_plan.types.size() - 1;
+		} else {
+			auto &bound_ref = expressions[0]->Cast<BoundReferenceExpression>();
+			resolved_row_id_col = bound_ref.index;
+		}
+	}
+
+	auto &op = planner.Make<PhysicalCacheInvalidator>(table_oid, mode, resolved_row_id_col, pre_insert_row_count,
+	                                                  child_plan.types, estimated_cardinality);
+	op.children.push_back(child_plan);
+	return op;
+}
+
+vector<ColumnBinding> LogicalCacheInvalidator::GetColumnBindings() {
+	return children[0]->GetColumnBindings();
+}
+
+void LogicalCacheInvalidator::ResolveTypes() {
+	types = children[0]->types;
+}
+
+} // namespace duckdb

--- a/src/physical_cache_invalidator.cpp
+++ b/src/physical_cache_invalidator.cpp
@@ -1,0 +1,118 @@
+#include "physical_cache_invalidator.hpp"
+
+#include "query_condition_cache_state.hpp"
+
+namespace duckdb {
+
+PhysicalCacheInvalidator::PhysicalCacheInvalidator(PhysicalPlan &physical_plan, idx_t table_oid,
+                                                   CacheInvalidatorMode mode, idx_t row_id_column_index,
+                                                   idx_t pre_insert_row_count, vector<LogicalType> types,
+                                                   idx_t estimated_cardinality)
+    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, std::move(types), estimated_cardinality),
+      table_oid(table_oid), mode(mode), row_id_column_index(row_id_column_index),
+      pre_insert_row_count(pre_insert_row_count) {
+}
+
+unique_ptr<GlobalOperatorState> PhysicalCacheInvalidator::GetGlobalOperatorState(ClientContext &context) const {
+	return make_uniq<CacheInvalidatorGlobalState>();
+}
+
+// Collect row group indices from valid row IDs in the given vector.
+// For rows with NULL row IDs, increment inserted_row_count instead.
+static void CollectRowGroups(Vector &row_id_vec, idx_t count, CacheInvalidatorGlobalState &state, bool track_nulls) {
+	UnifiedVectorFormat row_id_data;
+	row_id_vec.ToUnifiedFormat(count, row_id_data);
+	auto row_ids = UnifiedVectorFormat::GetData<row_t>(row_id_data);
+
+	lock_guard<mutex> guard(state.lock);
+	for (idx_t i = 0; i < count; ++i) {
+		auto idx = row_id_data.sel->get_index(i);
+		if (!row_id_data.validity.RowIsValid(idx)) {
+			if (track_nulls) {
+				++state.inserted_row_count;
+			}
+			continue;
+		}
+		auto row_id = NumericCast<idx_t>(row_ids[idx]);
+		state.affected_row_groups.insert(row_id / DEFAULT_ROW_GROUP_SIZE);
+	}
+}
+
+OperatorResultType PhysicalCacheInvalidator::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                     GlobalOperatorState &gstate, OperatorState &state) const {
+	chunk.Reference(input);
+	auto &invalidator_state = gstate.Cast<CacheInvalidatorGlobalState>();
+
+	switch (mode) {
+	case CacheInvalidatorMode::ROW_ID:
+		CollectRowGroups(input.data[row_id_column_index], input.size(), invalidator_state, /*track_nulls=*/false);
+		break;
+	case CacheInvalidatorMode::INSERT: {
+		lock_guard<mutex> guard(invalidator_state.lock);
+		invalidator_state.inserted_row_count += input.size();
+		break;
+	}
+	case CacheInvalidatorMode::MERGE:
+		// For MERGE: valid row IDs → row group tracking, NULL row IDs → insert counting
+		CollectRowGroups(input.data[row_id_column_index], input.size(), invalidator_state, /*track_nulls=*/true);
+		break;
+	}
+
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+OperatorFinalResultType PhysicalCacheInvalidator::OperatorFinalize(Pipeline &pipeline, Event &event,
+                                                                   ClientContext &context,
+                                                                   OperatorFinalizeInput &input) const {
+	auto &invalidator_state = input.global_state.Cast<CacheInvalidatorGlobalState>();
+
+	// For INSERT and MERGE modes: compute row groups from the inserted row range
+	if (invalidator_state.inserted_row_count > 0) {
+		idx_t first_rg = pre_insert_row_count / DEFAULT_ROW_GROUP_SIZE;
+		idx_t last_rg = (pre_insert_row_count + invalidator_state.inserted_row_count - 1) / DEFAULT_ROW_GROUP_SIZE;
+		for (idx_t rg = first_rg; rg <= last_rg; ++rg) {
+			invalidator_state.affected_row_groups.insert(rg);
+		}
+	}
+
+	if (!invalidator_state.affected_row_groups.empty()) {
+		auto store = ConditionCacheStore::GetOrCreate(context);
+		store->RemoveRowGroupsForTable(table_oid, invalidator_state.affected_row_groups);
+	}
+	return OperatorFinalResultType::FINISHED;
+}
+
+bool PhysicalCacheInvalidator::RequiresOperatorFinalize() const {
+	return true;
+}
+
+bool PhysicalCacheInvalidator::ParallelOperator() const {
+	return true;
+}
+
+string PhysicalCacheInvalidator::GetName() const {
+	return "CACHE_INVALIDATOR";
+}
+
+InsertionOrderPreservingMap<string> PhysicalCacheInvalidator::ParamsToString() const {
+	InsertionOrderPreservingMap<string> result;
+	result["Table OID"] = to_string(table_oid);
+	switch (mode) {
+	case CacheInvalidatorMode::ROW_ID:
+		result["Mode"] = "ROW_ID";
+		result["Row ID Column"] = to_string(row_id_column_index);
+		break;
+	case CacheInvalidatorMode::INSERT:
+		result["Mode"] = "INSERT";
+		result["Pre-insert Rows"] = to_string(pre_insert_row_count);
+		break;
+	case CacheInvalidatorMode::MERGE:
+		result["Mode"] = "MERGE";
+		result["Row ID Column"] = to_string(row_id_column_index);
+		result["Pre-insert Rows"] = to_string(pre_insert_row_count);
+		break;
+	}
+	return result;
+}
+
+} // namespace duckdb

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -2,17 +2,17 @@
 
 #include "query_condition_cache_extension.hpp"
 
-#include "query_condition_cache_functions.hpp"
-#include "query_condition_cache_optimizer.hpp"
-
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "query_condition_cache_functions.hpp"
+#include "query_condition_cache_optimizer.hpp"
 
 namespace duckdb {
 
 namespace {
 void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(ConditionCacheBuildFunction());
+	loader.RegisterFunction(ConditionCacheInfoFunction());
 
 	// Register the use_query_condition_cache setting (default: false)
 	auto &db = loader.GetDatabaseInstance();
@@ -20,8 +20,9 @@ void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("use_query_condition_cache", "Enable automatic query condition cache build and apply",
 	                          LogicalType {LogicalTypeId::BOOLEAN}, Value::BOOLEAN(false));
 
-	// Register optimizer extension (pre-optimize + post-optimize)
+	// Register optimizer extensions
 	config.optimizer_extensions.push_back(QueryConditionCacheOptimizer());
+	config.optimizer_extensions.push_back(CacheInvalidationOptimizer());
 }
 } // namespace
 

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -261,4 +261,66 @@ TableFunction ConditionCacheBuildFunction() {
 	return func;
 }
 
+// ------- condition_cache_info(table_name VARCHAR, predicate VARCHAR) -------
+// Returns the number of cached row groups for a given (table, predicate) pair.
+// Returns 0 if no cache entry exists.
+
+struct ConditionCacheInfoBindData : public TableFunctionData {
+	idx_t table_oid;
+	string predicate_sql;
+};
+
+struct ConditionCacheInfoState : public GlobalTableFunctionState {
+	bool done = false;
+};
+
+unique_ptr<FunctionData> ConditionCacheInfoBind(ClientContext &context, TableFunctionBindInput &input,
+                                                vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_uniq<ConditionCacheInfoBindData>();
+	result->predicate_sql = input.inputs[1].GetValue<string>();
+
+	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
+	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
+
+	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, qname.catalog, qname.schema, qname.name);
+	result->table_oid = table_entry.oid;
+
+	names.emplace_back("cached_row_groups");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	return result;
+}
+
+unique_ptr<GlobalTableFunctionState> ConditionCacheInfoInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_uniq<ConditionCacheInfoState>();
+}
+
+void ConditionCacheInfoExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &gstate = data_p.global_state->Cast<ConditionCacheInfoState>();
+	if (gstate.done) {
+		return;
+	}
+	gstate.done = true;
+
+	const auto &bind_data = data_p.bind_data->Cast<ConditionCacheInfoBindData>();
+	CacheKey key {bind_data.table_oid, bind_data.predicate_sql};
+	auto store = ConditionCacheStore::GetOrCreate(context);
+	auto entry = store->Lookup(key);
+
+	output.SetCardinality(1);
+	if (entry) {
+		output.data[0].SetValue(0, Value::INTEGER(static_cast<int32_t>(entry->bitvectors.size())));
+	} else {
+		output.data[0].SetValue(0, Value::INTEGER(0));
+	}
+}
+
+TableFunction ConditionCacheInfoFunction() {
+	TableFunction func(
+	    "condition_cache_info",
+	    {LogicalType {LogicalTypeId::VARCHAR} /*table*/, LogicalType {LogicalTypeId::VARCHAR} /*predicate_sql*/},
+	    ConditionCacheInfoExecute, ConditionCacheInfoBind, ConditionCacheInfoInit);
+	return func;
+}
+
 } // namespace duckdb

--- a/src/query_condition_cache_optimizer.cpp
+++ b/src/query_condition_cache_optimizer.cpp
@@ -184,7 +184,7 @@ void QueryConditionCacheOptimizer::PostOptimizeWalk(unique_ptr<LogicalOperator> 
 // ============================================================================
 
 void QueryConditionCacheOptimizer::InjectCacheFilter(unique_ptr<LogicalOperator> &get_plan,
-                                                    shared_ptr<ConditionCacheEntry> entry) {
+                                                     shared_ptr<ConditionCacheEntry> entry) {
 	auto &get = get_plan->Cast<LogicalGet>();
 
 	ScalarFunction func("__condition_cache_filter", {LogicalType {LogicalTypeId::BIGINT}},

--- a/src/query_condition_cache_optimizer.cpp
+++ b/src/query_condition_cache_optimizer.cpp
@@ -184,7 +184,7 @@ void QueryConditionCacheOptimizer::PostOptimizeWalk(unique_ptr<LogicalOperator> 
 // ============================================================================
 
 void QueryConditionCacheOptimizer::InjectCacheFilter(unique_ptr<LogicalOperator> &get_plan,
-                                                     shared_ptr<ConditionCacheEntry> entry) {
+                                                    shared_ptr<ConditionCacheEntry> entry) {
 	auto &get = get_plan->Cast<LogicalGet>();
 
 	ScalarFunction func("__condition_cache_filter", {LogicalType {LogicalTypeId::BIGINT}},
@@ -218,6 +218,92 @@ void QueryConditionCacheOptimizer::InjectCacheFilter(unique_ptr<LogicalOperator>
 		}
 		get.AddColumnId(COLUMN_IDENTIFIER_ROW_ID);
 	}
+}
+
+} // namespace duckdb
+
+// ============================================================================
+// Cache invalidation optimizer (separate translation unit merged here)
+// ============================================================================
+
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/common/enums/logical_operator_type.hpp"
+#include "duckdb/planner/operator/logical_delete.hpp"
+#include "duckdb/planner/operator/logical_insert.hpp"
+#include "duckdb/planner/operator/logical_merge_into.hpp"
+#include "duckdb/planner/operator/logical_update.hpp"
+#include "logical_cache_invalidator.hpp"
+
+namespace duckdb {
+
+CacheInvalidationOptimizer::CacheInvalidationOptimizer() {
+	optimize_function = OptimizeFunction;
+}
+
+void CacheInvalidationOptimizer::WalkPlanForDML(ClientContext &context, unique_ptr<LogicalOperator> &op) {
+	// Recurse into children first
+	for (auto &child : op->children) {
+		WalkPlanForDML(context, child);
+	}
+
+	switch (op->type) {
+	case LogicalOperatorType::LOGICAL_DELETE: {
+		auto &del = op->Cast<LogicalDelete>();
+		auto table_oid = del.table.oid;
+
+		// Copy the row_id expression; it will be resolved during column binding resolution
+		auto row_id_expr = del.expressions[0]->Copy();
+
+		auto invalidator = make_uniq<LogicalCacheInvalidator>(table_oid, std::move(row_id_expr));
+		invalidator->children = std::move(del.children);
+		del.children.clear();
+		del.children.push_back(std::move(invalidator));
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_UPDATE: {
+		auto &upd = op->Cast<LogicalUpdate>();
+		auto table_oid = upd.table.oid;
+
+		auto invalidator = make_uniq<LogicalCacheInvalidator>(table_oid);
+		invalidator->children = std::move(upd.children);
+		upd.children.clear();
+		upd.children.push_back(std::move(invalidator));
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_INSERT: {
+		auto &ins = op->Cast<LogicalInsert>();
+		auto table_oid = ins.table.oid;
+
+		auto &duck_table = ins.table.Cast<DuckTableEntry>();
+		auto pre_insert_rows = duck_table.GetStorage().GetTotalRows();
+
+		auto invalidator = make_uniq<LogicalCacheInvalidator>(table_oid, pre_insert_rows);
+		invalidator->children = std::move(ins.children);
+		ins.children.clear();
+		ins.children.push_back(std::move(invalidator));
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_MERGE_INTO: {
+		auto &merge = op->Cast<LogicalMergeInto>();
+		auto table_oid = merge.table.oid;
+		auto &duck_table = merge.table.Cast<DuckTableEntry>();
+		auto pre_insert_rows = duck_table.GetStorage().GetTotalRows();
+
+		auto row_id_col = merge.row_id_start;
+
+		auto invalidator = make_uniq<LogicalCacheInvalidator>(table_oid, row_id_col, pre_insert_rows);
+		invalidator->children = std::move(merge.children);
+		merge.children.clear();
+		merge.children.push_back(std::move(invalidator));
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+void CacheInvalidationOptimizer::OptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
+	WalkPlanForDML(input.context, plan);
 }
 
 } // namespace duckdb

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -68,6 +68,46 @@ vector<shared_ptr<ConditionCacheEntry>> ConditionCacheStore::GetAll() {
 	return result;
 }
 
+idx_t ConditionCacheStore::RemoveRowGroupsForTable(idx_t table_oid, const unordered_set<idx_t> &row_group_indices) {
+	lock_guard<mutex> guard(cache_lock);
+	idx_t removed_count = 0;
+	vector<CacheKey> keys_to_remove;
+	for (auto &pair : entries) {
+		if (pair.first.table_oid != table_oid) {
+			continue;
+		}
+		auto &entry = pair.second;
+		for (auto rg_idx : row_group_indices) {
+			if (entry->bitvectors.erase(rg_idx) > 0) {
+				++removed_count;
+			}
+		}
+		if (entry->bitvectors.empty()) {
+			keys_to_remove.push_back(pair.first);
+		}
+	}
+	for (auto &key : keys_to_remove) {
+		entries.erase(key);
+	}
+	return removed_count;
+}
+
+idx_t ConditionCacheStore::RemoveByTable(idx_t table_oid) {
+	lock_guard<mutex> guard(cache_lock);
+	idx_t removed_count = 0;
+	vector<CacheKey> keys_to_remove;
+	for (auto &pair : entries) {
+		if (pair.first.table_oid == table_oid) {
+			keys_to_remove.push_back(pair.first);
+		}
+	}
+	for (auto &key : keys_to_remove) {
+		entries.erase(key);
+		++removed_count;
+	}
+	return removed_count;
+}
+
 shared_ptr<ConditionCacheStore> ConditionCacheStore::GetOrCreate(ClientContext &context) {
 	auto &cache = ObjectCache::GetObjectCache(context);
 	return cache.GetOrCreate<ConditionCacheStore>(CACHE_KEY);

--- a/test/sql/condition_cache_invalidation.test
+++ b/test/sql/condition_cache_invalidation.test
@@ -1,0 +1,109 @@
+# name: test/sql/condition_cache_invalidation.test
+# description: Test cache invalidation on DML operations
+# group: [sql]
+
+require query_condition_cache
+
+# Create table with multiple row groups (122880 rows per RG, 5 RGs)
+statement ok
+CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i);
+
+# Build cache for a predicate that hits all 5 row groups
+query I
+SELECT status FROM condition_cache_build('t', 'val = 42');
+----
+Cache Built: 245/245 vectors, 5/5 row groups
+
+# Verify 5 row groups are cached
+query I
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+5
+
+# DELETE a row in RG0 should invalidate only RG0
+statement ok
+DELETE FROM t WHERE id = 42;
+
+# Only 4 row groups remain cached (RG0 invalidated)
+query I
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+4
+
+# Rebuild restores all 5 row groups
+query I
+SELECT status FROM condition_cache_build('t', 'val = 42');
+----
+Cache Built: 245/245 vectors, 5/5 row groups
+
+query I
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+5
+
+# UPDATE a row in RG0 should invalidate only RG0
+statement ok
+UPDATE t SET val = 999 WHERE id = 200;
+
+query I
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+4
+
+# Rebuild
+query I
+SELECT status FROM condition_cache_build('t', 'val = 42');
+----
+Cache Built: 245/245 vectors, 5/5 row groups
+
+# INSERT appends to the last row group — only that RG is invalidated
+# Build a predicate that only hits RG0
+query I
+SELECT status FROM condition_cache_build('t', 'id < 3000');
+----
+Cache Built: 2/245 vectors, 1/5 row groups
+
+query I
+SELECT * FROM condition_cache_info('t', 'id < 3000');
+----
+1
+
+statement ok
+INSERT INTO t VALUES (999999, 0);
+
+# RG0 cache (for 'id < 3000') should be preserved since insert only affects the last RG
+query I
+SELECT * FROM condition_cache_info('t', 'id < 3000');
+----
+1
+
+# But 'val = 42' cache lost its last RG (RG4 where new row was appended)
+query I
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+4
+
+# Cross-table isolation: DML on table B should not affect table A's cache
+statement ok
+CREATE TABLE t2 AS SELECT i AS id, i % 10 AS val FROM range(1000) t(i);
+
+# Rebuild t's cache fully
+query I
+SELECT status FROM condition_cache_build('t', 'val = 42');
+----
+Cache Built: 245/245 vectors, 5/5 row groups
+
+statement ok
+DELETE FROM t2 WHERE id < 100;
+
+# t's cache is unaffected by t2's DML
+query I
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+5
+
+# No cache entry returns 0
+query I
+SELECT * FROM condition_cache_info('t2', 'val = 5');
+----
+0

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -6,8 +6,9 @@ include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
 set(QUERY_CACHE_UNITTEST_OBJECTS
-    main.cpp test_bitvector.cpp test_build_cache_entry.cpp test_cache_store.cpp
-    test_filter.cpp)
+    main.cpp test_bitvector.cpp test_build_cache_entry.cpp
+    test_cache_invalidation.cpp test_cache_store.cpp
+    test_filter.cpp test_optimizer_invalidation.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})
 

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -6,9 +6,13 @@ include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
 set(QUERY_CACHE_UNITTEST_OBJECTS
-    main.cpp test_bitvector.cpp test_build_cache_entry.cpp
-    test_cache_invalidation.cpp test_cache_store.cpp
-    test_filter.cpp test_optimizer_invalidation.cpp)
+    main.cpp
+    test_bitvector.cpp
+    test_build_cache_entry.cpp
+    test_cache_invalidation.cpp
+    test_cache_store.cpp
+    test_filter.cpp
+    test_optimizer_invalidation.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})
 

--- a/test/unittest/test_bitvector.cpp
+++ b/test/unittest/test_bitvector.cpp
@@ -1,7 +1,7 @@
 #include "catch/catch.hpp"
 #include "query_condition_cache_state.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
 TEST_CASE("RowGroupFilter - basic operations", "[bitvector]") {
 
@@ -47,3 +47,4 @@ TEST_CASE("RowGroupFilter - basic operations", "[bitvector]") {
 		REQUIRE_FALSE(bv.VectorHasRows(6));
 	}
 }
+} // namespace duckdb

--- a/test/unittest/test_build_cache_entry.cpp
+++ b/test/unittest/test_build_cache_entry.cpp
@@ -10,7 +10,7 @@
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression_binder/check_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
 TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 	DuckDB db(nullptr);
@@ -92,3 +92,4 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		REQUIRE(entry->bitvectors.empty());
 	}
 }
+} // namespace duckdb

--- a/test/unittest/test_cache_invalidation.cpp
+++ b/test/unittest/test_cache_invalidation.cpp
@@ -1,0 +1,125 @@
+#include "catch/catch.hpp"
+#include "query_condition_cache_state.hpp"
+
+namespace duckdb {
+
+TEST_CASE("RemoveRowGroupsForTable - basic operations", "[invalidation]") {
+	ConditionCacheStore store;
+
+	SECTION("empty store returns 0") {
+		unordered_set<idx_t> rg_indices = {0, 1, 2};
+		REQUIRE(store.RemoveRowGroupsForTable(1, rg_indices) == 0);
+	}
+
+	SECTION("removes specified row groups from matching table entries") {
+		auto entry = make_shared_ptr<ConditionCacheEntry>();
+		entry->bitvectors[0].SetVector(0);
+		entry->bitvectors[1].SetVector(0);
+		entry->bitvectors[2].SetVector(0);
+		store.Upsert({1, "val > 5"}, entry);
+
+		unordered_set<idx_t> rg_indices = {0, 2};
+		auto removed = store.RemoveRowGroupsForTable(1, rg_indices);
+		REQUIRE(removed == 2);
+
+		// Entry still exists with RG 1
+		auto found = store.Lookup({1, "val > 5"});
+		REQUIRE(found != nullptr);
+		REQUIRE(found->bitvectors.count(0) == 0);
+		REQUIRE(found->bitvectors.count(1) == 1);
+		REQUIRE(found->bitvectors.count(2) == 0);
+	}
+
+	SECTION("removes entire entry when all row groups are removed") {
+		auto entry = make_shared_ptr<ConditionCacheEntry>();
+		entry->bitvectors[0].SetVector(0);
+		store.Upsert({1, "val > 5"}, entry);
+
+		unordered_set<idx_t> rg_indices = {0};
+		store.RemoveRowGroupsForTable(1, rg_indices);
+
+		REQUIRE(store.Lookup({1, "val > 5"}) == nullptr);
+	}
+
+	SECTION("does not affect entries for other tables") {
+		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
+		entry1->bitvectors[0].SetVector(0);
+		store.Upsert({1, "val > 5"}, entry1);
+
+		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
+		entry2->bitvectors[0].SetVector(0);
+		store.Upsert({2, "val > 5"}, entry2);
+
+		unordered_set<idx_t> rg_indices = {0};
+		store.RemoveRowGroupsForTable(1, rg_indices);
+
+		REQUIRE(store.Lookup({1, "val > 5"}) == nullptr);
+		auto found2 = store.Lookup({2, "val > 5"});
+		REQUIRE(found2 != nullptr);
+		REQUIRE(found2->bitvectors.count(0) == 1);
+	}
+
+	SECTION("removes from multiple entries for the same table") {
+		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
+		entry1->bitvectors[0].SetVector(0);
+		entry1->bitvectors[1].SetVector(0);
+		store.Upsert({1, "val > 5"}, entry1);
+
+		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
+		entry2->bitvectors[0].SetVector(0);
+		entry2->bitvectors[1].SetVector(0);
+		store.Upsert({1, "val < 10"}, entry2);
+
+		unordered_set<idx_t> rg_indices = {0};
+		auto removed = store.RemoveRowGroupsForTable(1, rg_indices);
+		REQUIRE(removed == 2); // one from each entry
+
+		auto found1 = store.Lookup({1, "val > 5"});
+		REQUIRE(found1 != nullptr);
+		REQUIRE(found1->bitvectors.count(0) == 0);
+		REQUIRE(found1->bitvectors.count(1) == 1);
+
+		auto found2 = store.Lookup({1, "val < 10"});
+		REQUIRE(found2 != nullptr);
+		REQUIRE(found2->bitvectors.count(0) == 0);
+		REQUIRE(found2->bitvectors.count(1) == 1);
+	}
+}
+
+TEST_CASE("RemoveByTable - basic operations", "[invalidation]") {
+	ConditionCacheStore store;
+
+	SECTION("empty store returns 0") {
+		REQUIRE(store.RemoveByTable(1) == 0);
+	}
+
+	SECTION("removes all entries for the specified table") {
+		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
+		entry1->bitvectors[0].SetVector(0);
+		store.Upsert({1, "val > 5"}, entry1);
+
+		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
+		entry2->bitvectors[0].SetVector(0);
+		store.Upsert({1, "val < 10"}, entry2);
+
+		auto removed = store.RemoveByTable(1);
+		REQUIRE(removed == 2);
+
+		REQUIRE(store.Lookup({1, "val > 5"}) == nullptr);
+		REQUIRE(store.Lookup({1, "val < 10"}) == nullptr);
+	}
+
+	SECTION("does not affect entries for other tables") {
+		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
+		store.Upsert({1, "val > 5"}, entry1);
+
+		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
+		store.Upsert({2, "val > 5"}, entry2);
+
+		store.RemoveByTable(1);
+
+		REQUIRE(store.Lookup({1, "val > 5"}) == nullptr);
+		REQUIRE(store.Lookup({2, "val > 5"}) != nullptr);
+	}
+}
+} // namespace duckdb

--- a/test/unittest/test_cache_store.cpp
+++ b/test/unittest/test_cache_store.cpp
@@ -3,7 +3,7 @@
 
 #include "duckdb/common/exception.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
 TEST_CASE("ConditionCacheStore - basic operations", "[cache_store]") {
 	ConditionCacheStore store;
@@ -75,3 +75,4 @@ TEST_CASE("ConditionCacheStore - basic operations", "[cache_store]") {
 		REQUIRE_THROWS_AS(store.Upsert({1, "col:>5"}, nullptr), InvalidInputException);
 	}
 }
+} // namespace duckdb

--- a/test/unittest/test_filter.cpp
+++ b/test/unittest/test_filter.cpp
@@ -27,12 +27,12 @@ TEST_CASE("CacheExpressionFilter - CheckStatistics", "[query_condition_cache]") 
 		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::NO_PRUNING_POSSIBLE);
 	}
 
-	SECTION("row group without qualifying vectors: always false") {
+	SECTION("row group without qualifying vectors: no pruning") {
 		// Stats covering row group 1 (row_ids 122880..245759) - no entry in cache
 		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
 		NumericStats::SetMin(stats, Value::BIGINT(122880));
 		NumericStats::SetMax(stats, Value::BIGINT(200000));
-		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::FILTER_ALWAYS_FALSE);
+		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::NO_PRUNING_POSSIBLE);
 	}
 
 	SECTION("row group 2 with qualifying vectors: no pruning") {

--- a/test/unittest/test_optimizer_invalidation.cpp
+++ b/test/unittest/test_optimizer_invalidation.cpp
@@ -1,0 +1,272 @@
+#include "catch/catch.hpp"
+#include "query_condition_cache_extension.hpp"
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+
+namespace duckdb {
+
+// Helper: build cache for (table_name, predicate) via the SQL table function.
+static void BuildCache(Connection &con, const string &table_name, const string &predicate) {
+	auto result = con.Query("SELECT * FROM condition_cache_build('" + table_name + "', '" + predicate + "')");
+	REQUIRE(result->GetError() == "");
+}
+
+// Helper: get the cache store from a connection's context.
+static shared_ptr<ConditionCacheStore> GetStore(Connection &con) {
+	return ConditionCacheStore::GetOrCreate(*con.context);
+}
+
+// Helper: look up a cache entry by table OID and predicate.
+static shared_ptr<ConditionCacheEntry> LookupEntry(Connection &con, idx_t table_oid, const string &predicate) {
+	auto store = GetStore(con);
+	return store->Lookup({table_oid, predicate});
+}
+
+// Helper: get the OID of a table via the catalog API.
+static idx_t GetTableOid(Connection &con, const string &table_name) {
+	con.BeginTransaction();
+	auto &context = *con.context;
+	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, table_name);
+	auto oid = table_entry.oid;
+	con.Commit();
+	return oid;
+}
+
+TEST_CASE("Optimizer invalidation - DELETE removes affected row groups from cache", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	// Create table spanning multiple row groups (122880 rows per RG → 5 RGs for 500000 rows)
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	// Build cache with a selective predicate (only hits RG0: ids 0..2999)
+	BuildCache(con, "t", "id < 3000");
+	auto entry = LookupEntry(con, table_oid, "id < 3000");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->bitvectors.size() == 1);
+	REQUIRE(entry->bitvectors.count(0) == 1); // only RG0
+
+	// Also build a broad predicate that hits all RGs
+	BuildCache(con, "t", "val = 42");
+	auto broad_entry = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(broad_entry != nullptr);
+	REQUIRE(broad_entry->bitvectors.size() == 5);
+
+	// DELETE rows in RG0 only
+	auto del_result = con.Query("DELETE FROM t WHERE id < 100");
+	REQUIRE_FALSE(del_result->HasError());
+
+	// The selective entry (only had RG0) should be fully removed
+	auto after_del = LookupEntry(con, table_oid, "id < 3000");
+	REQUIRE(after_del == nullptr);
+
+	// The broad entry should have RG0 removed but RGs 1-4 preserved
+	auto broad_after = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(broad_after != nullptr);
+	REQUIRE(broad_after->bitvectors.size() == 4);
+	REQUIRE(broad_after->bitvectors.count(0) == 0);
+	REQUIRE(broad_after->bitvectors.count(1) == 1);
+	REQUIRE(broad_after->bitvectors.count(2) == 1);
+	REQUIRE(broad_after->bitvectors.count(3) == 1);
+	REQUIRE(broad_after->bitvectors.count(4) == 1);
+}
+
+TEST_CASE("Optimizer invalidation - UPDATE removes affected row groups from cache", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	BuildCache(con, "t", "val = 42");
+	auto entry = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->bitvectors.size() == 5);
+
+	// UPDATE a row in RG0 (id=200 is in the first row group)
+	auto upd_result = con.Query("UPDATE t SET val = 999 WHERE id = 200");
+	REQUIRE_FALSE(upd_result->HasError());
+
+	// RG0 should be invalidated, others preserved
+	auto after_upd = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(after_upd != nullptr);
+	REQUIRE(after_upd->bitvectors.size() == 4);
+	REQUIRE(after_upd->bitvectors.count(0) == 0);
+}
+
+TEST_CASE("Optimizer invalidation - INSERT only invalidates affected row groups", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	// 500000 rows = 5 row groups (122880 per RG). Last RG (RG4) starts at row 491520.
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	// Build cache with a selective predicate (only RG0)
+	BuildCache(con, "t", "id < 3000");
+	auto selective = LookupEntry(con, table_oid, "id < 3000");
+	REQUIRE(selective != nullptr);
+	REQUIRE(selective->bitvectors.size() == 1);
+	REQUIRE(selective->bitvectors.count(0) == 1);
+
+	// Build cache with a broad predicate (all RGs)
+	BuildCache(con, "t", "val = 42");
+	auto broad = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(broad != nullptr);
+	REQUIRE(broad->bitvectors.size() == 5);
+
+	// INSERT a single row — appended at the end, affects only the last RG (RG4)
+	auto ins_result = con.Query("INSERT INTO t VALUES (999999, 0)");
+	REQUIRE_FALSE(ins_result->HasError());
+
+	// Selective entry (RG0 only) should be preserved — INSERT didn't touch RG0
+	auto selective_after = LookupEntry(con, table_oid, "id < 3000");
+	REQUIRE(selective_after != nullptr);
+	REQUIRE(selective_after->bitvectors.size() == 1);
+	REQUIRE(selective_after->bitvectors.count(0) == 1);
+
+	// Broad entry should have RG4 invalidated, RGs 0-3 preserved
+	auto broad_after = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(broad_after != nullptr);
+	REQUIRE(broad_after->bitvectors.size() == 4);
+	REQUIRE(broad_after->bitvectors.count(0) == 1);
+	REQUIRE(broad_after->bitvectors.count(1) == 1);
+	REQUIRE(broad_after->bitvectors.count(2) == 1);
+	REQUIRE(broad_after->bitvectors.count(3) == 1);
+	REQUIRE(broad_after->bitvectors.count(4) == 0);
+}
+
+TEST_CASE("Optimizer invalidation - INSERT spanning multiple new row groups", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	// Start with a small table (1 row group)
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(100000) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	BuildCache(con, "t", "val = 42");
+	auto entry = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->bitvectors.size() == 1); // 1 RG
+	REQUIRE(entry->bitvectors.count(0) == 1);
+
+	// INSERT enough rows to create new row groups (add 300000 rows → spans RG0 tail + RG1 + RG2)
+	auto ins_result = con.Query("INSERT INTO t SELECT i AS id, i % 100 AS val FROM range(300000) t(i)");
+	REQUIRE_FALSE(ins_result->HasError());
+
+	// RG0 should be invalidated (new rows appended into it), original entry gone
+	auto after = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(after == nullptr); // only had RG0, which got invalidated
+}
+
+TEST_CASE("Optimizer invalidation - INSERT ON CONFLICT DO UPDATE invalidates per row group",
+          "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t (id INTEGER PRIMARY KEY, val INTEGER)");
+	con.Query("INSERT INTO t SELECT i, i % 100 FROM range(500000) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	BuildCache(con, "t", "val = 42");
+	auto entry = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->bitvectors.size() == 5);
+
+	// ON CONFLICT DO UPDATE: row 200 is in RG0 (200 / 122880 = 0)
+	auto ins_result = con.Query("INSERT INTO t VALUES (200, 999) ON CONFLICT (id) DO UPDATE SET val = 999");
+	REQUIRE_FALSE(ins_result->HasError());
+
+	// Only RG0 should be invalidated; RGs 1-4 remain
+	auto after = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(after != nullptr);
+	REQUIRE(after->bitvectors.size() == 4);
+	REQUIRE(after->bitvectors.count(0) == 0); // RG0 invalidated
+	REQUIRE(after->bitvectors.count(1) == 1);
+	REQUIRE(after->bitvectors.count(2) == 1);
+	REQUIRE(after->bitvectors.count(3) == 1);
+	REQUIRE(after->bitvectors.count(4) == 1);
+}
+
+TEST_CASE("Optimizer invalidation - cross-table isolation", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t1 AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+	con.Query("CREATE TABLE t2 AS SELECT i AS id, i % 10 AS val FROM range(1000) t(i)");
+	auto t1_oid = GetTableOid(con, "t1");
+
+	// Build cache for t1
+	BuildCache(con, "t1", "val = 42");
+	auto t1_entry = LookupEntry(con, t1_oid, "val = 42");
+	REQUIRE(t1_entry != nullptr);
+	REQUIRE(t1_entry->bitvectors.size() == 5);
+
+	// DML on t2 should not affect t1's cache
+	con.Query("DELETE FROM t2 WHERE id < 100");
+	con.Query("UPDATE t2 SET val = 0 WHERE id = 500");
+	con.Query("INSERT INTO t2 VALUES (9999, 0)");
+
+	auto t1_after = LookupEntry(con, t1_oid, "val = 42");
+	REQUIRE(t1_after != nullptr);
+	REQUIRE(t1_after->bitvectors.size() == 5);
+}
+
+TEST_CASE("Optimizer invalidation - DELETE across multiple row groups", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	BuildCache(con, "t", "val = 42");
+	auto entry = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->bitvectors.size() == 5);
+
+	// DELETE rows spanning RG0 and RG2 (RG size = 122880)
+	// RG0: ids 0..122879, RG2: ids 245760..368639
+	auto del_result = con.Query("DELETE FROM t WHERE id < 100 OR (id >= 250000 AND id < 250100)");
+	REQUIRE_FALSE(del_result->HasError());
+
+	// RG0 and RG2 should be invalidated
+	auto after = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(after != nullptr);
+	REQUIRE(after->bitvectors.size() == 3);
+	REQUIRE(after->bitvectors.count(0) == 0);
+	REQUIRE(after->bitvectors.count(1) == 1);
+	REQUIRE(after->bitvectors.count(2) == 0);
+	REQUIRE(after->bitvectors.count(3) == 1);
+	REQUIRE(after->bitvectors.count(4) == 1);
+}
+
+TEST_CASE("Optimizer invalidation - DML on empty cache is no-op", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id FROM range(1000) t(i)");
+
+	// DML without any cache built should not crash
+	auto del_result = con.Query("DELETE FROM t WHERE id < 10");
+	REQUIRE_FALSE(del_result->HasError());
+
+	auto upd_result = con.Query("UPDATE t SET id = id + 1 WHERE id < 10");
+	REQUIRE_FALSE(upd_result->HasError());
+
+	auto ins_result = con.Query("INSERT INTO t VALUES (9999)");
+	REQUIRE_FALSE(ins_result->HasError());
+}
+} // namespace duckdb


### PR DESCRIPTION
Closes: https://github.com/dentiny/duckdb-query-condition-cache/issues/12

Introduce LogicalCacheInvalidator and PhysicalCacheInvalidator to manage cache invalidation for DML operations (INSERT, UPDATE, DELETE, MERGE). The LogicalCacheInvalidator prepares the logical plan for cache invalidation, while the PhysicalCacheInvalidator executes the invalidation logic during query execution. This implementation enhances cache management by tracking affected row groups and ensuring efficient cache updates.

Also, add CacheInvalidationOptimizer to automatically inject invalidation logic into DML operations during query optimization. This ensures that the cache remains consistent with the underlying data changes.

Includes tests for cache invalidation behavior across various DML scenarios, ensuring correctness and performance improvements in cache management.