### PR TITLE
Use object cache LRU cache for predicate cache entries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,9 @@ endif()
 
 include_directories(src/include)
 
-set(EXTENSION_SOURCES src/query_condition_cache_extension.cpp
-                      src/query_condition_cache_functions.cpp
-                      src/query_condition_cache_state.cpp)
+set(EXTENSION_SOURCES
+    src/query_condition_cache_extension.cpp
+    src/query_condition_cache_functions.cpp src/query_condition_cache_state.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -48,8 +48,19 @@ struct CacheKeyHashFunction {
 };
 
 // A single cache entry: the bitvectors for one (table, predicate) combination.
-struct ConditionCacheEntry {
+struct ConditionCacheEntry : public ObjectCacheEntry {
 	unordered_map<idx_t, RowGroupFilter> bitvectors; // rg_idx -> bitvector
+
+	static string ObjectType() {
+		return "query_condition_cache_entry";
+	}
+
+	string GetObjectType() override {
+		return ObjectType();
+	}
+
+	// Return estimated memory usage for LRU eviction
+	optional_idx GetEstimatedCacheMemory() const override;
 };
 
 // Stored in DuckDB's per-database ObjectCache
@@ -70,24 +81,17 @@ public:
 	}
 
 	// Lookup by cache key; returns nullptr if not found
-	shared_ptr<ConditionCacheEntry> Lookup(const CacheKey &key);
+	shared_ptr<ConditionCacheEntry> Lookup(ClientContext &context, const CacheKey &key);
 
 	// Upsert an entry
-	void Upsert(const CacheKey &key, shared_ptr<ConditionCacheEntry> entry);
-
-	// Clear all entries
-	void Clear();
-
-	// Get all entries
-	vector<shared_ptr<ConditionCacheEntry>> GetAll();
+	void Upsert(ClientContext &context, const CacheKey &key, shared_ptr<ConditionCacheEntry> entry);
 
 	// Get or create the store from a client context
 	static shared_ptr<ConditionCacheStore> GetOrCreate(ClientContext &context);
 
 private:
-	mutex cache_lock;
-	// TODO: Consider sharding for scalability
-	unordered_map<CacheKey, shared_ptr<ConditionCacheEntry>, CacheKeyHashFunction> entries;
+	// Generate a unique cache key string from CacheKey
+	static string MakeCacheKeyString(const CacheKey &key);
 };
 
 } // namespace duckdb

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -14,19 +14,18 @@ namespace {
 // This callback throws an exception to confirm it's being called
 void EnableQueryConditionCacheCallback(ClientContext &context, SetScope scope, Value &parameter) {
 	// Throw an error to verify this callback is being called
-	throw InvalidInputException("enable_query_condition_cache callback was called! Setting value: %s", parameter.ToString());
+	throw InvalidInputException("enable_query_condition_cache callback was called! Setting value: %s",
+	                            parameter.ToString());
 }
 
 void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(ConditionCacheBuildFunction());
-	
+
 	// Register extension settings
 	auto &db_instance = loader.GetDatabaseInstance();
 	auto &config = DBConfig::GetConfig(db_instance);
-	config.AddExtensionOption("enable_query_condition_cache",
-	                          "Enable or disable the query condition cache feature",
-	                          LogicalType {LogicalTypeId::BOOLEAN}, Value(true),
-	                          EnableQueryConditionCacheCallback);
+	config.AddExtensionOption("enable_query_condition_cache", "Enable or disable the query condition cache feature",
+	                          LogicalType {LogicalTypeId::BOOLEAN}, Value(true), EnableQueryConditionCacheCallback);
 }
 } // namespace
 

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -239,7 +239,7 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	// TODO: Invalidate cache on table modification (INSERT/DELETE/UPDATE/VACUUM)
 	CacheKey key {bind_data.table_oid, bind_data.predicate_sql};
 	auto store = ConditionCacheStore::GetOrCreate(context);
