### PR TITLE
[Demo] Automatic cache build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,12 @@ endif()
 
 include_directories(src/include)
 
-set(EXTENSION_SOURCES src/query_condition_cache_extension.cpp
-                      src/query_condition_cache_functions.cpp
-                      src/query_condition_cache_state.cpp)
+set(EXTENSION_SOURCES
+    src/query_condition_cache_extension.cpp
+    src/query_condition_cache_filter.cpp
+    src/query_condition_cache_functions.cpp
+    src/query_condition_cache_optimizer.cpp
+    src/query_condition_cache_state.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 include_directories(src/include)
 
 set(EXTENSION_SOURCES src/query_condition_cache_extension.cpp
+                      src/query_condition_cache_functions.cpp
                       src/query_condition_cache_state.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})

--- a/benchmark/benchmark.sql
+++ b/benchmark/benchmark.sql
@@ -1,0 +1,270 @@
+-- Benchmark: Query Condition Cache — OR predicates with heavy payload columns
+-- Modeled after condition-cache-vector-level-prototype benchmarks
+-- Key: OR can't be pushed down, so DuckDB must decompress ALL columns for ALL vectors
+-- Cache skips vectors → avoids decompression of heavy payload columns
+
+.timer off
+
+-- ============================================================
+-- Benchmark 1: Compound OR — Two LIKE predicates (30M rows)
+-- ============================================================
+.print '=== Benchmark 1: Compound LIKE OR (30M rows, 9 columns) ==='
+
+CREATE TABLE events_like AS
+SELECT
+    i AS id,
+    CASE WHEN i % 50000 = 0
+         THEN 'PREFIX_ERROR_' || md5(i::VARCHAR)
+         ELSE md5(i::VARCHAR) || md5((i*7)::VARCHAR)
+    END AS text_a,
+    CASE WHEN i % 40000 = 0
+         THEN 'PREFIX_WARN_' || md5(i::VARCHAR)
+         ELSE md5((i*2)::VARCHAR) || md5((i*8)::VARCHAR)
+    END AS text_b,
+    md5((i*3)::VARCHAR) AS col1,
+    md5((i*4)::VARCHAR) AS col2,
+    md5((i*5)::VARCHAR) AS col3,
+    md5((i*6)::VARCHAR) AS col4,
+    repeat('payload-' || (i%1000)::VARCHAR, 10) AS payload1,
+    repeat('x', 100) AS payload2
+FROM range(30000000) t(i);
+CHECKPOINT;
+
+-- Warmup
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_like WHERE text_a LIKE '%ERROR%' OR text_b LIKE '%WARN%';
+
+.print '--- baseline (no cache) ---'
+SET use_query_condition_cache = false;
+.timer on
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_like WHERE text_a LIKE '%ERROR%' OR text_b LIKE '%WARN%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_like WHERE text_a LIKE '%ERROR%' OR text_b LIKE '%WARN%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_like WHERE text_a LIKE '%ERROR%' OR text_b LIKE '%WARN%';
+
+.timer off
+
+.print '--- cache (build + hit) ---'
+SET use_query_condition_cache = true;
+.timer on
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_like WHERE text_a LIKE '%ERROR%' OR text_b LIKE '%WARN%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_like WHERE text_a LIKE '%ERROR%' OR text_b LIKE '%WARN%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_like WHERE text_a LIKE '%ERROR%' OR text_b LIKE '%WARN%';
+
+.timer off
+DROP TABLE events_like;
+
+-- ============================================================
+-- Benchmark 2: Simple OR — Integer predicates (30M rows)
+-- Even trivial int comparisons can't use zone maps under OR
+-- Bottleneck is decompression of all 9 columns
+-- ============================================================
+.print ''
+.print '=== Benchmark 2: Simple Integer OR (30M rows, 9 columns) ==='
+
+CREATE TABLE events_int AS
+SELECT
+    i AS id,
+    (i % 60000) AS val_a,
+    (i % 80000) AS val_b,
+    md5((i*2)::VARCHAR) AS col1,
+    md5((i*3)::VARCHAR) AS col2,
+    md5((i*4)::VARCHAR) AS col3,
+    md5((i*5)::VARCHAR) AS col4,
+    repeat('payload-' || (i%1000)::VARCHAR, 10) AS payload1,
+    repeat('x', 100) AS payload2
+FROM range(30000000) t(i);
+CHECKPOINT;
+
+-- Warmup
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_int WHERE val_a < 50 OR val_b < 30;
+
+.print '--- baseline (no cache) ---'
+SET use_query_condition_cache = false;
+.timer on
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_int WHERE val_a < 50 OR val_b < 30;
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_int WHERE val_a < 50 OR val_b < 30;
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_int WHERE val_a < 50 OR val_b < 30;
+
+.timer off
+
+.print '--- cache (build + hit) ---'
+SET use_query_condition_cache = true;
+.timer on
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_int WHERE val_a < 50 OR val_b < 30;
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_int WHERE val_a < 50 OR val_b < 30;
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_int WHERE val_a < 50 OR val_b < 30;
+
+.timer off
+DROP TABLE events_int;
+
+-- ============================================================
+-- Benchmark 3: Mixed AND — Integer + LIKE (30M rows)
+-- Zone map handles int, cache handles LIKE
+-- ============================================================
+.print ''
+.print '=== Benchmark 3: Mixed AND - int + LIKE (30M rows, 8 columns) ==='
+
+CREATE TABLE events_mix AS
+SELECT
+    i AS id,
+    (i % 60000) AS val,
+    CASE WHEN i % 50000 = 0
+         THEN 'PREFIX_ERROR_' || md5(i::VARCHAR)
+         ELSE md5(i::VARCHAR) || md5((i*7)::VARCHAR)
+    END AS text_col,
+    md5((i*3)::VARCHAR) AS col1,
+    md5((i*4)::VARCHAR) AS col2,
+    md5((i*5)::VARCHAR) AS col3,
+    md5((i*6)::VARCHAR) AS col4,
+    repeat('payload-' || (i%1000)::VARCHAR, 10) AS payload1,
+    repeat('x', 100) AS payload2
+FROM range(30000000) t(i);
+CHECKPOINT;
+
+-- Warmup
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_mix WHERE val < 50 AND text_col LIKE '%ERROR%';
+
+.print '--- baseline (no cache) ---'
+SET use_query_condition_cache = false;
+.timer on
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_mix WHERE val < 50 AND text_col LIKE '%ERROR%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_mix WHERE val < 50 AND text_col LIKE '%ERROR%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_mix WHERE val < 50 AND text_col LIKE '%ERROR%';
+
+.timer off
+
+.print '--- cache (build + hit) ---'
+SET use_query_condition_cache = true;
+.timer on
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_mix WHERE val < 50 AND text_col LIKE '%ERROR%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_mix WHERE val < 50 AND text_col LIKE '%ERROR%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(payload1)), sum(length(payload2))
+FROM events_mix WHERE val < 50 AND text_col LIKE '%ERROR%';
+
+.timer off
+DROP TABLE events_mix;
+
+-- ============================================================
+-- Benchmark 4: Single LIKE (pushable predicate, 30M rows)
+-- LIKE gets pushed to table_filters as ExpressionFilter
+-- No zone map benefit — cache provides row-group + vector skip
+-- ============================================================
+.print ''
+.print '=== Benchmark 4: Single LIKE (30M rows, 9 columns, pushable) ==='
+
+CREATE TABLE events_single AS
+SELECT
+    i AS id,
+    CASE WHEN i % 50000 = 0
+         THEN 'PREFIX_ERROR_' || md5(i::VARCHAR)
+         ELSE md5(i::VARCHAR) || md5((i*7)::VARCHAR)
+    END AS text_col,
+    md5((i*3)::VARCHAR) AS col1,
+    md5((i*4)::VARCHAR) AS col2,
+    md5((i*5)::VARCHAR) AS col3,
+    md5((i*6)::VARCHAR) AS col4,
+    md5((i*7)::VARCHAR) AS col5,
+    repeat('payload-' || (i%1000)::VARCHAR, 10) AS payload1,
+    repeat('x', 100) AS payload2
+FROM range(30000000) t(i);
+CHECKPOINT;
+
+-- Warmup
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%';
+
+.print '--- baseline (no cache) ---'
+SET use_query_condition_cache = false;
+.timer on
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%';
+
+.timer off
+
+.print '--- cache (build + hit) ---'
+SET use_query_condition_cache = true;
+.timer on
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%';
+
+.timer off
+DROP TABLE events_single;

--- a/benchmark/benchmark_like.sql
+++ b/benchmark/benchmark_like.sql
@@ -1,0 +1,66 @@
+-- Benchmark: Single LIKE (pushable predicate, 30M rows)
+-- LIKE gets pushed to table_filters as ExpressionFilter
+-- No zone map benefit — cache provides row-group + vector skip
+-- Peter/poc got 6.2x on this scenario
+
+.timer off
+.print '=== Single LIKE (30M rows, 9 columns, pushable) ==='
+
+CREATE TABLE events_single AS
+SELECT
+    i AS id,
+    CASE WHEN i % 50000 = 0
+         THEN 'PREFIX_ERROR_' || md5(i::VARCHAR)
+         ELSE md5(i::VARCHAR) || md5((i*7)::VARCHAR)
+    END AS text_col,
+    md5((i*3)::VARCHAR) AS col1,
+    md5((i*4)::VARCHAR) AS col2,
+    md5((i*5)::VARCHAR) AS col3,
+    md5((i*6)::VARCHAR) AS col4,
+    md5((i*7)::VARCHAR) AS col5,
+    repeat('payload-' || (i%1000)::VARCHAR, 10) AS payload1,
+    repeat('x', 100) AS payload2
+FROM range(30000000) t(i);
+CHECKPOINT;
+
+-- Warmup
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%';
+
+.print '--- baseline (no cache) ---'
+SET use_query_condition_cache = false;
+.timer on
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%';
+
+.timer off
+
+.print '--- cache (build + hit) ---'
+SET use_query_condition_cache = true;
+.timer on
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%';
+
+.timer off
+DROP TABLE events_single;

