### PR TITLE
Add makefile command to test all DuckDB queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,22 +8,22 @@ EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 
 test_release_all:
-	@echo "Running tests from test/sql..."
-	./build/release/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
 	@echo "Running tests from duckdb/test..."
-	./build/release/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
+	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/enable_query_condition_cache.json ./build/release/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
+	@echo "Running tests from test/sql..."
+	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/enable_query_condition_cache.json ./build/release/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
 
 test_debug_all:
-	@echo "Running tests from test/sql..."
-	./build/debug/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
 	@echo "Running tests from duckdb/test..."
-	./build/debug/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
+	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/enable_query_condition_cache.json ./build/debug/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
+	@echo "Running tests from test/sql..."
+	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/enable_query_condition_cache.json ./build/debug/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
 
 test_reldebug_all:
-	@echo "Running tests from test/sql..."
-	./build/reldebug/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
 	@echo "Running tests from duckdb/test..."
-	./build/reldebug/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
+	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/enable_query_condition_cache.json ./build/reldebug/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
+	@echo "Running tests from test/sql..."
+	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/enable_query_condition_cache.json ./build/reldebug/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
 
 format-all: format
 	find test/unittest -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,18 @@ EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 
+test_release_all:
+	@echo "Running tests from test/sql..."
+	./build/release/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
+	@echo "Running tests from duckdb/test..."
+	./build/release/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
+
+test_debug_all:
+	@echo "Running tests from test/sql..."
+	./build/debug/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
+	@echo "Running tests from duckdb/test..."
+	./build/debug/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
+
 test_reldebug_all:
 	@echo "Running tests from test/sql..."
 	./build/reldebug/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
@@ -18,4 +30,4 @@ format-all: format
 	cmake-format -i CMakeLists.txt
 	cmake-format -i test/unittest/CMakeLists.txt
 
-PHONY: format-all test_reldebug_all
+PHONY: format-all test_release_all test_debug_all test_reldebug_all

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,15 @@ EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 
+test_reldebug_all:
+	@echo "Running tests from test/sql..."
+	./build/reldebug/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
+	@echo "Running tests from duckdb/test..."
+	./build/reldebug/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
+
 format-all: format
 	find test/unittest -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
 	cmake-format -i CMakeLists.txt
 	cmake-format -i test/unittest/CMakeLists.txt
 
-PHONY: format-all
+PHONY: format-all test_reldebug_all

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -25,7 +25,7 @@ void LoadInternal(ExtensionLoader &loader) {
 	auto &config = DBConfig::GetConfig(db_instance);
 	config.AddExtensionOption("enable_query_condition_cache",
 	                          "Enable or disable the query condition cache feature",
-	                          LogicalType::BOOLEAN, Value(true),
+	                          LogicalType {LogicalTypeId::BOOLEAN}, Value(true),
 	                          EnableQueryConditionCacheCallback);
 }
 } // namespace

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -3,13 +3,30 @@
 #include "query_condition_cache_extension.hpp"
 
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/common/exception.hpp"
 #include "query_condition_cache_functions.hpp"
 
 namespace duckdb {
 
 namespace {
+// Callback to verify the setting is being accessed
+// This callback throws an exception to confirm it's being called
+void EnableQueryConditionCacheCallback(ClientContext &context, SetScope scope, Value &parameter) {
+	// Throw an error to verify this callback is being called
+	throw InvalidInputException("enable_query_condition_cache callback was called! Setting value: %s", parameter.ToString());
+}
+
 void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(ConditionCacheBuildFunction());
+	
+	// Register extension settings
+	auto &db_instance = loader.GetDatabaseInstance();
+	auto &config = DBConfig::GetConfig(db_instance);
+	config.AddExtensionOption("enable_query_condition_cache",
+	                          "Enable or disable the query condition cache feature",
+	                          LogicalType::BOOLEAN, Value(true),
+	                          EnableQueryConditionCacheCallback);
 }
 } // namespace
 

--- a/test/configs/disable_query_condition_cache.json
+++ b/test/configs/disable_query_condition_cache.json
@@ -1,5 +1,0 @@
-{
-  "description": "Run tests with enable_query_condition_cache setting disabled",
-  "on_new_connection": "SET enable_query_condition_cache = false;",
-  "skip_compiled": "true"
-}

--- a/test/configs/disable_query_condition_cache.json
+++ b/test/configs/disable_query_condition_cache.json
@@ -1,0 +1,5 @@
+{
+  "description": "Run tests with enable_query_condition_cache setting disabled",
+  "on_new_connection": "SET enable_query_condition_cache = false;",
+  "skip_compiled": "true"
+}

--- a/test/configs/enable_query_condition_cache.json
+++ b/test/configs/enable_query_condition_cache.json
@@ -1,0 +1,10 @@
+{
+  "description": "Run tests with enable_query_condition_cache setting enabled",
+  "statically_loaded_extensions": [
+    "core_functions",
+    "query_condition_cache"
+  ],
+  "on_init": "LOAD query_condition_cache;",
+  "on_new_connection": "SET enable_query_condition_cache = true;",
+  "skip_compiled": "true"
+}

--- a/test/configs/enable_query_condition_cache.json
+++ b/test/configs/enable_query_condition_cache.json
@@ -2,6 +2,8 @@
   "description": "Run tests with enable_query_condition_cache setting enabled",
   "statically_loaded_extensions": [
     "core_functions",
+    "parquet",
+    "httpfs",
     "query_condition_cache"
   ],
   "on_init": "LOAD query_condition_cache;",


### PR DESCRIPTION
Closes https://github.com/dentiny/duckdb-query-condition-cache/issues/14

In this PR, I added a test config with extension loaded to run all DuckDB repo SQL tests.

To make sure the extension does load correctly, callback is made intentionally throwing exception.
Result:
```sh
176/4322] (4%): test/sql/attach/attach_enable_external_access.test             -------------------------------------------------------------------------------
test/sql/attach/attach_enable_external_access.test
-------------------------------------------------------------------------------
/home/vscode/duckdb-query-condition-cache/duckdb/test/sqlite/test_sqllogictest.cpp:207
...............................................................................

/home/vscode/duckdb-query-condition-cache/duckdb/test/sqlite/sqllogic_test_runner.cpp:190: FAILED:
explicitly with message:
  enable_query_condition_cache callback was called! Setting value: true
```