-	store->Upsert(key, std::move(entry));
+	store->Upsert(context, key, std::move(entry));
 
 	output.SetCardinality(1);
 	output.data[0].SetValue(0, StringUtil::Format("Cache Built: %llu/%llu vectors, %llu/%llu row groups",

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -1,6 +1,8 @@
 #include "query_condition_cache_state.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/storage/object_cache.hpp"
 
 namespace duckdb {
 
@@ -29,43 +31,36 @@ bool RowGroupFilter::IsEmpty() const {
 	return true;
 }
 
-// ------- CONDITION_CACHE_STORE -------
+// ------- CONDITION_CACHE_ENTRY -------
 
-shared_ptr<ConditionCacheEntry> ConditionCacheStore::Lookup(const CacheKey &key) {
-	lock_guard<mutex> guard(cache_lock);
-	auto it = entries.find(key);
-	if (it != entries.end()) {
-		return it->second;
-	}
-	return nullptr;
+optional_idx ConditionCacheEntry::GetEstimatedCacheMemory() const {
+	// Rough estimate: each RowGroupFilter is ~BITVECTOR_ARRAY_SIZE * 8 bytes
+	// Plus overhead for the map structure
+	idx_t estimated_size = sizeof(ConditionCacheEntry);
+	estimated_size += bitvectors.size() * (sizeof(idx_t) + sizeof(RowGroupFilter) + 32); // map overhead
+	return optional_idx(estimated_size);
 }
 
-void ConditionCacheStore::Upsert(const CacheKey &key, shared_ptr<ConditionCacheEntry> entry) {
+// ------- CONDITION_CACHE_STORE -------
+
+string ConditionCacheStore::MakeCacheKeyString(const CacheKey &key) {
+	// Format: "query_condition_cache_entry:{table_oid}:{filter_key}"
+	return StringUtil::Format("query_condition_cache_entry:%llu:%s", key.table_oid, key.filter_key);
+}
+
+shared_ptr<ConditionCacheEntry> ConditionCacheStore::Lookup(ClientContext &context, const CacheKey &key) {
+	auto &cache = ObjectCache::GetObjectCache(context);
+	string cache_key = MakeCacheKeyString(key);
+	return cache.Get<ConditionCacheEntry>(cache_key);
+}
+
+void ConditionCacheStore::Upsert(ClientContext &context, const CacheKey &key, shared_ptr<ConditionCacheEntry> entry) {
 	if (!entry) {
 		throw InvalidInputException("ConditionCacheStore::Upsert: entry must not be null");
 	}
-	lock_guard<mutex> guard(cache_lock);
-	auto result = entries.emplace(key, entry);
-	if (!result.second) {
-		result.first->second = std::move(entry);
-	}
-}
-
-void ConditionCacheStore::Clear() {
-	lock_guard<mutex> guard(cache_lock);
-	entries.clear();
-}
-
-vector<shared_ptr<ConditionCacheEntry>> ConditionCacheStore::GetAll() {
-	vector<shared_ptr<ConditionCacheEntry>> result;
-	{
-		lock_guard<mutex> guard(cache_lock);
-		result.reserve(entries.size());
-		for (const auto &pair : entries) {
-			result.push_back(pair.second);
-		}
-	}
-	return result;
+	auto &cache = ObjectCache::GetObjectCache(context);
+	string cache_key = MakeCacheKeyString(key);
+	cache.Put(cache_key, std::move(entry));
 }
 
 shared_ptr<ConditionCacheStore> ConditionCacheStore::GetOrCreate(ClientContext &context) {

--- a/test/unittest/test_bitvector.cpp
+++ b/test/unittest/test_bitvector.cpp
@@ -4,7 +4,6 @@
 using namespace duckdb;
 
 TEST_CASE("RowGroupFilter - basic operations", "[bitvector]") {
-
 	SECTION("default constructor is empty") {
 		RowGroupFilter bv;
 		REQUIRE(bv.IsEmpty());

--- a/test/unittest/test_cache_store.cpp
+++ b/test/unittest/test_cache_store.cpp
@@ -2,76 +2,59 @@
 #include "query_condition_cache_state.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "test_helpers.hpp"
 
 using namespace duckdb;
 
 TEST_CASE("ConditionCacheStore - basic operations", "[cache_store]") {
-	ConditionCacheStore store;
+	DuckDB db;
+	Connection con(db);
+	auto &context = *con.context;
+	auto store = ConditionCacheStore::GetOrCreate(context);
 
 	SECTION("lookup empty store returns nullptr") {
-		auto result = store.Lookup({1, "nonexistent"});
+		auto result = store->Lookup(context, {1, "nonexistent"});
 		REQUIRE(result == nullptr);
 	}
 
 	SECTION("upsert and lookup by cache key") {
 		auto entry = make_shared_ptr<ConditionCacheEntry>();
-		store.Upsert({1, "col:>5"}, entry);
+		store->Upsert(context, {1, "col:>5"}, entry);
 
-		auto found = store.Lookup({1, "col:>5"});
+		auto found = store->Lookup(context, {1, "col:>5"});
 		REQUIRE(found != nullptr);
 
-		auto not_found = store.Lookup({1, "col:<10"});
+		auto not_found = store->Lookup(context, {1, "col:<10"});
 		REQUIRE(not_found == nullptr);
 
-		auto wrong_oid = store.Lookup({2, "col:>5"});
+		auto wrong_oid = store->Lookup(context, {2, "col:>5"});
 		REQUIRE(wrong_oid == nullptr);
 	}
 
 	SECTION("upsert duplicate key updates entry") {
 		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
-		store.Upsert({1, "col:>5"}, entry1);
+		store->Upsert(context, {1, "col:>5"}, entry1);
 
 		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
-		store.Upsert({1, "col:>5"}, entry2);
+		store->Upsert(context, {1, "col:>5"}, entry2);
 
-		auto found = store.Lookup({1, "col:>5"});
+		auto found = store->Lookup(context, {1, "col:>5"});
 		REQUIRE(found != nullptr);
 		REQUIRE(found == entry2);
 	}
 
 	SECTION("different oid same filter_key are separate entries") {
 		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
-		store.Upsert({1, "col:>5"}, entry1);
+		store->Upsert(context, {1, "col:>5"}, entry1);
 
 		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
-		store.Upsert({2, "col:>5"}, entry2);
+		store->Upsert(context, {2, "col:>5"}, entry2);
 
-		REQUIRE(store.Lookup({1, "col:>5"}) == entry1);
-		REQUIRE(store.Lookup({2, "col:>5"}) == entry2);
-	}
-
-	SECTION("clear removes all entries") {
-		auto entry = make_shared_ptr<ConditionCacheEntry>();
-		store.Upsert({1, "col:>5"}, entry);
-
-		store.Clear();
-
-		REQUIRE(store.Lookup({1, "col:>5"}) == nullptr);
-		REQUIRE(store.GetAll().empty());
-	}
-
-	SECTION("get all returns all entries") {
-		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
-		store.Upsert({1, "col:>5"}, entry1);
-
-		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
-		store.Upsert({2, "col:<10"}, entry2);
-
-		auto all = store.GetAll();
-		REQUIRE(all.size() == 2);
+		REQUIRE(store->Lookup(context, {1, "col:>5"}) == entry1);
+		REQUIRE(store->Lookup(context, {2, "col:>5"}) == entry2);
 	}
 
 	SECTION("upsert null entry throws") {
-		REQUIRE_THROWS_AS(store.Upsert({1, "col:>5"}, nullptr), InvalidInputException);
+		REQUIRE_THROWS_AS(store->Upsert(context, {1, "col:>5"}, nullptr), InvalidInputException);
 	}
 }


### PR DESCRIPTION
Closes: https://github.com/dentiny/duckdb-query-condition-cache/issues/7

This PR integrates predicate cache entries into object cache, which is a DuckDB internal LRU cache.
The benefit for the integration is it's accounted into whole database instance's resource consumption, and is managed by `max_memory` config.
I removed two functions, which are definitely not supported for now; let me know if they're really needed.