--- a/benchmark/benchmark_like_or.sql
+++ b/benchmark/benchmark_like_or.sql
@@ -1,0 +1,65 @@
+-- Benchmark: Single LIKE with OR (non-pushable)
+-- Same table as benchmark_like but using OR to prevent pushdown
+-- This forces full decompression of ALL columns for ALL vectors
+
+.timer off
+.print '=== Single LIKE OR (30M rows, 9 columns, non-pushable) ==='
+
+CREATE TABLE events_single AS
+SELECT
+    i AS id,
+    CASE WHEN i % 50000 = 0
+         THEN 'PREFIX_ERROR_' || md5(i::VARCHAR)
+         ELSE md5(i::VARCHAR) || md5((i*7)::VARCHAR)
+    END AS text_col,
+    md5((i*3)::VARCHAR) AS col1,
+    md5((i*4)::VARCHAR) AS col2,
+    md5((i*5)::VARCHAR) AS col3,
+    md5((i*6)::VARCHAR) AS col4,
+    md5((i*7)::VARCHAR) AS col5,
+    repeat('payload-' || (i%1000)::VARCHAR, 10) AS payload1,
+    repeat('x', 100) AS payload2
+FROM range(30000000) t(i);
+CHECKPOINT;
+
+-- Warmup
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%' OR text_col LIKE '%XYZNOTEXIST%';
+
+.print '--- baseline (no cache) ---'
+SET use_query_condition_cache = false;
+.timer on
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%' OR text_col LIKE '%XYZNOTEXIST%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%' OR text_col LIKE '%XYZNOTEXIST%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%' OR text_col LIKE '%XYZNOTEXIST%';
+
+.timer off
+
+.print '--- cache (build + hit) ---'
+SET use_query_condition_cache = true;
+.timer on
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%' OR text_col LIKE '%XYZNOTEXIST%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%' OR text_col LIKE '%XYZNOTEXIST%';
+
+SELECT count(*), sum(length(col1)), sum(length(col2)), sum(length(col3)),
+       sum(length(col4)), sum(length(col5)), sum(length(payload1)), sum(length(payload2))
+FROM events_single WHERE text_col LIKE '%ERROR%' OR text_col LIKE '%XYZNOTEXIST%';
+
+.timer off
+DROP TABLE events_single;

--- a/src/include/query_condition_cache_filter.hpp
+++ b/src/include/query_condition_cache_filter.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/planner/expression.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
+
+namespace duckdb {
+
+// Bind data containing the cached bitvectors
+struct ConditionCacheFilterBindData : public FunctionData {
+	shared_ptr<ConditionCacheEntry> cache_entry;
+
+	explicit ConditionCacheFilterBindData(shared_ptr<ConditionCacheEntry> entry);
+
+	unique_ptr<FunctionData> Copy() const override;
+	bool Equals(const FunctionData &other_p) const override;
+};
+
+// Bind callback (should never be called directly — bind data is created by the optimizer)
+unique_ptr<FunctionData> ConditionCacheFilterBind(ClientContext &context, ScalarFunction &bound_function,
+                                                  vector<unique_ptr<Expression>> &arguments);
+
+// Per-thread local state (placeholder)
+struct ConditionCacheFilterState : public FunctionLocalState {};
+
+unique_ptr<FunctionLocalState> ConditionCacheFilterInit(ExpressionState &state, const BoundFunctionExpression &expr,
+                                                        FunctionData *bind_data);
+
+// The filter function: for each vector, check the bitvector and return constant boolean
+void ConditionCacheFilterFn(DataChunk &args, ExpressionState &state, Vector &result);
+
+// ExpressionFilter subclass that overrides CheckStatistics for row-group level pruning
+class CacheExpressionFilter : public ExpressionFilter {
+public:
+	shared_ptr<ConditionCacheEntry> cache_entry;
+
+	CacheExpressionFilter(unique_ptr<Expression> expr, shared_ptr<ConditionCacheEntry> entry);
+
+	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override;
+	unique_ptr<TableFilter> Copy() const override;
+};
+
+} // namespace duckdb

--- a/src/include/query_condition_cache_functions.hpp
+++ b/src/include/query_condition_cache_functions.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/function/table_function.hpp"
+
+namespace duckdb {
+
+class DuckTableEntry;
+class Expression;
+
+// Scan all rows in the table, evaluate bound_expr, and build a ConditionCacheEntry
+// recording which vectors contain qualifying rows.
+// Modifies bound_expr in-place (remaps column indices to scan positions).
+shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTableEntry &table_entry,
+                                                Expression &bound_expr, idx_t &total_qualifying_rows);
+
+TableFunction ConditionCacheBuildFunction();
+
+} // namespace duckdb

--- a/src/include/query_condition_cache_functions.hpp
+++ b/src/include/query_condition_cache_functions.hpp
@@ -14,7 +14,7 @@ class Expression;
 // recording which vectors contain qualifying rows.
 // Modifies bound_expr in-place (remaps column indices to scan positions).
 shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTableEntry &table_entry,
-                                                Expression &bound_expr, idx_t &total_qualifying_rows);
+                                                Expression &bound_expr);
 
 struct CacheEntryStats {
 	idx_t qualifying_vectors;

--- a/src/include/query_condition_cache_functions.hpp
+++ b/src/include/query_condition_cache_functions.hpp
@@ -9,11 +9,22 @@ namespace duckdb {
 class DuckTableEntry;
 class Expression;
 
+// TODO: Exposed for future reuse and C++ unit testing.
 // Scan all rows in the table, evaluate bound_expr, and build a ConditionCacheEntry
 // recording which vectors contain qualifying rows.
 // Modifies bound_expr in-place (remaps column indices to scan positions).
 shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTableEntry &table_entry,
                                                 Expression &bound_expr, idx_t &total_qualifying_rows);
+
+struct CacheEntryStats {
+	idx_t qualifying_vectors;
+	idx_t total_vectors;
+	idx_t qualifying_row_groups;
+	idx_t total_row_groups;
+};
+
+// TODO: Exposed for future reuse. 
+CacheEntryStats ComputeCacheEntryStats(const ConditionCacheEntry &entry, idx_t total_rows);
 
 TableFunction ConditionCacheBuildFunction();
 

--- a/src/include/query_condition_cache_functions.hpp
+++ b/src/include/query_condition_cache_functions.hpp
@@ -23,7 +23,7 @@ struct CacheEntryStats {
 	idx_t total_row_groups;
 };
 
-// TODO: Exposed for future reuse. 
+// TODO: Exposed for future reuse.
 CacheEntryStats ComputeCacheEntryStats(const ConditionCacheEntry &entry, idx_t total_rows);
 
 TableFunction ConditionCacheBuildFunction();

--- a/src/include/query_condition_cache_optimizer.hpp
+++ b/src/include/query_condition_cache_optimizer.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/optimizer/optimizer_extension.hpp"
+
+namespace duckdb {
+
+class QueryConditionCacheOptimizer : public OptimizerExtension {
+public:
+	QueryConditionCacheOptimizer();
+
+	//! Pre-optimize: compute canonical predicate keys before FilterPushdown splits the WHERE clause.
+	//! On cache miss, builds cache inline so the first query benefits immediately.
+	static void PreOptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
+
+	//! Post-optimize: inject cache filters into LogicalGet nodes that were matched pre-optimize
+	static void OptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
+
+private:
+	//! Check if use_query_condition_cache setting is enabled
+	static bool IsSettingEnabled(ClientContext &context);
+
+	//! Walk plan pre-pushdown: find LogicalFilter→LogicalGet, compute key, lookup/build cache
+	static void PreOptimizeWalk(ClientContext &context, unique_ptr<LogicalOperator> &plan);
+
+	//! Walk plan post-pushdown: inject cache filters for pending entries
+	static void PostOptimizeWalk(unique_ptr<LogicalOperator> &plan);
+
+	//! Compute a canonical predicate key from filter expressions (sorted, joined with ";")
+	static CacheKey ComputePredicateKey(idx_t table_oid, const vector<unique_ptr<Expression>> &expressions);
+
+	//! Build cache entry for a predicate on a table, store in cache store, and return it
+	static shared_ptr<ConditionCacheEntry>
+	BuildCacheForPredicate(ClientContext &context, const vector<unique_ptr<Expression>> &expressions, LogicalGet &get);
+
+	//! Inject cache filter on a LogicalGet via ROW_ID table filter
+	static void InjectCacheFilter(unique_ptr<LogicalOperator> &get_plan, shared_ptr<ConditionCacheEntry> entry);
+};
+
+} // namespace duckdb

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -26,6 +26,7 @@ struct RowGroupFilter {
 	// Each index must be in [0, VECTORS_PER_ROW_GROUP). Duplicates are allowed.
 	explicit RowGroupFilter(const vector<idx_t> &qualifying_vectors);
 
+	void SetVector(idx_t vector_index);
 	bool VectorHasRows(idx_t vector_index) const;
 	bool IsEmpty() const;
 };

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -2,14 +2,26 @@
 
 #include "query_condition_cache_extension.hpp"
 
-#include "duckdb/main/extension/extension_loader.hpp"
 #include "query_condition_cache_functions.hpp"
+#include "query_condition_cache_optimizer.hpp"
+
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 
 namespace duckdb {
 
 namespace {
 void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(ConditionCacheBuildFunction());
+
+	// Register the use_query_condition_cache setting (default: false)
+	auto &db = loader.GetDatabaseInstance();
+	auto &config = DBConfig::GetConfig(db);
+	config.AddExtensionOption("use_query_condition_cache", "Enable automatic query condition cache build and apply",
+	                          LogicalType {LogicalTypeId::BOOLEAN}, Value::BOOLEAN(false));
+
+	// Register optimizer extension (pre-optimize + post-optimize)
+	config.optimizer_extensions.push_back(QueryConditionCacheOptimizer());
 }
 } // namespace
 

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -1,14 +1,11 @@
 #define DUCKDB_EXTENSION_MAIN
 
 #include "query_condition_cache_extension.hpp"
+#include "query_condition_cache_functions.hpp"
 
-#include "duckdb/function/table_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
 namespace duckdb {
-
-// Defined in query_condition_cache_functions.cpp
-TableFunction ConditionCacheBuildFunction();
 
 namespace {
 void LoadInternal(ExtensionLoader &loader) {

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -2,13 +2,17 @@
 
 #include "query_condition_cache_extension.hpp"
 
+#include "duckdb/function/table_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
 namespace duckdb {
 
+// Defined in query_condition_cache_functions.cpp
+TableFunction ConditionCacheBuildFunction();
+
 namespace {
 void LoadInternal(ExtensionLoader &loader) {
-	// Functions and optimizer will be registered in subsequent PRs.
+	loader.RegisterFunction(ConditionCacheBuildFunction());
 }
 } // namespace
 

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -1,9 +1,9 @@
 #define DUCKDB_EXTENSION_MAIN
 
 #include "query_condition_cache_extension.hpp"
-#include "query_condition_cache_functions.hpp"
 
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "query_condition_cache_functions.hpp"
 
 namespace duckdb {
 

--- a/src/query_condition_cache_filter.cpp
+++ b/src/query_condition_cache_filter.cpp
@@ -57,7 +57,9 @@ void ConditionCacheFilterFn(DataChunk &args, ExpressionState &state, Vector &res
 	idx_t rg_idx = NumericCast<idx_t>(first_row_id) / DEFAULT_ROW_GROUP_SIZE;
 	idx_t vec_idx = (NumericCast<idx_t>(first_row_id) % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
 
-	bool passes = false;
+	// Default to true: if row group is not in cache (e.g. newly inserted),
+	// let it pass through to upper filter evaluation for correctness.
+	bool passes = true;
 	auto it = entry.bitvectors.find(rg_idx);
 	if (it != entry.bitvectors.end()) {
 		passes = it->second.VectorHasRows(vec_idx);
@@ -84,10 +86,10 @@ FilterPropagateResult CacheExpressionFilter::CheckStatistics(BaseStatistics &sta
 	idx_t min_rg = NumericCast<idx_t>(min_val) / DEFAULT_ROW_GROUP_SIZE;
 	idx_t max_rg = NumericCast<idx_t>(max_val) / DEFAULT_ROW_GROUP_SIZE;
 
-	// If any row group in the range has matching vectors, we can't prune
+	// If any row group is not in cache (e.g. newly inserted) or has matching vectors, we can't prune
 	for (idx_t rg = min_rg; rg <= max_rg; ++rg) {
 		auto it = cache_entry->bitvectors.find(rg);
-		if (it != cache_entry->bitvectors.end() && !it->second.IsEmpty()) {
+		if (it == cache_entry->bitvectors.end() || !it->second.IsEmpty()) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
 	}

--- a/src/query_condition_cache_filter.cpp
+++ b/src/query_condition_cache_filter.cpp
@@ -1,0 +1,101 @@
+#include "query_condition_cache_filter.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+namespace duckdb {
+
+// --- ConditionCacheFilterBindData ---
+
+ConditionCacheFilterBindData::ConditionCacheFilterBindData(shared_ptr<ConditionCacheEntry> entry)
+    : cache_entry(std::move(entry)) {
+}
+
+unique_ptr<FunctionData> ConditionCacheFilterBindData::Copy() const {
+	return make_uniq<ConditionCacheFilterBindData>(cache_entry);
+}
+
+bool ConditionCacheFilterBindData::Equals(const FunctionData &other_p) const {
+	auto &other = other_p.Cast<ConditionCacheFilterBindData>();
+	return cache_entry == other.cache_entry;
+}
+
+// --- Bind (should never be called) ---
+
+unique_ptr<FunctionData> ConditionCacheFilterBind(ClientContext &context, ScalarFunction &bound_function,
+                                                  vector<unique_ptr<Expression>> &arguments) {
+	throw InternalException("__condition_cache_filter: bind should never be called directly");
+}
+
+// --- Init ---
+
+unique_ptr<FunctionLocalState> ConditionCacheFilterInit(ExpressionState &state, const BoundFunctionExpression &expr,
+                                                        FunctionData *bind_data) {
+	return make_uniq<ConditionCacheFilterState>();
+}
+
+// --- Filter Function ---
+// All row_ids in a single vector call belong to the same vector range.
+// Check the bitvector once and return a constant boolean for the entire vector.
+void ConditionCacheFilterFn(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<ConditionCacheFilterBindData>();
+	auto &entry = *bind_data.cache_entry;
+
+	auto &input_vec = args.data[0];
+	idx_t count = args.size();
+
+	// Get the first row_id to determine which vector we're in
+	UnifiedVectorFormat vdata;
+	input_vec.ToUnifiedFormat(count, vdata);
+	auto row_ids = UnifiedVectorFormat::GetData<int64_t>(vdata);
+
+	auto first_idx = vdata.sel->get_index(0);
+	int64_t first_row_id = row_ids[first_idx];
+
+	idx_t rg_idx = NumericCast<idx_t>(first_row_id) / DEFAULT_ROW_GROUP_SIZE;
+	idx_t vec_idx = (NumericCast<idx_t>(first_row_id) % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
+
+	bool passes = false;
+	auto it = entry.bitvectors.find(rg_idx);
+	if (it != entry.bitvectors.end()) {
+		passes = it->second.VectorHasRows(vec_idx);
+	}
+
+	// Return constant result for the entire vector
+	result.Reference(Value::BOOLEAN(passes));
+}
+
+// --- CacheExpressionFilter: ExpressionFilter with row-group level pruning ---
+
+CacheExpressionFilter::CacheExpressionFilter(unique_ptr<Expression> expr_p, shared_ptr<ConditionCacheEntry> entry)
+    : ExpressionFilter(std::move(expr_p)), cache_entry(std::move(entry)) {
+}
+
+FilterPropagateResult CacheExpressionFilter::CheckStatistics(BaseStatistics &stats) const {
+	if (!NumericStats::HasMinMax(stats)) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	auto min_val = NumericStats::GetMin<int64_t>(stats);
+	auto max_val = NumericStats::GetMax<int64_t>(stats);
+
+	idx_t min_rg = NumericCast<idx_t>(min_val) / DEFAULT_ROW_GROUP_SIZE;
+	idx_t max_rg = NumericCast<idx_t>(max_val) / DEFAULT_ROW_GROUP_SIZE;
+
+	// If any row group in the range has matching vectors, we can't prune
+	for (idx_t rg = min_rg; rg <= max_rg; ++rg) {
+		auto it = cache_entry->bitvectors.find(rg);
+		if (it != cache_entry->bitvectors.end() && !it->second.IsEmpty()) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+	}
+	return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+}
+
+unique_ptr<TableFilter> CacheExpressionFilter::Copy() const {
+	return make_uniq<CacheExpressionFilter>(expr->Copy(), cache_entry);
+}
+
+} // namespace duckdb

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -33,7 +33,7 @@ struct ConditionCacheBuildBindData : public TableFunctionData {
 	string table;
 	string predicate_sql;
 	idx_t table_oid;
-	idx_t total_rows;
+	idx_t total_rows; // total number of rows in the table
 };
 
 struct ConditionCacheBuildState : public GlobalTableFunctionState {
@@ -48,9 +48,9 @@ unique_ptr<FunctionData> ConditionCacheBuildBind(ClientContext &context, TableFu
 	// Parse qualified table name (supports "table", "schema.table", "catalog.schema.table")
 	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
 	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
-	result->catalog = qname.catalog;
-	result->schema = qname.schema;
-	result->table = qname.name;
+	result->catalog = std::move(qname.catalog);
+	result->schema = std::move(qname.schema);
+	result->table = std::move(qname.name);
 
 	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, result->catalog, result->schema, result->table);
 	result->table_oid = table_entry.oid;
@@ -66,20 +66,32 @@ unique_ptr<GlobalTableFunctionState> ConditionCacheBuildInit(ClientContext &cont
 	return make_uniq<ConditionCacheBuildState>();
 }
 
+// Collect all column OIDs referenced by bound expressions (BoundReferenceExpression).
+void CollectReferencedColumns(Expression &expr, unordered_set<column_t> &column_oids) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
+		auto &ref = expr.Cast<BoundReferenceExpression>();
+		column_oids.insert(ref.index);
+	}
+	ExpressionIterator::EnumerateChildren(expr,
+	                                      [&](Expression &child) { CollectReferencedColumns(child, column_oids); });
+}
+
 // After binding, column indices refer to StorageOid which may not match the scan order.
 // Remap them to the actual DataChunk column positions.
-void RemapColumnIndices(Expression &expr, const unordered_map<idx_t, idx_t> &mapping) {
+void RemapColumnIndices(Expression &expr, const unordered_map<column_t, idx_t> &mapping) {
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
 		auto &ref = expr.Cast<BoundReferenceExpression>();
 		auto it = mapping.find(ref.index);
-		if (it != mapping.end()) {
-			ref.index = it->second;
-		}
+		D_ASSERT(it != mapping.end());
+		ref.index = it->second;
 	}
-	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) {
-		RemapColumnIndices(child, mapping);
-	});
+	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) { RemapColumnIndices(child, mapping); });
 }
+
+struct ScanColumn {
+	StorageIndex index;
+	LogicalType type;
+};
 
 } // namespace
 
@@ -90,23 +102,34 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 	auto &storage = table_entry.GetStorage();
 	auto &columns = table_entry.GetColumns();
 
-	// Scan all physical columns (needed by the predicate expression) plus rowid
-	vector<pair<StorageIndex, LogicalType>> scan_columns;
-	unordered_map<idx_t, idx_t> storage_to_scan_idx;
+	// Only scan columns referenced by the predicate, plus rowid
+	unordered_set<column_t> referenced_oids;
+	CollectReferencedColumns(bound_expr, referenced_oids);
+
+	vector<ScanColumn> scan_columns;
+	// Maps storage column OID to scan position in DataChunk
+	unordered_map<column_t, idx_t> storage_to_scan_idx;
+
+	scan_columns.reserve(referenced_oids.size() + 1);
 
 	idx_t scan_pos = 0;
-	for (auto &col : columns.Physical()) {
-		scan_columns.emplace_back(StorageIndex(col.Oid()), col.Type());
+	for (const auto &col : columns.Physical()) {
+		if (referenced_oids.count(col.Oid()) == 0) {
+			continue;
+		}
+		scan_columns.push_back({StorageIndex(col.Oid()), col.Type()});
 		storage_to_scan_idx[col.Oid()] = scan_pos++;
 	}
 	const idx_t rowid_col_idx = scan_pos;
-	scan_columns.emplace_back(StorageIndex(COLUMN_IDENTIFIER_ROW_ID), LogicalType::ROW_TYPE);
+	scan_columns.push_back({StorageIndex(COLUMN_IDENTIFIER_ROW_ID), LogicalType {LogicalType::ROW_TYPE}});
 
 	vector<StorageIndex> column_ids;
 	vector<LogicalType> scan_types;
-	for (const auto &[id, type] : scan_columns) {
-		column_ids.push_back(id);
-		scan_types.push_back(type);
+	column_ids.reserve(scan_columns.size());
+	scan_types.reserve(scan_columns.size());
+	for (const auto &sc : scan_columns) {
+		column_ids.push_back(sc.index);
+		scan_types.push_back(sc.type);
 	}
 
 	RemapColumnIndices(bound_expr, storage_to_scan_idx);
@@ -119,7 +142,7 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 	// Scan and evaluate predicate
 	ExpressionExecutor executor(context, bound_expr);
 
-	unordered_map<idx_t, unordered_set<idx_t>> row_group_vec_indices;
+	auto entry = make_shared_ptr<ConditionCacheEntry>();
 
 	while (true) {
 		DataChunk chunk;
@@ -137,24 +160,18 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 		rowid_vec.ToUnifiedFormat(chunk.size(), rowid_data);
 		auto rowids = UnifiedVectorFormat::GetData<row_t>(rowid_data);
 
-		for (idx_t i = 0; i < match_count; ++i) {
-			auto rid_idx = rowid_data.sel->get_index(sel.get_index(i));
-			if (!rowid_data.validity.RowIsValid(rid_idx)) {
+		for (idx_t idx = 0; idx < match_count; ++idx) {
+			auto rowid_entry = rowid_data.sel->get_index(sel.get_index(idx));
+			if (!rowid_data.validity.RowIsValid(rowid_entry)) {
 				continue;
 			}
-			auto row_id = NumericCast<idx_t>(rowids[rid_idx]);
+			auto row_id = NumericCast<idx_t>(rowids[rowid_entry]);
 			idx_t row_group_idx = row_id / DEFAULT_ROW_GROUP_SIZE;
 			idx_t vector_idx = (row_id % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
-			row_group_vec_indices[row_group_idx].insert(vector_idx);
+			entry->bitvectors[row_group_idx].SetVector(vector_idx);
 		}
 	}
 
-	// Build cache entry from collected indices
-	auto entry = make_shared_ptr<ConditionCacheEntry>();
-	for (const auto &pair : row_group_vec_indices) {
-		vector<idx_t> indices(pair.second.begin(), pair.second.end());
-		entry->bitvectors.emplace(pair.first, RowGroupFilter(indices));
-	}
 	return entry;
 }
 
@@ -180,7 +197,12 @@ CacheEntryStats ComputeCacheEntryStats(const ConditionCacheEntry &entry, idx_t t
 	idx_t qualifying_row_groups = entry.bitvectors.size();
 	idx_t total_row_groups = (total_rows + DEFAULT_ROW_GROUP_SIZE - 1) / DEFAULT_ROW_GROUP_SIZE;
 
-	return {qualifying_vectors, total_vectors, qualifying_row_groups, total_row_groups};
+	CacheEntryStats stats;
+	stats.qualifying_vectors = qualifying_vectors;
+	stats.total_vectors = total_vectors;
+	stats.qualifying_row_groups = qualifying_row_groups;
+	stats.total_row_groups = total_row_groups;
+	return stats;
 }
 
 void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
@@ -211,12 +233,9 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	CheckBinder check_binder(*binder, context, bind_data.table, table_entry.GetColumns(), bound_columns);
 	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-	// CheckBinder sets target_type = INTEGER, so all expressions get cast to INTEGER.
-	// Re-cast to BOOLEAN for SelectExpression.
-	if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
-		bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
-		                                               LogicalType {LogicalTypeId::BOOLEAN});
-	}
+	// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN for SelectExpression.
+	bound_expr =
+	    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
 
 	auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 	auto stats = ComputeCacheEntryStats(*entry, bind_data.total_rows);
@@ -229,17 +248,16 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	store->Upsert(key, std::move(entry));
 
 	output.SetCardinality(1);
-	output.data[0].SetValue(
-	    0, StringUtil::Format("Cache Built: %llu/%llu vectors, %llu/%llu row groups",
-	                          stats.qualifying_vectors, stats.total_vectors,
-	                          stats.qualifying_row_groups, stats.total_row_groups));
+	output.data[0].SetValue(0, StringUtil::Format("Cache Built: %llu/%llu vectors, %llu/%llu row groups",
+	                                              stats.qualifying_vectors, stats.total_vectors,
+	                                              stats.qualifying_row_groups, stats.total_row_groups));
 }
 
 TableFunction ConditionCacheBuildFunction() {
-	TableFunction func("condition_cache_build",
-	                   {LogicalType {LogicalTypeId::VARCHAR} /*table*/,
-	                    LogicalType {LogicalTypeId::VARCHAR} /*predicate_sql*/},
-	                   ConditionCacheBuildExecute, ConditionCacheBuildBind, ConditionCacheBuildInit);
+	TableFunction func(
+	    "condition_cache_build",
+	    {LogicalType {LogicalTypeId::VARCHAR} /*table*/, LogicalType {LogicalTypeId::VARCHAR} /*predicate_sql*/},
+	    ConditionCacheBuildExecute, ConditionCacheBuildBind, ConditionCacheBuildInit);
 	return func;
 }
 

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -1,5 +1,4 @@
 #include "query_condition_cache_functions.hpp"
-#include "query_condition_cache_state.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
@@ -21,6 +20,7 @@
 #include "duckdb/storage/storage_index.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
+#include "query_condition_cache_state.hpp"
 
 namespace duckdb {
 namespace {
@@ -30,7 +30,7 @@ namespace {
 struct ConditionCacheBuildBindData : public TableFunctionData {
 	string catalog;
 	string schema;
-	string table_name;
+	string table;
 	string predicate_sql;
 	idx_t table_oid;
 	idx_t total_rows;
@@ -50,9 +50,9 @@ unique_ptr<FunctionData> ConditionCacheBuildBind(ClientContext &context, TableFu
 	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
 	result->catalog = qname.catalog;
 	result->schema = qname.schema;
-	result->table_name = qname.name;
+	result->table = qname.name;
 
-	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, result->catalog, result->schema, result->table_name);
+	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, result->catalog, result->schema, result->table);
 	result->table_oid = table_entry.oid;
 	result->total_rows = table_entry.GetStorage().GetTotalRows();
 
@@ -91,19 +91,23 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 	auto &columns = table_entry.GetColumns();
 
 	// Scan all physical columns (needed by the predicate expression) plus rowid
-	vector<StorageIndex> column_ids;
-	vector<LogicalType> scan_types;
+	vector<pair<StorageIndex, LogicalType>> scan_columns;
 	unordered_map<idx_t, idx_t> storage_to_scan_idx;
 
 	idx_t scan_pos = 0;
 	for (auto &col : columns.Physical()) {
-		column_ids.push_back(StorageIndex(col.Oid()));
-		scan_types.push_back(col.Type());
+		scan_columns.emplace_back(StorageIndex(col.Oid()), col.Type());
 		storage_to_scan_idx[col.Oid()] = scan_pos++;
 	}
 	idx_t rowid_col_idx = scan_pos;
-	column_ids.push_back(StorageIndex(COLUMN_IDENTIFIER_ROW_ID));
-	scan_types.push_back(LogicalType::ROW_TYPE);
+	scan_columns.emplace_back(StorageIndex(COLUMN_IDENTIFIER_ROW_ID), LogicalType::ROW_TYPE);
+
+	vector<StorageIndex> column_ids;
+	vector<LogicalType> scan_types;
+	for (auto &[id, type] : scan_columns) {
+		column_ids.push_back(id);
+		scan_types.push_back(type);
+	}
 
 	RemapColumnIndices(bound_expr, storage_to_scan_idx);
 
@@ -113,15 +117,14 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 	storage.InitializeScan(context, transaction, scan_state, column_ids);
 
 	// Scan and evaluate predicate
-	DataChunk chunk;
-	chunk.Initialize(Allocator::Get(context), scan_types);
 	ExpressionExecutor executor(context, bound_expr);
 
 	unordered_map<idx_t, unordered_set<idx_t>> row_group_vec_indices;
 	total_qualifying_rows = 0;
 
 	while (true) {
-		chunk.Reset();
+		DataChunk chunk;
+		chunk.Initialize(Allocator::Get(context), scan_types);
 		storage.Scan(transaction, chunk, scan_state);
 		if (chunk.size() == 0) {
 			break;
@@ -167,19 +170,26 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	const auto &bind_data = data_p.bind_data->Cast<ConditionCacheBuildBindData>();
 
 	auto &table_entry =
-	    Catalog::GetEntry<DuckTableEntry>(context, bind_data.catalog, bind_data.schema, bind_data.table_name);
+	    Catalog::GetEntry<DuckTableEntry>(context, bind_data.catalog, bind_data.schema, bind_data.table);
 
 	// Parse predicate SQL and bind column references to table columns
 	auto parsed_exprs = Parser::ParseExpressionList(bind_data.predicate_sql);
 	if (parsed_exprs.empty()) {
 		throw InvalidInputException("condition_cache_build: failed to parse predicate");
 	}
+	// Reject bare column references (e.g. predicate = 'val')
+	if (parsed_exprs[0]->GetExpressionClass() == ExpressionClass::COLUMN_REF) {
+		throw InvalidInputException(
+		    "condition_cache_build: predicate must be a boolean expression, not a column reference");
+	}
+
 	auto binder = Binder::CreateBinder(context);
 	physical_index_set_t bound_columns;
-	CheckBinder check_binder(*binder, context, bind_data.table_name, table_entry.GetColumns(), bound_columns);
+	CheckBinder check_binder(*binder, context, bind_data.table, table_entry.GetColumns(), bound_columns);
 	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-	// SelectExpression requires BOOLEAN return type
+	// CheckBinder sets target_type = INTEGER, so all expressions get cast to INTEGER.
+	// Re-cast to BOOLEAN for SelectExpression.
 	if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
 		bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
 		                                               LogicalType {LogicalTypeId::BOOLEAN});
@@ -225,7 +235,7 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 
 TableFunction ConditionCacheBuildFunction() {
 	TableFunction func("condition_cache_build",
-	                   {LogicalType {LogicalTypeId::VARCHAR} /*table_name*/,
+	                   {LogicalType {LogicalTypeId::VARCHAR} /*table*/,
 	                    LogicalType {LogicalTypeId::VARCHAR} /*predicate_sql*/},
 	                   ConditionCacheBuildExecute, ConditionCacheBuildBind, ConditionCacheBuildInit);
 	return func;

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -99,12 +99,12 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 		scan_columns.emplace_back(StorageIndex(col.Oid()), col.Type());
 		storage_to_scan_idx[col.Oid()] = scan_pos++;
 	}
-	idx_t rowid_col_idx = scan_pos;
+	const idx_t rowid_col_idx = scan_pos;
 	scan_columns.emplace_back(StorageIndex(COLUMN_IDENTIFIER_ROW_ID), LogicalType::ROW_TYPE);
 
 	vector<StorageIndex> column_ids;
 	vector<LogicalType> scan_types;
-	for (auto &[id, type] : scan_columns) {
+	for (const auto &[id, type] : scan_columns) {
 		column_ids.push_back(id);
 		scan_types.push_back(type);
 	}
@@ -160,6 +160,31 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 	return entry;
 }
 
+CacheEntryStats ComputeCacheEntryStats(const ConditionCacheEntry &entry, idx_t total_rows) {
+	constexpr idx_t vectors_per_row_group = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
+
+	idx_t qualifying_vectors = 0;
+	for (const auto &bitvector_pair : entry.bitvectors) {
+		for (idx_t v = 0; v < vectors_per_row_group; ++v) {
+			if (bitvector_pair.second.VectorHasRows(v)) {
+				++qualifying_vectors;
+			}
+		}
+	}
+
+	idx_t full_row_groups = total_rows / DEFAULT_ROW_GROUP_SIZE;
+	idx_t remaining_rows = total_rows % DEFAULT_ROW_GROUP_SIZE;
+	idx_t total_vectors = full_row_groups * vectors_per_row_group;
+	if (remaining_rows > 0) {
+		total_vectors += (remaining_rows + STANDARD_VECTOR_SIZE - 1) / STANDARD_VECTOR_SIZE;
+	}
+
+	idx_t qualifying_row_groups = entry.bitvectors.size();
+	idx_t total_row_groups = (total_rows + DEFAULT_ROW_GROUP_SIZE - 1) / DEFAULT_ROW_GROUP_SIZE;
+
+	return {qualifying_vectors, total_vectors, qualifying_row_groups, total_row_groups};
+}
+
 void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &gstate = data_p.global_state->Cast<ConditionCacheBuildState>();
 	if (gstate.done) {
@@ -198,26 +223,7 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	idx_t total_qualifying_rows = 0;
 	auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
 
-	// Compute statistics
-	constexpr idx_t vectors_per_row_group = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
-	idx_t qualifying_row_groups = entry->bitvectors.size();
-	idx_t total_row_groups = (bind_data.total_rows + DEFAULT_ROW_GROUP_SIZE - 1) / DEFAULT_ROW_GROUP_SIZE;
-
-	idx_t qualifying_vectors = 0;
-	for (const auto &bitvector_pair : entry->bitvectors) {
-		for (idx_t v = 0; v < vectors_per_row_group; ++v) {
-			if (bitvector_pair.second.VectorHasRows(v)) {
-				++qualifying_vectors;
-			}
-		}
-	}
-
-	idx_t full_row_groups = bind_data.total_rows / DEFAULT_ROW_GROUP_SIZE;
-	idx_t remaining_rows = bind_data.total_rows % DEFAULT_ROW_GROUP_SIZE;
-	idx_t total_vectors = full_row_groups * vectors_per_row_group;
-	if (remaining_rows > 0) {
-		total_vectors += (remaining_rows + STANDARD_VECTOR_SIZE - 1) / STANDARD_VECTOR_SIZE;
-	}
+	auto stats = ComputeCacheEntryStats(*entry, bind_data.total_rows);
 
 	// Store in cache
 	// TODO: Use canonical predicate key (sorted expressions) so that "a AND b" and "b AND a" hit same entry
@@ -229,8 +235,8 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	output.SetCardinality(1);
 	output.data[0].SetValue(
 	    0, StringUtil::Format("Cache Built: %llu qualifying rows, %llu/%llu vectors, %llu/%llu row groups",
-	                          total_qualifying_rows, qualifying_vectors, total_vectors, qualifying_row_groups,
-	                          total_row_groups));
+	                          total_qualifying_rows, stats.qualifying_vectors, stats.total_vectors,
+	                          stats.qualifying_row_groups, stats.total_row_groups));
 }
 
 TableFunction ConditionCacheBuildFunction() {

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -1,16 +1,26 @@
+#include "query_condition_cache_functions.hpp"
 #include "query_condition_cache_state.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/common/allocator.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/table_function.hpp"
-#include "duckdb/main/connection.hpp"
-#include "duckdb/main/database.hpp"
-#include "duckdb/parser/keyword_helper.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/qualified_name.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/expression_binder/check_binder.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/storage/storage_index.hpp"
+#include "duckdb/storage/table/scan_state.hpp"
+#include "duckdb/transaction/duck_transaction.hpp"
 
 namespace duckdb {
 namespace {
@@ -18,6 +28,8 @@ namespace {
 // ------- condition_cache_build(table_name VARCHAR, predicate VARCHAR) -------
 
 struct ConditionCacheBuildBindData : public TableFunctionData {
+	string catalog;
+	string schema;
 	string table_name;
 	string predicate_sql;
 	idx_t table_oid;
@@ -31,11 +43,16 @@ struct ConditionCacheBuildState : public GlobalTableFunctionState {
 unique_ptr<FunctionData> ConditionCacheBuildBind(ClientContext &context, TableFunctionBindInput &input,
                                                  vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_uniq<ConditionCacheBuildBindData>();
-	result->table_name = input.inputs[0].GetValue<string>();
 	result->predicate_sql = input.inputs[1].GetValue<string>();
 
-	// Resolve table to get OID and total rows; throws if table doesn't exist
-	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, result->table_name);
+	// Parse qualified table name (supports "table", "schema.table", "catalog.schema.table")
+	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
+	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
+	result->catalog = qname.catalog;
+	result->schema = qname.schema;
+	result->table_name = qname.name;
+
+	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, result->catalog, result->schema, result->table_name);
 	result->table_oid = table_entry.oid;
 	result->total_rows = table_entry.GetStorage().GetTotalRows();
 
@@ -49,47 +66,81 @@ unique_ptr<GlobalTableFunctionState> ConditionCacheBuildInit(ClientContext &cont
 	return make_uniq<ConditionCacheBuildState>();
 }
 
-void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-	auto &gstate = data_p.global_state->Cast<ConditionCacheBuildState>();
-	if (gstate.done) {
-		return;
+// After binding, column indices refer to StorageOid which may not match the scan order.
+// Remap them to the actual DataChunk column positions.
+void RemapColumnIndices(Expression &expr, const unordered_map<idx_t, idx_t> &mapping) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
+		auto &ref = expr.Cast<BoundReferenceExpression>();
+		auto it = mapping.find(ref.index);
+		if (it != mapping.end()) {
+			ref.index = it->second;
+		}
 	}
-	gstate.done = true;
+	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) {
+		RemapColumnIndices(child, mapping);
+	});
+}
 
-	const auto &bind_data = data_p.bind_data->Cast<ConditionCacheBuildBindData>();
+} // namespace
 
-	// Run SELECT rowid on a new connection
-	string quoted_table = KeywordHelper::WriteQuoted(bind_data.table_name, '"');
-	string query = StringUtil::Format("SELECT rowid FROM %s WHERE %s", quoted_table, bind_data.predicate_sql);
-	auto &db = DatabaseInstance::GetDatabase(context);
-	Connection con(db);
-	auto result = con.Query(query);
+// Scan all rows, evaluate predicate, and build a ConditionCacheEntry.
+// Modifies bound_expr in-place (remaps column indices to scan positions).
+shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTableEntry &table_entry,
+                                                Expression &bound_expr, idx_t &total_qualifying_rows) {
+	auto &storage = table_entry.GetStorage();
+	auto &columns = table_entry.GetColumns();
 
-	if (result->HasError()) {
-		throw InvalidInputException("condition_cache_build: query failed: %s", result->GetError());
+	// Scan all physical columns (needed by the predicate expression) plus rowid
+	vector<StorageIndex> column_ids;
+	vector<LogicalType> scan_types;
+	unordered_map<idx_t, idx_t> storage_to_scan_idx;
+
+	idx_t scan_pos = 0;
+	for (auto &col : columns.Physical()) {
+		column_ids.push_back(StorageIndex(col.Oid()));
+		scan_types.push_back(col.Type());
+		storage_to_scan_idx[col.Oid()] = scan_pos++;
 	}
+	idx_t rowid_col_idx = scan_pos;
+	column_ids.push_back(StorageIndex(COLUMN_IDENTIFIER_ROW_ID));
+	scan_types.push_back(LogicalType::ROW_TYPE);
 
-	// Collect qualifying vector indices per row group
+	RemapColumnIndices(bound_expr, storage_to_scan_idx);
+
+	// Direct table scan with predicate evaluation via ExpressionExecutor
+	auto &transaction = DuckTransaction::Get(context, table_entry.ParentCatalog().GetAttached());
+	TableScanState scan_state;
+	storage.InitializeScan(context, transaction, scan_state, column_ids);
+
+	// Scan and evaluate predicate
+	DataChunk chunk;
+	chunk.Initialize(Allocator::Get(context), scan_types);
+	ExpressionExecutor executor(context, bound_expr);
+
 	unordered_map<idx_t, unordered_set<idx_t>> row_group_vec_indices;
-	idx_t total_qualifying_rows = 0;
+	total_qualifying_rows = 0;
 
 	while (true) {
-		auto chunk = result->Fetch();
-		if (!chunk || chunk->size() == 0) {
+		chunk.Reset();
+		storage.Scan(transaction, chunk, scan_state);
+		if (chunk.size() == 0) {
 			break;
 		}
 
-		auto &rowid_vec = chunk->data[0];
-		UnifiedVectorFormat vector_data;
-		rowid_vec.ToUnifiedFormat(chunk->size(), vector_data);
-		auto rowids = UnifiedVectorFormat::GetData<int64_t>(vector_data);
+		SelectionVector sel(chunk.size());
+		idx_t match_count = executor.SelectExpression(chunk, sel);
 
-		for (idx_t i = 0; i < chunk->size(); ++i) {
-			auto idx = vector_data.sel->get_index(i);
-			if (!vector_data.validity.RowIsValid(idx)) {
+		auto &rowid_vec = chunk.data[rowid_col_idx];
+		UnifiedVectorFormat rowid_data;
+		rowid_vec.ToUnifiedFormat(chunk.size(), rowid_data);
+		auto rowids = UnifiedVectorFormat::GetData<row_t>(rowid_data);
+
+		for (idx_t i = 0; i < match_count; ++i) {
+			auto rid_idx = rowid_data.sel->get_index(sel.get_index(i));
+			if (!rowid_data.validity.RowIsValid(rid_idx)) {
 				continue;
 			}
-			auto row_id = NumericCast<idx_t>(rowids[idx]);
+			auto row_id = NumericCast<idx_t>(rowids[rid_idx]);
 			idx_t row_group_idx = row_id / DEFAULT_ROW_GROUP_SIZE;
 			idx_t vector_idx = (row_id % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
 			row_group_vec_indices[row_group_idx].insert(vector_idx);
@@ -103,10 +154,43 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 		vector<idx_t> indices(pair.second.begin(), pair.second.end());
 		entry->bitvectors.emplace(pair.first, RowGroupFilter(indices));
 	}
+	return entry;
+}
+
+void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &gstate = data_p.global_state->Cast<ConditionCacheBuildState>();
+	if (gstate.done) {
+		return;
+	}
+	gstate.done = true;
+
+	const auto &bind_data = data_p.bind_data->Cast<ConditionCacheBuildBindData>();
+
+	auto &table_entry =
+	    Catalog::GetEntry<DuckTableEntry>(context, bind_data.catalog, bind_data.schema, bind_data.table_name);
+
+	// Parse predicate SQL and bind column references to table columns
+	auto parsed_exprs = Parser::ParseExpressionList(bind_data.predicate_sql);
+	if (parsed_exprs.empty()) {
+		throw InvalidInputException("condition_cache_build: failed to parse predicate");
+	}
+	auto binder = Binder::CreateBinder(context);
+	physical_index_set_t bound_columns;
+	CheckBinder check_binder(*binder, context, bind_data.table_name, table_entry.GetColumns(), bound_columns);
+	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+
+	// SelectExpression requires BOOLEAN return type
+	if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
+		bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
+		                                               LogicalType {LogicalTypeId::BOOLEAN});
+	}
+
+	idx_t total_qualifying_rows = 0;
+	auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
 
 	// Compute statistics
 	constexpr idx_t vectors_per_row_group = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
-	idx_t qualifying_row_groups = row_group_vec_indices.size();
+	idx_t qualifying_row_groups = entry->bitvectors.size();
 	idx_t total_row_groups = (bind_data.total_rows + DEFAULT_ROW_GROUP_SIZE - 1) / DEFAULT_ROW_GROUP_SIZE;
 
 	idx_t qualifying_vectors = 0;
@@ -127,8 +211,7 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 
 	// Store in cache
 	// TODO: Use canonical predicate key (sorted expressions) so that "a AND b" and "b AND a" hit same entry
-	// TODO: Invalidate cache on table modification (INSERT/DELETE/UPDATE/VACUUM), need to implement invalidation
-	// mechanism
+	// TODO: Invalidate cache on table modification (INSERT/DELETE/UPDATE/VACUUM)
 	CacheKey key {bind_data.table_oid, bind_data.predicate_sql};
 	auto store = ConditionCacheStore::GetOrCreate(context);
 	store->Upsert(key, std::move(entry));
@@ -140,11 +223,10 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	                          total_row_groups));
 }
 
-} // namespace
-
 TableFunction ConditionCacheBuildFunction() {
 	TableFunction func("condition_cache_build",
-	                   {LogicalType {LogicalTypeId::VARCHAR}, LogicalType {LogicalTypeId::VARCHAR}},
+	                   {LogicalType {LogicalTypeId::VARCHAR} /*table_name*/,
+	                    LogicalType {LogicalTypeId::VARCHAR} /*predicate_sql*/},
 	                   ConditionCacheBuildExecute, ConditionCacheBuildBind, ConditionCacheBuildInit);
 	return func;
 }

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -86,7 +86,7 @@ void RemapColumnIndices(Expression &expr, const unordered_map<idx_t, idx_t> &map
 // Scan all rows, evaluate predicate, and build a ConditionCacheEntry.
 // Modifies bound_expr in-place (remaps column indices to scan positions).
 shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTableEntry &table_entry,
-                                                Expression &bound_expr, idx_t &total_qualifying_rows) {
+                                                Expression &bound_expr) {
 	auto &storage = table_entry.GetStorage();
 	auto &columns = table_entry.GetColumns();
 
@@ -120,7 +120,6 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 	ExpressionExecutor executor(context, bound_expr);
 
 	unordered_map<idx_t, unordered_set<idx_t>> row_group_vec_indices;
-	total_qualifying_rows = 0;
 
 	while (true) {
 		DataChunk chunk;
@@ -147,7 +146,6 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 			idx_t row_group_idx = row_id / DEFAULT_ROW_GROUP_SIZE;
 			idx_t vector_idx = (row_id % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
 			row_group_vec_indices[row_group_idx].insert(vector_idx);
-			++total_qualifying_rows;
 		}
 	}
 
@@ -220,9 +218,7 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 		                                               LogicalType {LogicalTypeId::BOOLEAN});
 	}
 
-	idx_t total_qualifying_rows = 0;
-	auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
-
+	auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 	auto stats = ComputeCacheEntryStats(*entry, bind_data.total_rows);
 
 	// Store in cache
@@ -234,8 +230,8 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 
 	output.SetCardinality(1);
 	output.data[0].SetValue(
-	    0, StringUtil::Format("Cache Built: %llu qualifying rows, %llu/%llu vectors, %llu/%llu row groups",
-	                          total_qualifying_rows, stats.qualifying_vectors, stats.total_vectors,
+	    0, StringUtil::Format("Cache Built: %llu/%llu vectors, %llu/%llu row groups",
+	                          stats.qualifying_vectors, stats.total_vectors,
 	                          stats.qualifying_row_groups, stats.total_row_groups));
 }
 

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -1,0 +1,152 @@
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/unordered_set.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/parser/keyword_helper.hpp"
+
+namespace duckdb {
+namespace {
+
+// ------- condition_cache_build(table_name VARCHAR, predicate VARCHAR) -------
+
+struct ConditionCacheBuildBindData : public TableFunctionData {
+	string table_name;
+	string predicate_sql;
+	idx_t table_oid;
+	idx_t total_rows;
+};
+
+struct ConditionCacheBuildState : public GlobalTableFunctionState {
+	bool done = false;
+};
+
+unique_ptr<FunctionData> ConditionCacheBuildBind(ClientContext &context, TableFunctionBindInput &input,
+                                                 vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_uniq<ConditionCacheBuildBindData>();
+	result->table_name = input.inputs[0].GetValue<string>();
+	result->predicate_sql = input.inputs[1].GetValue<string>();
+
+	// Resolve table to get OID and total rows; throws if table doesn't exist
+	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, result->table_name);
+	result->table_oid = table_entry.oid;
+	result->total_rows = table_entry.GetStorage().GetTotalRows();
+
+	names.emplace_back("status");
+	return_types.emplace_back(LogicalType {LogicalTypeId::VARCHAR});
+
+	return result;
+}
+
+unique_ptr<GlobalTableFunctionState> ConditionCacheBuildInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_uniq<ConditionCacheBuildState>();
+}
+
+void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &gstate = data_p.global_state->Cast<ConditionCacheBuildState>();
+	if (gstate.done) {
+		return;
+	}
+	gstate.done = true;
+
+	const auto &bind_data = data_p.bind_data->Cast<ConditionCacheBuildBindData>();
+
+	// Run SELECT rowid on a new connection
+	string quoted_table = KeywordHelper::WriteQuoted(bind_data.table_name, '"');
+	string query = StringUtil::Format("SELECT rowid FROM %s WHERE %s", quoted_table, bind_data.predicate_sql);
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection con(db);
+	auto result = con.Query(query);
+
+	if (result->HasError()) {
+		throw InvalidInputException("condition_cache_build: query failed: %s", result->GetError());
+	}
+
+	// Collect qualifying vector indices per row group
+	unordered_map<idx_t, unordered_set<idx_t>> row_group_vec_indices;
+	idx_t total_qualifying_rows = 0;
+
+	while (true) {
+		auto chunk = result->Fetch();
+		if (!chunk || chunk->size() == 0) {
+			break;
+		}
+
+		auto &rowid_vec = chunk->data[0];
+		UnifiedVectorFormat vector_data;
+		rowid_vec.ToUnifiedFormat(chunk->size(), vector_data);
+		auto rowids = UnifiedVectorFormat::GetData<int64_t>(vector_data);
+
+		for (idx_t i = 0; i < chunk->size(); ++i) {
+			auto idx = vector_data.sel->get_index(i);
+			if (!vector_data.validity.RowIsValid(idx)) {
+				continue;
+			}
+			auto row_id = NumericCast<idx_t>(rowids[idx]);
+			idx_t row_group_idx = row_id / DEFAULT_ROW_GROUP_SIZE;
+			idx_t vector_idx = (row_id % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
+			row_group_vec_indices[row_group_idx].insert(vector_idx);
+			++total_qualifying_rows;
+		}
+	}
+
+	// Build cache entry from collected indices
+	auto entry = make_shared_ptr<ConditionCacheEntry>();
+	for (const auto &pair : row_group_vec_indices) {
+		vector<idx_t> indices(pair.second.begin(), pair.second.end());
+		entry->bitvectors.emplace(pair.first, RowGroupFilter(indices));
+	}
+
+	// Compute statistics
+	constexpr idx_t vectors_per_row_group = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
+	idx_t qualifying_row_groups = row_group_vec_indices.size();
+	idx_t total_row_groups = (bind_data.total_rows + DEFAULT_ROW_GROUP_SIZE - 1) / DEFAULT_ROW_GROUP_SIZE;
+
+	idx_t qualifying_vectors = 0;
+	for (const auto &bitvector_pair : entry->bitvectors) {
+		for (idx_t v = 0; v < vectors_per_row_group; ++v) {
+			if (bitvector_pair.second.VectorHasRows(v)) {
+				++qualifying_vectors;
+			}
+		}
+	}
+
+	idx_t full_row_groups = bind_data.total_rows / DEFAULT_ROW_GROUP_SIZE;
+	idx_t remaining_rows = bind_data.total_rows % DEFAULT_ROW_GROUP_SIZE;
+	idx_t total_vectors = full_row_groups * vectors_per_row_group;
+	if (remaining_rows > 0) {
+		total_vectors += (remaining_rows + STANDARD_VECTOR_SIZE - 1) / STANDARD_VECTOR_SIZE;
+	}
+
+	// Store in cache
+	// TODO: Use canonical predicate key (sorted expressions) so that "a AND b" and "b AND a" hit same entry
+	// TODO: Invalidate cache on table modification (INSERT/DELETE/UPDATE/VACUUM), need to implement invalidation
+	// mechanism
+	CacheKey key {bind_data.table_oid, bind_data.predicate_sql};
+	auto store = ConditionCacheStore::GetOrCreate(context);
+	store->Upsert(key, std::move(entry));
+
+	output.SetCardinality(1);
+	output.data[0].SetValue(
+	    0, StringUtil::Format("Cache Built: %llu qualifying rows, %llu/%llu vectors, %llu/%llu row groups",
+	                          total_qualifying_rows, qualifying_vectors, total_vectors, qualifying_row_groups,
+	                          total_row_groups));
+}
+
+} // namespace
+
+TableFunction ConditionCacheBuildFunction() {
+	TableFunction func("condition_cache_build",
+	                   {LogicalType {LogicalTypeId::VARCHAR}, LogicalType {LogicalTypeId::VARCHAR}},
+	                   ConditionCacheBuildExecute, ConditionCacheBuildBind, ConditionCacheBuildInit);
+	return func;
+}
+
+} // namespace duckdb

--- a/src/query_condition_cache_optimizer.cpp
+++ b/src/query_condition_cache_optimizer.cpp
@@ -1,0 +1,223 @@
+#include "query_condition_cache_optimizer.hpp"
+#include "query_condition_cache_filter.hpp"
+#include "query_condition_cache_functions.hpp"
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/algorithm.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/expression_binder/check_binder.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+
+namespace duckdb {
+
+namespace {
+// Thread-local: table_index -> cache entry to inject in the post-optimize pass.
+// Populated by PreOptimizeFunction, consumed and cleared by OptimizeFunction.
+thread_local unordered_map<idx_t, shared_ptr<ConditionCacheEntry>> tl_cache_apply_pending;
+} // namespace
+
+QueryConditionCacheOptimizer::QueryConditionCacheOptimizer() {
+	pre_optimize_function = PreOptimizeFunction;
+	optimize_function = OptimizeFunction;
+}
+
+// ============================================================================
+// Setting check
+// ============================================================================
+
+bool QueryConditionCacheOptimizer::IsSettingEnabled(ClientContext &context) {
+	Value val;
+	auto result = context.TryGetCurrentSetting("use_query_condition_cache", val);
+	if (!result) {
+		return false;
+	}
+	return val.GetValue<bool>();
+}
+
+// ============================================================================
+// Pre-optimize: runs BEFORE built-in passes (including FilterPushdown).
+// The full WHERE clause is still in LogicalFilter.expressions, so we can
+// compute a canonical key that covers the entire predicate.
+// On cache miss, builds cache inline so the first query benefits immediately.
+// ============================================================================
+
+void QueryConditionCacheOptimizer::PreOptimizeFunction(OptimizerExtensionInput &input,
+                                                       unique_ptr<LogicalOperator> &plan) {
+	if (!IsSettingEnabled(input.context)) {
+		return;
+	}
+	tl_cache_apply_pending.clear();
+	PreOptimizeWalk(input.context, plan);
+}
+
+void QueryConditionCacheOptimizer::PreOptimizeWalk(ClientContext &context, unique_ptr<LogicalOperator> &plan) {
+	for (auto &child : plan->children) {
+		PreOptimizeWalk(context, child);
+	}
+
+	if (plan->type != LogicalOperatorType::LOGICAL_FILTER || plan->children.empty()) {
+		return;
+	}
+	if (plan->children[0]->type != LogicalOperatorType::LOGICAL_GET) {
+		return;
+	}
+
+	auto &filter = plan->Cast<LogicalFilter>();
+	auto &get = plan->children[0]->Cast<LogicalGet>();
+	auto table = get.GetTable();
+	if (!table) {
+		return; // Not a DuckDB table (e.g. system table, external), skip gracefully
+	}
+	if (filter.expressions.empty()) {
+		return;
+	}
+
+	auto key = ComputePredicateKey(table->oid, filter.expressions);
+	auto store = ConditionCacheStore::GetOrCreate(context);
+	auto entry = store->Lookup(key);
+
+	if (!entry) {
+		// Cache miss: build cache inline
+		entry = BuildCacheForPredicate(context, filter.expressions, get);
+		if (entry) {
+			store->Upsert(key, entry);
+		}
+	}
+
+	if (entry) {
+		tl_cache_apply_pending[get.table_index] = std::move(entry);
+	}
+}
+
+CacheKey QueryConditionCacheOptimizer::ComputePredicateKey(idx_t table_oid,
+                                                           const vector<unique_ptr<Expression>> &expressions) {
+	vector<string> parts;
+	parts.reserve(expressions.size());
+	for (auto &expr : expressions) {
+		parts.push_back(expr->ToString());
+	}
+	std::sort(parts.begin(), parts.end());
+	return CacheKey {table_oid, StringUtil::Join(parts, ";")};
+}
+
+shared_ptr<ConditionCacheEntry> QueryConditionCacheOptimizer::BuildCacheForPredicate(
+    ClientContext &context, const vector<unique_ptr<Expression>> &expressions, LogicalGet &get) {
+	auto table_ptr = get.GetTable();
+	if (!table_ptr) {
+		return nullptr;
+	}
+
+	// We need a DuckTableEntry to use BuildCacheEntry
+	auto &table_entry = table_ptr->Cast<DuckTableEntry>();
+
+	// Reconstruct predicate SQL from the bound expressions.
+	// Join multiple filter expressions with AND.
+	vector<string> parts;
+	parts.reserve(expressions.size());
+	for (auto &expr : expressions) {
+		parts.push_back(expr->ToString());
+	}
+	string predicate_sql = StringUtil::Join(parts, " AND ");
+
+	// Parse, bind, and build cache entry (same flow as condition_cache_build table function)
+	auto parsed_exprs = Parser::ParseExpressionList(predicate_sql);
+	if (parsed_exprs.empty()) {
+		return nullptr;
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	physical_index_set_t bound_columns;
+	CheckBinder check_binder(*binder, context, table_entry.name, table_entry.GetColumns(), bound_columns);
+	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+
+	// CheckBinder sets target_type = INTEGER, re-cast to BOOLEAN
+	bound_expr =
+	    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
+
+	return BuildCacheEntry(context, table_entry, *bound_expr);
+}
+
+// ============================================================================
+// Post-optimize: runs AFTER all built-in passes.
+// FilterPushdown has already split predicates; we don't care about the split
+// because the key was computed pre-pushdown. We just find the LogicalGet
+// nodes whose table_index was matched and inject the cache filter.
+// ============================================================================
+
+void QueryConditionCacheOptimizer::OptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
+	if (tl_cache_apply_pending.empty()) {
+		return;
+	}
+	PostOptimizeWalk(plan);
+	tl_cache_apply_pending.clear();
+}
+
+void QueryConditionCacheOptimizer::PostOptimizeWalk(unique_ptr<LogicalOperator> &plan) {
+	for (auto &child : plan->children) {
+		PostOptimizeWalk(child);
+	}
+
+	if (plan->type != LogicalOperatorType::LOGICAL_GET) {
+		return;
+	}
+
+	auto &get = plan->Cast<LogicalGet>();
+	auto it = tl_cache_apply_pending.find(get.table_index);
+	if (it == tl_cache_apply_pending.end()) {
+		return;
+	}
+
+	InjectCacheFilter(plan, std::move(it->second));
+	tl_cache_apply_pending.erase(it);
+}
+
+// ============================================================================
+// InjectCacheFilter: add __condition_cache_filter on ROW_ID
+// ============================================================================
+
+void QueryConditionCacheOptimizer::InjectCacheFilter(unique_ptr<LogicalOperator> &get_plan,
+                                                     shared_ptr<ConditionCacheEntry> entry) {
+	auto &get = get_plan->Cast<LogicalGet>();
+
+	ScalarFunction func("__condition_cache_filter", {LogicalType {LogicalTypeId::BIGINT}},
+	                    LogicalType {LogicalTypeId::BOOLEAN}, ConditionCacheFilterFn, ConditionCacheFilterBind, nullptr,
+	                    nullptr, ConditionCacheFilterInit);
+
+	auto bind_data = make_uniq<ConditionCacheFilterBindData>(entry);
+
+	vector<unique_ptr<Expression>> children;
+	children.push_back(make_uniq<BoundReferenceExpression>(LogicalType {LogicalTypeId::BIGINT}, 0));
+
+	auto func_expr = make_uniq<BoundFunctionExpression>(LogicalType {LogicalTypeId::BOOLEAN}, func, std::move(children),
+	                                                    std::move(bind_data));
+
+	get.table_filters.PushFilter(ColumnIndex(COLUMN_IDENTIFIER_ROW_ID),
+	                             make_uniq<CacheExpressionFilter>(std::move(func_expr), entry));
+
+	// Ensure ROW_ID column is in the scan
+	bool has_rowid = false;
+	for (auto &col : get.GetColumnIds()) {
+		if (col.IsRowIdColumn()) {
+			has_rowid = true;
+			break;
+		}
+	}
+	if (!has_rowid) {
+		if (get.projection_ids.empty()) {
+			for (idx_t i = 0; i < get.GetColumnIds().size(); ++i) {
+				get.projection_ids.push_back(i);
+			}
+		}
+		get.AddColumnId(COLUMN_IDENTIFIER_ROW_ID);
+	}
+}
+
+} // namespace duckdb

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -12,6 +12,10 @@ RowGroupFilter::RowGroupFilter(const vector<idx_t> &qualifying_vectors) {
 	}
 }
 
+void RowGroupFilter::SetVector(idx_t vector_index) {
+	matching_vectors.at(vector_index / 64) |= (1ULL << (vector_index % 64));
+}
+
 bool RowGroupFilter::VectorHasRows(idx_t vector_index) const {
 	return (matching_vectors.at(vector_index / 64) >> (vector_index % 64)) & 1ULL;
 }

--- a/test/sql/condition_cache_auto.test
+++ b/test/sql/condition_cache_auto.test
@@ -1,0 +1,74 @@
+# name: test/sql/condition_cache_auto.test
+# description: Test automatic query condition cache build and apply
+# group: [sql]
+
+require query_condition_cache
+
+# Setting defaults to false
+query I
+SELECT current_setting('use_query_condition_cache');
+----
+false
+
+# Create table with multiple row groups (>122880 rows)
+statement ok
+CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i);
+
+# Without setting, normal query works
+query I
+SELECT count(*) FROM t WHERE val = 42;
+----
+5000
+
+# Enable automatic cache
+statement ok
+SET use_query_condition_cache = true;
+
+# First query with setting ON: builds cache and returns correct results
+query I
+SELECT count(*) FROM t WHERE val = 42;
+----
+5000
+
+# Second query (cache hit): same correct results
+query I
+SELECT count(*) FROM t WHERE val = 42;
+----
+5000
+
+# Selective predicate: different cache entry, correct results
+query I
+SELECT count(*) FROM t WHERE id < 3000;
+----
+3000
+
+# Multiple predicates (AND)
+query I
+SELECT count(*) FROM t WHERE val = 42 AND id < 200000;
+----
+2000
+
+# Setting can be toggled off
+statement ok
+SET use_query_condition_cache = false;
+
+# With setting off, queries still return correct results (no automatic behavior)
+query I
+SELECT count(*) FROM t WHERE val = 99;
+----
+5000
+
+# Manual condition_cache_build still works regardless of setting
+query I
+SELECT status FROM condition_cache_build('t', 'val = 99');
+----
+Cache Built: 245/245 vectors, 5/5 row groups
+
+# Re-enable and test that previously manually built cache can be used
+statement ok
+SET use_query_condition_cache = true;
+
+query I
+SELECT count(*) FROM t WHERE val = 99;
+----
+5000

--- a/test/sql/condition_cache_build.test
+++ b/test/sql/condition_cache_build.test
@@ -12,19 +12,19 @@ CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i);
 query I
 SELECT status FROM condition_cache_build('t', 'val = 42');
 ----
-Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+Cache Built: 245/245 vectors, 5/5 row groups
 
 # Build with selective predicate (only hits RG0, 2 vectors)
 query I
 SELECT status FROM condition_cache_build('t', 'id < 3000');
 ----
-Cache Built: 3000 qualifying rows, 2/245 vectors, 1/5 row groups
+Cache Built: 2/245 vectors, 1/5 row groups
 
 # Build same predicate again (upsert, no error)
 query I
 SELECT status FROM condition_cache_build('t', 'val = 42');
 ----
-Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+Cache Built: 245/245 vectors, 5/5 row groups
 
 # Non-BOOLEAN predicate throws error
 statement error
@@ -48,13 +48,13 @@ does not contain column invalid_col
 query I
 SELECT status FROM condition_cache_build('main.t', 'val = 42');
 ----
-Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+Cache Built: 245/245 vectors, 5/5 row groups
 
 # Fully qualified table name (catalog.schema.table)
 query I
 SELECT status FROM condition_cache_build('memory.main.t', 'val = 42');
 ----
-Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+Cache Built: 245/245 vectors, 5/5 row groups
 
 # Invalid schema name
 statement error

--- a/test/sql/condition_cache_build.test
+++ b/test/sql/condition_cache_build.test
@@ -26,6 +26,12 @@ SELECT status FROM condition_cache_build('t', 'val = 42');
 ----
 Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
 
+# Non-BOOLEAN predicate throws error
+statement error
+SELECT * FROM condition_cache_build('t', 'val');
+----
+predicate must be a boolean expression
+
 # Nonexistent table throws error
 statement error
 SELECT * FROM condition_cache_build('nonexistent', 'val = 42');
@@ -49,3 +55,15 @@ query I
 SELECT status FROM condition_cache_build('memory.main.t', 'val = 42');
 ----
 Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+
+# Invalid schema name
+statement error
+SELECT * FROM condition_cache_build('bad_schema.t', 'val = 42');
+----
+Table with name t does not exist
+
+# Invalid database name
+statement error
+SELECT * FROM condition_cache_build('bad_catalog.main.t', 'val = 42');
+----
+Catalog "bad_catalog" does not exist

--- a/test/sql/condition_cache_build.test
+++ b/test/sql/condition_cache_build.test
@@ -1,0 +1,39 @@
+# name: test/sql/condition_cache_build.test
+# description: Test condition_cache_build table function
+# group: [sql]
+
+require query_condition_cache
+
+# Create table with multiple row groups (>122880 rows)
+statement ok
+CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i);
+
+# Build cache for simple equality predicate
+query I
+SELECT status FROM condition_cache_build('t', 'val = 42');
+----
+Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+
+# Build with selective predicate (only hits RG0, 2 vectors)
+query I
+SELECT status FROM condition_cache_build('t', 'id < 3000');
+----
+Cache Built: 3000 qualifying rows, 2/245 vectors, 1/5 row groups
+
+# Build same predicate again (upsert, no error)
+query I
+SELECT status FROM condition_cache_build('t', 'val = 42');
+----
+Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+
+# Nonexistent table throws error
+statement error
+SELECT * FROM condition_cache_build('nonexistent', 'val = 42');
+----
+Table with name nonexistent does not exist
+
+# Invalid predicate throws error
+statement error
+SELECT * FROM condition_cache_build('t', 'invalid_col = 42');
+----
+not found in FROM clause

--- a/test/sql/condition_cache_build.test
+++ b/test/sql/condition_cache_build.test
@@ -36,4 +36,16 @@ Table with name nonexistent does not exist
 statement error
 SELECT * FROM condition_cache_build('t', 'invalid_col = 42');
 ----
-not found in FROM clause
+does not contain column invalid_col
+
+# Qualified table name with schema
+query I
+SELECT status FROM condition_cache_build('main.t', 'val = 42');
+----
+Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups
+
+# Fully qualified table name (catalog.schema.table)
+query I
+SELECT status FROM condition_cache_build('memory.main.t', 'val = 42');
+----
+Cache Built: 5000 qualifying rows, 245/245 vectors, 5/5 row groups

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
 set(QUERY_CACHE_UNITTEST_OBJECTS main.cpp test_bitvector.cpp
+                                 test_build_cache_entry.cpp
                                  test_cache_store.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -5,9 +5,8 @@ include_directories(${CMAKE_SOURCE_DIR}/src/include)
 include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
-set(QUERY_CACHE_UNITTEST_OBJECTS main.cpp test_bitvector.cpp
-                                 test_build_cache_entry.cpp
-                                 test_cache_store.cpp)
+set(QUERY_CACHE_UNITTEST_OBJECTS
+    main.cpp test_bitvector.cpp test_build_cache_entry.cpp test_cache_store.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})
 

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -6,7 +6,8 @@ include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
 set(QUERY_CACHE_UNITTEST_OBJECTS
-    main.cpp test_bitvector.cpp test_build_cache_entry.cpp test_cache_store.cpp)
+    main.cpp test_bitvector.cpp test_build_cache_entry.cpp test_cache_store.cpp
+    test_filter.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})
 

--- a/test/unittest/test_build_cache_entry.cpp
+++ b/test/unittest/test_build_cache_entry.cpp
@@ -35,11 +35,9 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 			                                               LogicalType {LogicalTypeId::BOOLEAN});
 		}
 
-		idx_t total_qualifying_rows = 0;
-		auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
+		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
 		REQUIRE(entry != nullptr);
-		REQUIRE(total_qualifying_rows == 5000);
 		REQUIRE(entry->bitvectors.size() == 5); // 5 row groups
 	}
 
@@ -55,11 +53,9 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 			                                               LogicalType {LogicalTypeId::BOOLEAN});
 		}
 
-		idx_t total_qualifying_rows = 0;
-		auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
+		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
 		REQUIRE(entry != nullptr);
-		REQUIRE(total_qualifying_rows == 3000);
 		REQUIRE(entry->bitvectors.size() == 1); // only row group 0
 	}
 
@@ -75,11 +71,9 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 			                                               LogicalType {LogicalTypeId::BOOLEAN});
 		}
 
-		idx_t total_qualifying_rows = 0;
-		auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
+		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
 		REQUIRE(entry != nullptr);
-		REQUIRE(total_qualifying_rows == 0);
 		REQUIRE(entry->bitvectors.empty());
 	}
 }

--- a/test/unittest/test_build_cache_entry.cpp
+++ b/test/unittest/test_build_cache_entry.cpp
@@ -30,10 +30,9 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
 		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-		if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
-			bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
-			                                               LogicalType {LogicalTypeId::BOOLEAN});
-		}
+		// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN
+		bound_expr =
+		    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
 
 		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
@@ -48,15 +47,32 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
 		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-		if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
-			bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
-			                                               LogicalType {LogicalTypeId::BOOLEAN});
-		}
+		// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN
+		bound_expr =
+		    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
 
 		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
 		REQUIRE(entry != nullptr);
 		REQUIRE(entry->bitvectors.size() == 1); // only row group 0
+	}
+
+	SECTION("odd values pass, even values don't") {
+		auto parsed_exprs = Parser::ParseExpressionList("val % 2 = 1");
+		auto binder = Binder::CreateBinder(context);
+		physical_index_set_t bound_columns;
+		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
+		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+
+		// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN
+		bound_expr =
+		    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
+
+		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
+
+		REQUIRE(entry != nullptr);
+		// Odd values exist in every row group, so all 5 row groups should be present
+		REQUIRE(entry->bitvectors.size() == 5);
 	}
 
 	SECTION("no matching rows") {
@@ -66,10 +82,9 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
 		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-		if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
-			bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
-			                                               LogicalType {LogicalTypeId::BOOLEAN});
-		}
+		// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN
+		bound_expr =
+		    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
 
 		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 

--- a/test/unittest/test_build_cache_entry.cpp
+++ b/test/unittest/test_build_cache_entry.cpp
@@ -1,0 +1,85 @@
+#include "catch/catch.hpp"
+#include "query_condition_cache_functions.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression_binder/check_binder.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	// Create table with enough rows to span multiple row groups
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+
+	auto &context = *con.context;
+	con.BeginTransaction();
+	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, "t");
+
+	SECTION("equality predicate") {
+		auto parsed_exprs = Parser::ParseExpressionList("val = 42");
+		auto binder = Binder::CreateBinder(context);
+		physical_index_set_t bound_columns;
+		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
+		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+
+		if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
+			bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
+			                                               LogicalType {LogicalTypeId::BOOLEAN});
+		}
+
+		idx_t total_qualifying_rows = 0;
+		auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
+
+		REQUIRE(entry != nullptr);
+		REQUIRE(total_qualifying_rows == 5000);
+		REQUIRE(entry->bitvectors.size() == 5); // 5 row groups
+	}
+
+	SECTION("selective predicate") {
+		auto parsed_exprs = Parser::ParseExpressionList("id < 3000");
+		auto binder = Binder::CreateBinder(context);
+		physical_index_set_t bound_columns;
+		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
+		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+
+		if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
+			bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
+			                                               LogicalType {LogicalTypeId::BOOLEAN});
+		}
+
+		idx_t total_qualifying_rows = 0;
+		auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
+
+		REQUIRE(entry != nullptr);
+		REQUIRE(total_qualifying_rows == 3000);
+		REQUIRE(entry->bitvectors.size() == 1); // only row group 0
+	}
+
+	SECTION("no matching rows") {
+		auto parsed_exprs = Parser::ParseExpressionList("id < 0");
+		auto binder = Binder::CreateBinder(context);
+		physical_index_set_t bound_columns;
+		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
+		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+
+		if (bound_expr->return_type.id() != LogicalTypeId::BOOLEAN) {
+			bound_expr = BoundCastExpression::AddCastToType(context, std::move(bound_expr),
+			                                               LogicalType {LogicalTypeId::BOOLEAN});
+		}
+
+		idx_t total_qualifying_rows = 0;
+		auto entry = BuildCacheEntry(context, table_entry, *bound_expr, total_qualifying_rows);
+
+		REQUIRE(entry != nullptr);
+		REQUIRE(total_qualifying_rows == 0);
+		REQUIRE(entry->bitvectors.empty());
+	}
+}

--- a/test/unittest/test_filter.cpp
+++ b/test/unittest/test_filter.cpp
@@ -1,0 +1,50 @@
+#include "catch/catch.hpp"
+#include "query_condition_cache_filter.hpp"
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("CacheExpressionFilter - CheckStatistics", "[query_condition_cache]") {
+	// Build a cache entry with qualifying vectors in row group 0 and 2
+	auto entry = make_shared_ptr<ConditionCacheEntry>();
+	entry->bitvectors[0].SetVector(0);
+	entry->bitvectors[0].SetVector(5);
+	entry->bitvectors[2].SetVector(10);
+
+	// Create a dummy expression for the filter (won't be evaluated in stats check)
+	auto dummy_expr = make_uniq<BoundReferenceExpression>(LogicalType {LogicalTypeId::BIGINT}, 0);
+	CacheExpressionFilter filter(std::move(dummy_expr), entry);
+
+	SECTION("row group with qualifying vectors: no pruning") {
+		// Stats covering row group 0 (row_ids 0..122879)
+		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
+		NumericStats::SetMin(stats, Value::BIGINT(0));
+		NumericStats::SetMax(stats, Value::BIGINT(100));
+		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::NO_PRUNING_POSSIBLE);
+	}
+
+	SECTION("row group without qualifying vectors: always false") {
+		// Stats covering row group 1 (row_ids 122880..245759) - no entry in cache
+		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
+		NumericStats::SetMin(stats, Value::BIGINT(122880));
+		NumericStats::SetMax(stats, Value::BIGINT(200000));
+		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::FILTER_ALWAYS_FALSE);
+	}
+
+	SECTION("row group 2 with qualifying vectors: no pruning") {
+		// Stats covering row group 2 (row_ids 245760..368639)
+		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
+		NumericStats::SetMin(stats, Value::BIGINT(245760));
+		NumericStats::SetMax(stats, Value::BIGINT(300000));
+		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::NO_PRUNING_POSSIBLE);
+	}
+
+	SECTION("stats without min/max: no pruning") {
+		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
+		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::NO_PRUNING_POSSIBLE);
+	}
+}


### PR DESCRIPTION
Closes: https://github.com/dentiny/duckdb-query-condition-cache/issues/11

## Summary

This PR adds automatic query condition cache build and apply via a two-phase optimizer extension. When `use_query_condition_cache` is enabled, the pre-optimize phase captures the full WHERE clause before FilterPushdown, computes a canonical predicate key, and builds the cache inline on miss so the first query benefits immediately. The post-optimize phase injects a `CacheExpressionFilter` on ROW_ID into `LogicalGet.table_filters`, providing row-group pruning via `CheckStatistics` and vector-level filtering via bitvector lookup. Benchmarks are included demonstrating significant speedups for non-pushable predicates (OR, compound LIKE OR) where DuckDB otherwise must decompress all columns for all vectors.

## Example Usage

```sql
-- Enable automatic cache
SET use_query_condition_cache = true;

-- First query: builds cache inline during planning, then executes with cache filter
SELECT sum(length(col1)), sum(length(col2)) FROM events WHERE text_a LIKE '%ERROR%' OR text_b LIKE '%WARN%';

-- Second query: cache hit, skips vectors with no qualifying rows
SELECT sum(length(col1)), sum(length(col2)) FROM events WHERE text_a LIKE '%ERROR%' OR text_b LIKE '%WARN%';

-- Disable when not needed
SET use_query_condition_cache = false;
```