### PR TITLE
Add unittest for operators and optimizer for cache invalidation

### DIFF
--- a/test/sql/condition_cache_correctness.test
+++ b/test/sql/condition_cache_correctness.test
@@ -1,0 +1,336 @@
+# name: test/sql/condition_cache_correctness.test
+# description: Verify query results remain correct after DML with condition cache enabled
+# group: [sql]
+
+require query_condition_cache
+
+statement ok
+SET use_query_condition_cache = true;
+
+# ============================================================================
+# TEST 1: UPDATE non-matching -> matching (single row)
+# Cache has bit=0 for the vector containing the updated row.
+# Without invalidation, the vector is skipped and the updated row is lost.
+# ============================================================================
+
+statement ok
+CREATE TABLE t_upd1 AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_upd1 WHERE flag = 1;
+----
+11
+
+statement ok
+UPDATE t_upd1 SET flag = 1 WHERE id = 100000;
+
+query I
+SELECT count(*) FROM t_upd1 WHERE flag = 1;
+----
+12
+
+# ============================================================================
+# TEST 2: Bulk UPDATE across many vectors
+# Updates rows spread across multiple vectors from non-matching to matching.
+# ============================================================================
+
+statement ok
+CREATE TABLE t_upd2 AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_upd2 WHERE flag = 1;
+----
+11
+
+statement ok
+UPDATE t_upd2 SET flag = 1 WHERE id % 2048 = 1000 AND id > 2048;
+
+query I
+SELECT count(*) FROM t_upd2 WHERE flag = 1;
+----
+108
+
+# ============================================================================
+# TEST 3: UPDATE matching -> non-matching (should still be correct)
+# The vector was already bit=1, so scanning it is fine; the updated row
+# just won't match the predicate anymore.
+# ============================================================================
+
+statement ok
+CREATE TABLE t_upd3 AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_upd3 WHERE flag = 1;
+----
+11
+
+statement ok
+UPDATE t_upd3 SET flag = 0 WHERE id = 5;
+
+query I
+SELECT count(*) FROM t_upd3 WHERE flag = 1;
+----
+10
+
+# ============================================================================
+# TEST 4: DELETE should not lose rows that still exist
+# ============================================================================
+
+statement ok
+CREATE TABLE t_del AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_del WHERE flag = 1;
+----
+11
+
+statement ok
+DELETE FROM t_del WHERE id = 5;
+
+query I
+SELECT count(*) FROM t_del WHERE flag = 1;
+----
+10
+
+# ============================================================================
+# TEST 5: INSERT should not hide new matching rows
+# ============================================================================
+
+statement ok
+CREATE TABLE t_ins AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_ins WHERE flag = 1;
+----
+11
+
+statement ok
+INSERT INTO t_ins VALUES (999999, 1);
+
+query I
+SELECT count(*) FROM t_ins WHERE flag = 1;
+----
+12
+
+# ============================================================================
+# TEST 6: Multiple DML operations interleaved with queries
+# Each query must return the correct count reflecting all prior DML.
+# ============================================================================
+
+statement ok
+CREATE TABLE t_multi AS
+  SELECT i AS id,
+         CASE WHEN i % 50000 = 0 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_multi WHERE flag = 1;
+----
+4
+
+statement ok
+UPDATE t_multi SET flag = 1 WHERE id = 75000;
+
+query I
+SELECT count(*) FROM t_multi WHERE flag = 1;
+----
+5
+
+statement ok
+DELETE FROM t_multi WHERE id = 0;
+
+query I
+SELECT count(*) FROM t_multi WHERE flag = 1;
+----
+4
+
+statement ok
+INSERT INTO t_multi VALUES (999999, 1);
+
+query I
+SELECT count(*) FROM t_multi WHERE flag = 1;
+----
+5
+
+statement ok
+UPDATE t_multi SET flag = 0 WHERE id = 75000;
+
+query I
+SELECT count(*) FROM t_multi WHERE flag = 1;
+----
+4
+
+# ============================================================================
+# TEST 7: SUM/actual values (not just count) to catch data correctness
+# ============================================================================
+
+statement ok
+CREATE TABLE t_sum AS
+  SELECT i AS id, i AS val FROM range(200000) t(i);
+
+query I
+SELECT sum(val) FROM t_sum WHERE val < 2048;
+----
+2096128
+
+statement ok
+UPDATE t_sum SET val = 0 WHERE id BETWEEN 100 AND 199;
+
+query I
+SELECT sum(val) FROM t_sum WHERE val < 2048;
+----
+2081178
+
+# ============================================================================
+# TEST 8: MERGE INTO — matched rows updated, unmatched rows inserted
+# Both paths must be reflected in subsequent queries.
+# ============================================================================
+
+statement ok
+CREATE TABLE t_merge_dst AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+# Prime the cache
+query I
+SELECT count(*) FROM t_merge_dst WHERE flag = 1;
+----
+11
+
+statement ok
+CREATE TABLE t_merge_src (id INTEGER, flag INTEGER);
+
+statement ok
+INSERT INTO t_merge_src VALUES (5, 0), (100000, 1), (300000, 1);
+
+statement ok
+MERGE INTO t_merge_dst AS dst
+USING t_merge_src AS src ON dst.id = src.id
+WHEN MATCHED THEN UPDATE SET flag = src.flag
+WHEN NOT MATCHED THEN INSERT VALUES (src.id, src.flag);
+
+# id=5 was flag=1, now updated to flag=0 → -1
+# id=100000 was flag=0, now updated to flag=1 → +1
+# id=300000 inserted with flag=1 → +1
+# 11 - 1 + 1 + 1 = 12
+query I
+SELECT count(*) FROM t_merge_dst WHERE flag = 1;
+----
+12
+
+# ============================================================================
+# TEST 9: TRUNCATE then query — stale cache must not cause wrong results
+# ============================================================================
+
+statement ok
+CREATE TABLE t_trunc AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+# Prime the cache
+query I
+SELECT count(*) FROM t_trunc WHERE flag = 1;
+----
+11
+
+statement ok
+TRUNCATE t_trunc;
+
+query I
+SELECT count(*) FROM t_trunc WHERE flag = 1;
+----
+0
+
+# Re-insert different data — matching row at a different location
+statement ok
+INSERT INTO t_trunc SELECT i AS id, CASE WHEN i = 50000 THEN 1 ELSE 0 END AS flag FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_trunc WHERE flag = 1;
+----
+1
+
+# ============================================================================
+# TEST 10: INSERT into partial tail row group — correctness
+# Cache is built when the last row group is partially filled.
+# New rows inserted into that partial row group must still be found.
+# ============================================================================
+
+statement ok
+CREATE TABLE t_partial AS
+  SELECT i AS id,
+         CASE WHEN i < 10 THEN 1 ELSE 0 END AS flag
+  FROM range(130000) t(i);
+
+# 130000 rows = 1 full RG (122880) + partial RG with 7120 rows
+# Prime the cache — flag=1 only in the first vector of RG0
+query I
+SELECT count(*) FROM t_partial WHERE flag = 1;
+----
+10
+
+# Insert a matching row into the partial tail row group
+statement ok
+INSERT INTO t_partial VALUES (999999, 1);
+
+query I
+SELECT count(*) FROM t_partial WHERE flag = 1;
+----
+11
+
+# Insert enough to create a new row group entirely
+statement ok
+INSERT INTO t_partial SELECT i + 1000000 AS id, CASE WHEN i = 0 THEN 1 ELSE 0 END AS flag FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_partial WHERE flag = 1;
+----
+12
+
+# ============================================================================
+# TEST 11: DROP TABLE and recreate — stale cache must not interfere
+# ============================================================================
+
+statement ok
+CREATE TABLE t_drop AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+# Prime the cache
+query I
+SELECT count(*) FROM t_drop WHERE flag = 1;
+----
+11
+
+statement ok
+DROP TABLE t_drop;
+
+statement ok
+CREATE TABLE t_drop AS
+  SELECT i AS id,
+         CASE WHEN i = 50000 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+# New table, different data — must return correct result
+query I
+SELECT count(*) FROM t_drop WHERE flag = 1;
+----
+1

--- a/test/sql/condition_cache_invalidation.test
+++ b/test/sql/condition_cache_invalidation.test
@@ -107,3 +107,54 @@ query I
 SELECT * FROM condition_cache_info('t2', 'val = 5');
 ----
 0
+
+# ============================================================================
+# TRUNCATE should not crash and stale entries should be harmless
+# ============================================================================
+
+statement ok
+CREATE TABLE t_trunc AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i);
+
+query I
+SELECT status FROM condition_cache_build('t_trunc', 'val = 42');
+----
+Cache Built: 245/245 vectors, 5/5 row groups
+
+query I
+SELECT * FROM condition_cache_info('t_trunc', 'val = 42');
+----
+5
+
+statement ok
+TRUNCATE t_trunc;
+
+# After truncate, cache entry may still exist but queries must still be correct
+# (empty table returns 0 rows regardless of stale cache)
+query I
+SELECT count(*) FROM t_trunc WHERE val = 42;
+----
+0
+
+# ============================================================================
+# DROP TABLE should not crash with active cache entries
+# ============================================================================
+
+statement ok
+CREATE TABLE t_drop AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i);
+
+query I
+SELECT status FROM condition_cache_build('t_drop', 'val = 42');
+----
+Cache Built: 245/245 vectors, 5/5 row groups
+
+statement ok
+DROP TABLE t_drop;
+
+# Recreate table — different OID, stale entries from old OID are orphaned but harmless
+statement ok
+CREATE TABLE t_drop AS SELECT i AS id, i % 10 AS val FROM range(1000) t(i);
+
+query I
+SELECT count(*) FROM t_drop WHERE val = 5;
+----
+100

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -12,7 +12,9 @@ set(QUERY_CACHE_UNITTEST_OBJECTS
     test_cache_invalidation.cpp
     test_cache_store.cpp
     test_filter.cpp
-    test_optimizer_invalidation.cpp)
+    test_optimizer_invalidation.cpp
+    test_logical_cache_invalidator.cpp
+    test_physical_cache_invalidator.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})
 

--- a/test/unittest/include/test_helpers_invalidation.hpp
+++ b/test/unittest/include/test_helpers_invalidation.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "catch/catch.hpp"
+#include "physical_cache_invalidator.hpp"
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/main/connection.hpp"
+
+namespace duckdb {
+
+// Helper: get the OID of a table via the catalog API.
+inline idx_t GetTableOid(Connection &con, const string &table_name) {
+	con.BeginTransaction();
+	auto &context = *con.context;
+	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, table_name);
+	auto oid = table_entry.oid;
+	con.Commit();
+	return oid;
+}
+
+// Helper: get the cache store from a connection's context.
+inline shared_ptr<ConditionCacheStore> GetStore(Connection &con) {
+	return ConditionCacheStore::GetOrCreate(*con.context);
+}
+
+// Helper: look up a cache entry by table OID and predicate.
+inline shared_ptr<ConditionCacheEntry> LookupEntry(Connection &con, idx_t table_oid, const string &predicate) {
+	auto store = GetStore(con);
+	return store->Lookup(*con.context, {table_oid, predicate});
+}
+
+// Helper: build cache for (table_name, predicate) via the SQL table function.
+inline void BuildCache(Connection &con, const string &table_name, const string &predicate) {
+	auto result = con.Query("SELECT * FROM condition_cache_build('" + table_name + "', '" + predicate + "')");
+	REQUIRE(result->GetError() == "");
+}
+
+// Helper: find a PhysicalCacheInvalidator in a physical plan tree.
+inline PhysicalCacheInvalidator *FindInvalidator(PhysicalOperator &op) {
+	if (op.type == PhysicalOperatorType::EXTENSION && op.GetName() == "CACHE_INVALIDATOR") {
+		return &op.Cast<PhysicalCacheInvalidator>();
+	}
+	for (auto &child : op.children) {
+		auto *result = FindInvalidator(child.get());
+		if (result) {
+			return result;
+		}
+	}
+	return nullptr;
+}
+
+} // namespace duckdb

--- a/test/unittest/test_logical_cache_invalidator.cpp
+++ b/test/unittest/test_logical_cache_invalidator.cpp
@@ -1,0 +1,53 @@
+#include "catch/catch.hpp"
+#include "logical_cache_invalidator.hpp"
+
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+
+namespace duckdb {
+
+TEST_CASE("LogicalCacheInvalidator - ROW_ID mode constructor", "[logical_invalidator]") {
+	auto row_id_expr = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 3);
+	LogicalCacheInvalidator op(42, std::move(row_id_expr));
+
+	REQUIRE(op.table_oid == 42);
+	REQUIRE(op.mode == CacheInvalidatorMode::ROW_ID);
+	REQUIRE(op.row_id_column_index == 0);
+	REQUIRE(op.pre_insert_row_count == 0);
+	REQUIRE(op.expressions.size() == 1);
+
+	auto &ref = op.expressions[0]->Cast<BoundReferenceExpression>();
+	REQUIRE(ref.index == 3);
+	REQUIRE(ref.return_type == LogicalType::BIGINT);
+}
+
+TEST_CASE("LogicalCacheInvalidator - INSERT mode constructor", "[logical_invalidator]") {
+	LogicalCacheInvalidator op(100, static_cast<idx_t>(50000));
+
+	REQUIRE(op.table_oid == 100);
+	REQUIRE(op.mode == CacheInvalidatorMode::INSERT);
+	REQUIRE(op.row_id_column_index == 0);
+	REQUIRE(op.pre_insert_row_count == 50000);
+	REQUIRE(op.expressions.empty());
+}
+
+TEST_CASE("LogicalCacheInvalidator - MERGE mode constructor", "[logical_invalidator]") {
+	LogicalCacheInvalidator op(200, static_cast<idx_t>(5), static_cast<idx_t>(10000));
+
+	REQUIRE(op.table_oid == 200);
+	REQUIRE(op.mode == CacheInvalidatorMode::MERGE);
+	REQUIRE(op.row_id_column_index == 5);
+	REQUIRE(op.pre_insert_row_count == 10000);
+	REQUIRE(op.expressions.empty());
+}
+
+TEST_CASE("LogicalCacheInvalidator - GetExtensionName", "[logical_invalidator]") {
+	LogicalCacheInvalidator op(1, static_cast<idx_t>(0));
+	REQUIRE(op.GetExtensionName() == "query_condition_cache");
+}
+
+TEST_CASE("CacheInvalidatorOperatorExtension - GetName", "[logical_invalidator]") {
+	CacheInvalidatorOperatorExtension ext;
+	REQUIRE(ext.GetName() == "query_condition_cache");
+}
+
+} // namespace duckdb

--- a/test/unittest/test_optimizer_invalidation.cpp
+++ b/test/unittest/test_optimizer_invalidation.cpp
@@ -1,6 +1,7 @@
 #include "catch/catch.hpp"
-#include "test_helpers_invalidation.hpp"
+#include "physical_cache_invalidator.hpp"
 #include "query_condition_cache_extension.hpp"
+#include "test_helpers_invalidation.hpp"
 
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/prepared_statement.hpp"
@@ -407,8 +408,7 @@ TEST_CASE("Optimizer invalidation - no invalidator for SELECT", "[invalidation][
 	REQUIRE_FALSE(invalidator);
 }
 
-TEST_CASE("Optimizer invalidation - injects MERGE invalidator for INSERT ON CONFLICT",
-          "[invalidation][optimizer]") {
+TEST_CASE("Optimizer invalidation - injects MERGE invalidator for INSERT ON CONFLICT", "[invalidation][optimizer]") {
 	DuckDB db(nullptr);
 	db.LoadStaticExtension<QueryConditionCacheExtension>();
 	Connection con(db);
@@ -421,7 +421,9 @@ TEST_CASE("Optimizer invalidation - injects MERGE invalidator for INSERT ON CONF
 	REQUIRE_FALSE(prepared->HasError());
 	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
 	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::MERGE);
 	REQUIRE(invalidator->table_oid == table_oid);
+	REQUIRE(invalidator->pre_insert_row_count == 1);
 }
 
 TEST_CASE("Optimizer invalidation - injects MERGE invalidator for MERGE", "[invalidation][optimizer]") {

--- a/test/unittest/test_optimizer_invalidation.cpp
+++ b/test/unittest/test_optimizer_invalidation.cpp
@@ -1,44 +1,12 @@
 #include "catch/catch.hpp"
-#include "physical_cache_invalidator.hpp"
+#include "test_helpers_invalidation.hpp"
 #include "query_condition_cache_extension.hpp"
-#include "query_condition_cache_state.hpp"
 
-#include "duckdb/catalog/catalog.hpp"
-#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
-#include "duckdb/execution/physical_plan_generator.hpp"
-#include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/prepared_statement.hpp"
 #include "duckdb/main/prepared_statement_data.hpp"
 
 namespace duckdb {
-
-// Helper: build cache for (table_name, predicate) via the SQL table function.
-static void BuildCache(Connection &con, const string &table_name, const string &predicate) {
-	auto result = con.Query("SELECT * FROM condition_cache_build('" + table_name + "', '" + predicate + "')");
-	REQUIRE(result->GetError() == "");
-}
-
-// Helper: get the cache store from a connection's context.
-static shared_ptr<ConditionCacheStore> GetStore(Connection &con) {
-	return ConditionCacheStore::GetOrCreate(*con.context);
-}
-
-// Helper: look up a cache entry by table OID and predicate.
-static shared_ptr<ConditionCacheEntry> LookupEntry(Connection &con, idx_t table_oid, const string &predicate) {
-	auto store = GetStore(con);
-	return store->Lookup(*con.context, {table_oid, predicate});
-}
-
-// Helper: get the OID of a table via the catalog API.
-static idx_t GetTableOid(Connection &con, const string &table_name) {
-	con.BeginTransaction();
-	auto &context = *con.context;
-	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, table_name);
-	auto oid = table_entry.oid;
-	con.Commit();
-	return oid;
-}
 
 TEST_CASE("Optimizer invalidation - DELETE removes affected row groups from cache", "[invalidation][optimizer]") {
 	DuckDB db(nullptr);
@@ -376,19 +344,6 @@ TEST_CASE("Optimizer invalidation - INSERT into partial tail row group", "[inval
 }
 
 // --- Plan injection tests (verify optimizer injects PhysicalCacheInvalidator with correct fields) ---
-
-static PhysicalCacheInvalidator *FindInvalidator(PhysicalOperator &op) {
-	if (op.type == PhysicalOperatorType::EXTENSION && op.GetName() == "CACHE_INVALIDATOR") {
-		return &op.Cast<PhysicalCacheInvalidator>();
-	}
-	for (auto &child : op.children) {
-		auto *result = FindInvalidator(child.get());
-		if (result) {
-			return result;
-		}
-	}
-	return nullptr;
-}
 
 TEST_CASE("Optimizer invalidation - injects ROW_ID invalidator for DELETE", "[invalidation][optimizer]") {
 	DuckDB db(nullptr);

--- a/test/unittest/test_optimizer_invalidation.cpp
+++ b/test/unittest/test_optimizer_invalidation.cpp
@@ -1,11 +1,15 @@
 #include "catch/catch.hpp"
+#include "physical_cache_invalidator.hpp"
 #include "query_condition_cache_extension.hpp"
 #include "query_condition_cache_state.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/prepared_statement.hpp"
+#include "duckdb/main/prepared_statement_data.hpp"
 
 namespace duckdb {
 
@@ -250,6 +254,257 @@ TEST_CASE("Optimizer invalidation - DELETE across multiple row groups", "[invali
 	REQUIRE(after->bitvectors.count(2) == 0);
 	REQUIRE(after->bitvectors.count(3) == 1);
 	REQUIRE(after->bitvectors.count(4) == 1);
+}
+
+TEST_CASE("Optimizer invalidation - MERGE invalidates matched and inserted row groups", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	// Create target table spanning multiple row groups
+	con.Query("CREATE TABLE dst AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+	auto table_oid = GetTableOid(con, "dst");
+
+	BuildCache(con, "dst", "val = 42");
+	auto entry = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->bitvectors.size() == 5);
+
+	// Create source table with:
+	// - id=200 matches an existing row in RG0 (update path)
+	// - id=600000 does not exist (insert path, appended after last RG)
+	con.Query("CREATE TABLE src (id INTEGER, val INTEGER)");
+	con.Query("INSERT INTO src VALUES (200, 999), (600000, 42)");
+
+	auto merge_result = con.Query("MERGE INTO dst USING src ON dst.id = src.id "
+	                              "WHEN MATCHED THEN UPDATE SET val = src.val "
+	                              "WHEN NOT MATCHED THEN INSERT VALUES (src.id, src.val)");
+	REQUIRE_FALSE(merge_result->HasError());
+
+	// RG0 should be invalidated (matched update of id=200)
+	// Last RG (RG4) should be invalidated (insert of id=600000 appended there)
+	auto after = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(after != nullptr);
+	// RG0 and RG4 invalidated, RGs 1-3 remain
+	REQUIRE(after->bitvectors.count(0) == 0);
+	REQUIRE(after->bitvectors.count(1) == 1);
+	REQUIRE(after->bitvectors.count(2) == 1);
+	REQUIRE(after->bitvectors.count(3) == 1);
+	REQUIRE(after->bitvectors.count(4) == 0);
+}
+
+TEST_CASE("Optimizer invalidation - TRUNCATE does not crash with stale cache", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	BuildCache(con, "t", "val = 42");
+	auto entry = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->bitvectors.size() == 5);
+
+	// TRUNCATE removes all rows — stale cache entries remain but are harmless
+	auto trunc_result = con.Query("TRUNCATE t");
+	REQUIRE_FALSE(trunc_result->HasError());
+
+	// Query on empty table should return 0 rows regardless of stale cache
+	auto count_result = con.Query("SELECT count(*) FROM t WHERE val = 42");
+	REQUIRE_FALSE(count_result->HasError());
+	auto chunk = count_result->Fetch();
+	REQUIRE(chunk->GetValue(0, 0).GetValue<int64_t>() == 0);
+}
+
+TEST_CASE("Optimizer invalidation - DROP TABLE does not crash with stale cache", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	BuildCache(con, "t", "val = 42");
+	auto entry = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(entry != nullptr);
+
+	// DROP TABLE — stale cache entries become orphaned
+	auto drop_result = con.Query("DROP TABLE t");
+	REQUIRE_FALSE(drop_result->HasError());
+
+	// Recreate table (gets new OID) and query — must work correctly
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 10 AS val FROM range(1000) t(i)");
+
+	auto count_result = con.Query("SELECT count(*) FROM t WHERE val = 5");
+	REQUIRE_FALSE(count_result->HasError());
+	auto chunk = count_result->Fetch();
+	REQUIRE(chunk->GetValue(0, 0).GetValue<int64_t>() == 100);
+}
+
+TEST_CASE("Optimizer invalidation - INSERT into partial tail row group", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	// 130000 rows = 1 full RG (122880) + partial RG with 7120 rows
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(130000) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	BuildCache(con, "t", "val = 42");
+	auto entry = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->bitvectors.size() == 2); // RG0 (full) + RG1 (partial)
+
+	// INSERT a single row — goes into the partial tail RG (RG1)
+	auto ins_result = con.Query("INSERT INTO t VALUES (999999, 42)");
+	REQUIRE_FALSE(ins_result->HasError());
+
+	// RG1 (partial tail) should be invalidated, RG0 preserved
+	auto after = LookupEntry(con, table_oid, "val = 42");
+	REQUIRE(after != nullptr);
+	REQUIRE(after->bitvectors.size() == 1);
+	REQUIRE(after->bitvectors.count(0) == 1);
+	REQUIRE(after->bitvectors.count(1) == 0);
+
+	// Query must still return correct results including the new row
+	auto count_result = con.Query("SELECT count(*) FROM t WHERE val = 42");
+	REQUIRE_FALSE(count_result->HasError());
+	auto chunk = count_result->Fetch();
+	// 130000 / 100 = 1300 rows with val=42, plus 1 inserted
+	REQUIRE(chunk->GetValue(0, 0).GetValue<int64_t>() == 1301);
+}
+
+// --- Plan injection tests (verify optimizer injects PhysicalCacheInvalidator with correct fields) ---
+
+static PhysicalCacheInvalidator *FindInvalidator(PhysicalOperator &op) {
+	if (op.type == PhysicalOperatorType::EXTENSION && op.GetName() == "CACHE_INVALIDATOR") {
+		return &op.Cast<PhysicalCacheInvalidator>();
+	}
+	for (auto &child : op.children) {
+		auto *result = FindInvalidator(child.get());
+		if (result) {
+			return result;
+		}
+	}
+	return nullptr;
+}
+
+TEST_CASE("Optimizer invalidation - injects ROW_ID invalidator for DELETE", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id FROM range(100) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	auto prepared = con.Prepare("DELETE FROM t WHERE id < 10");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::ROW_ID);
+	REQUIRE(invalidator->table_oid == table_oid);
+}
+
+TEST_CASE("Optimizer invalidation - injects ROW_ID invalidator for UPDATE", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id, i AS val FROM range(100) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	auto prepared = con.Prepare("UPDATE t SET val = 999 WHERE id = 5");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::ROW_ID);
+	REQUIRE(invalidator->table_oid == table_oid);
+}
+
+TEST_CASE("Optimizer invalidation - injects INSERT invalidator for INSERT", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t (id INTEGER, val INTEGER)");
+	auto table_oid = GetTableOid(con, "t");
+
+	auto prepared = con.Prepare("INSERT INTO t VALUES (1, 2)");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::INSERT);
+	REQUIRE(invalidator->table_oid == table_oid);
+	REQUIRE(invalidator->pre_insert_row_count == 0);
+}
+
+TEST_CASE("Optimizer invalidation - no invalidator for SELECT", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id FROM range(100) t(i)");
+
+	auto prepared = con.Prepare("SELECT * FROM t WHERE id < 10");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE_FALSE(invalidator);
+}
+
+TEST_CASE("Optimizer invalidation - injects MERGE invalidator for INSERT ON CONFLICT",
+          "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t (id INTEGER PRIMARY KEY, val INTEGER)");
+	con.Query("INSERT INTO t VALUES (1, 10)");
+	auto table_oid = GetTableOid(con, "t");
+
+	auto prepared = con.Prepare("INSERT INTO t VALUES (1, 20) ON CONFLICT (id) DO UPDATE SET val = 20");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->table_oid == table_oid);
+}
+
+TEST_CASE("Optimizer invalidation - injects MERGE invalidator for MERGE", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE dst AS SELECT i AS id, i AS val FROM range(100) t(i)");
+	con.Query("CREATE TABLE src AS SELECT i AS id, i * 10 AS val FROM range(50, 150) t(i)");
+	auto table_oid = GetTableOid(con, "dst");
+
+	auto prepared = con.Prepare("MERGE INTO dst USING src ON dst.id = src.id "
+	                            "WHEN MATCHED THEN UPDATE SET val = src.val "
+	                            "WHEN NOT MATCHED THEN INSERT VALUES (src.id, src.val)");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::MERGE);
+	REQUIRE(invalidator->table_oid == table_oid);
+	REQUIRE(invalidator->pre_insert_row_count == 100);
+}
+
+TEST_CASE("Optimizer invalidation - injects INSERT invalidator for INSERT SELECT", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE src AS SELECT i AS id FROM range(100) t(i)");
+	con.Query("CREATE TABLE dst (id INTEGER)");
+	auto table_oid = GetTableOid(con, "dst");
+
+	auto prepared = con.Prepare("INSERT INTO dst SELECT * FROM src WHERE id < 50");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::INSERT);
+	REQUIRE(invalidator->table_oid == table_oid);
+	REQUIRE(invalidator->pre_insert_row_count == 0);
 }
 
 TEST_CASE("Optimizer invalidation - DML on empty cache is no-op", "[invalidation][optimizer]") {

--- a/test/unittest/test_physical_cache_invalidator.cpp
+++ b/test/unittest/test_physical_cache_invalidator.cpp
@@ -1,129 +1,12 @@
 #include "catch/catch.hpp"
-#include "physical_cache_invalidator.hpp"
+#include "test_helpers_invalidation.hpp"
 #include "query_condition_cache_extension.hpp"
-#include "query_condition_cache_state.hpp"
 
-#include "duckdb/catalog/catalog.hpp"
-#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
-#include "duckdb/execution/physical_plan_generator.hpp"
-#include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/prepared_statement.hpp"
 #include "duckdb/main/prepared_statement_data.hpp"
 
 namespace duckdb {
-
-static PhysicalCacheInvalidator *FindInvalidator(PhysicalOperator &op) {
-	if (op.type == PhysicalOperatorType::EXTENSION && op.GetName() == "CACHE_INVALIDATOR") {
-		return &op.Cast<PhysicalCacheInvalidator>();
-	}
-	for (auto &child : op.children) {
-		auto *result = FindInvalidator(child.get());
-		if (result) {
-			return result;
-		}
-	}
-	return nullptr;
-}
-
-static idx_t GetTableOid(Connection &con, const string &table_name) {
-	con.BeginTransaction();
-	auto &context = *con.context;
-	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, table_name);
-	auto oid = table_entry.oid;
-	con.Commit();
-	return oid;
-}
-
-TEST_CASE("PhysicalCacheInvalidator - DELETE has ROW_ID mode with correct fields", "[physical_invalidator]") {
-	DuckDB db(nullptr);
-	db.LoadStaticExtension<QueryConditionCacheExtension>();
-	Connection con(db);
-
-	con.Query("CREATE TABLE t AS SELECT i AS id FROM range(100) t(i)");
-	auto table_oid = GetTableOid(con, "t");
-
-	auto prepared = con.Prepare("DELETE FROM t WHERE id < 10");
-	REQUIRE_FALSE(prepared->HasError());
-	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
-	REQUIRE(invalidator);
-	REQUIRE(invalidator->mode == CacheInvalidatorMode::ROW_ID);
-	REQUIRE(invalidator->table_oid == table_oid);
-	REQUIRE(invalidator->pre_insert_row_count == 0);
-}
-
-TEST_CASE("PhysicalCacheInvalidator - UPDATE has ROW_ID mode with correct fields", "[physical_invalidator]") {
-	DuckDB db(nullptr);
-	db.LoadStaticExtension<QueryConditionCacheExtension>();
-	Connection con(db);
-
-	con.Query("CREATE TABLE t AS SELECT i AS id, i AS val FROM range(100) t(i)");
-	auto table_oid = GetTableOid(con, "t");
-
-	auto prepared = con.Prepare("UPDATE t SET val = 999 WHERE id = 5");
-	REQUIRE_FALSE(prepared->HasError());
-	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
-	REQUIRE(invalidator);
-	REQUIRE(invalidator->mode == CacheInvalidatorMode::ROW_ID);
-	REQUIRE(invalidator->table_oid == table_oid);
-	REQUIRE(invalidator->pre_insert_row_count == 0);
-}
-
-TEST_CASE("PhysicalCacheInvalidator - INSERT has INSERT mode with correct pre_insert_row_count",
-          "[physical_invalidator]") {
-	DuckDB db(nullptr);
-	db.LoadStaticExtension<QueryConditionCacheExtension>();
-	Connection con(db);
-
-	con.Query("CREATE TABLE t AS SELECT i AS id FROM range(100) t(i)");
-	auto table_oid = GetTableOid(con, "t");
-
-	auto prepared = con.Prepare("INSERT INTO t VALUES (999)");
-	REQUIRE_FALSE(prepared->HasError());
-	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
-	REQUIRE(invalidator);
-	REQUIRE(invalidator->mode == CacheInvalidatorMode::INSERT);
-	REQUIRE(invalidator->table_oid == table_oid);
-	REQUIRE(invalidator->pre_insert_row_count == 100);
-}
-
-TEST_CASE("PhysicalCacheInvalidator - INSERT into empty table has zero pre_insert_row_count",
-          "[physical_invalidator]") {
-	DuckDB db(nullptr);
-	db.LoadStaticExtension<QueryConditionCacheExtension>();
-	Connection con(db);
-
-	con.Query("CREATE TABLE t (id INTEGER)");
-	auto table_oid = GetTableOid(con, "t");
-
-	auto prepared = con.Prepare("INSERT INTO t VALUES (1)");
-	REQUIRE_FALSE(prepared->HasError());
-	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
-	REQUIRE(invalidator);
-	REQUIRE(invalidator->mode == CacheInvalidatorMode::INSERT);
-	REQUIRE(invalidator->table_oid == table_oid);
-	REQUIRE(invalidator->pre_insert_row_count == 0);
-}
-
-TEST_CASE("PhysicalCacheInvalidator - MERGE has MERGE mode with correct fields", "[physical_invalidator]") {
-	DuckDB db(nullptr);
-	db.LoadStaticExtension<QueryConditionCacheExtension>();
-	Connection con(db);
-
-	con.Query("CREATE TABLE dst AS SELECT i AS id, i AS val FROM range(100) t(i)");
-	con.Query("CREATE TABLE src AS SELECT i AS id, i * 10 AS val FROM range(50, 150) t(i)");
-	auto table_oid = GetTableOid(con, "dst");
-
-	auto prepared = con.Prepare("MERGE INTO dst USING src ON dst.id = src.id "
-	                            "WHEN MATCHED THEN UPDATE SET val = src.val "
-	                            "WHEN NOT MATCHED THEN INSERT VALUES (src.id, src.val)");
-	REQUIRE_FALSE(prepared->HasError());
-	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
-	REQUIRE(invalidator);
-	REQUIRE(invalidator->mode == CacheInvalidatorMode::MERGE);
-	REQUIRE(invalidator->table_oid == table_oid);
-	REQUIRE(invalidator->pre_insert_row_count == 100);
-}
 
 TEST_CASE("PhysicalCacheInvalidator - GetName returns CACHE_INVALIDATOR", "[physical_invalidator]") {
 	DuckDB db(nullptr);
@@ -194,19 +77,17 @@ TEST_CASE("PhysicalCacheInvalidator - parallel execution preserves correctness",
 
 	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
 
-	auto build_result = con.Query("SELECT * FROM condition_cache_build('t', 'val = 42')");
-	REQUIRE_FALSE(build_result->HasError());
+	BuildCache(con, "t", "val = 42");
 
 	auto table_oid = GetTableOid(con, "t");
-	auto store = ConditionCacheStore::GetOrCreate(*con.context);
-	auto entry = store->Lookup(*con.context, {table_oid, "val = 42"});
+	auto entry = LookupEntry(con, table_oid, "val = 42");
 	REQUIRE(entry != nullptr);
 	REQUIRE(entry->bitvectors.size() == 5);
 
 	auto del_result = con.Query("DELETE FROM t WHERE val = 42");
 	REQUIRE_FALSE(del_result->HasError());
 
-	auto after = store->Lookup(*con.context, {table_oid, "val = 42"});
+	auto after = LookupEntry(con, table_oid, "val = 42");
 	REQUIRE(after == nullptr);
 }
 

--- a/test/unittest/test_physical_cache_invalidator.cpp
+++ b/test/unittest/test_physical_cache_invalidator.cpp
@@ -1,0 +1,213 @@
+#include "catch/catch.hpp"
+#include "physical_cache_invalidator.hpp"
+#include "query_condition_cache_extension.hpp"
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/prepared_statement.hpp"
+#include "duckdb/main/prepared_statement_data.hpp"
+
+namespace duckdb {
+
+static PhysicalCacheInvalidator *FindInvalidator(PhysicalOperator &op) {
+	if (op.type == PhysicalOperatorType::EXTENSION && op.GetName() == "CACHE_INVALIDATOR") {
+		return &op.Cast<PhysicalCacheInvalidator>();
+	}
+	for (auto &child : op.children) {
+		auto *result = FindInvalidator(child.get());
+		if (result) {
+			return result;
+		}
+	}
+	return nullptr;
+}
+
+static idx_t GetTableOid(Connection &con, const string &table_name) {
+	con.BeginTransaction();
+	auto &context = *con.context;
+	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, table_name);
+	auto oid = table_entry.oid;
+	con.Commit();
+	return oid;
+}
+
+TEST_CASE("PhysicalCacheInvalidator - DELETE has ROW_ID mode with correct fields", "[physical_invalidator]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id FROM range(100) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	auto prepared = con.Prepare("DELETE FROM t WHERE id < 10");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::ROW_ID);
+	REQUIRE(invalidator->table_oid == table_oid);
+	REQUIRE(invalidator->pre_insert_row_count == 0);
+}
+
+TEST_CASE("PhysicalCacheInvalidator - UPDATE has ROW_ID mode with correct fields", "[physical_invalidator]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id, i AS val FROM range(100) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	auto prepared = con.Prepare("UPDATE t SET val = 999 WHERE id = 5");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::ROW_ID);
+	REQUIRE(invalidator->table_oid == table_oid);
+	REQUIRE(invalidator->pre_insert_row_count == 0);
+}
+
+TEST_CASE("PhysicalCacheInvalidator - INSERT has INSERT mode with correct pre_insert_row_count",
+          "[physical_invalidator]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id FROM range(100) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	auto prepared = con.Prepare("INSERT INTO t VALUES (999)");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::INSERT);
+	REQUIRE(invalidator->table_oid == table_oid);
+	REQUIRE(invalidator->pre_insert_row_count == 100);
+}
+
+TEST_CASE("PhysicalCacheInvalidator - INSERT into empty table has zero pre_insert_row_count",
+          "[physical_invalidator]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t (id INTEGER)");
+	auto table_oid = GetTableOid(con, "t");
+
+	auto prepared = con.Prepare("INSERT INTO t VALUES (1)");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::INSERT);
+	REQUIRE(invalidator->table_oid == table_oid);
+	REQUIRE(invalidator->pre_insert_row_count == 0);
+}
+
+TEST_CASE("PhysicalCacheInvalidator - MERGE has MERGE mode with correct fields", "[physical_invalidator]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE dst AS SELECT i AS id, i AS val FROM range(100) t(i)");
+	con.Query("CREATE TABLE src AS SELECT i AS id, i * 10 AS val FROM range(50, 150) t(i)");
+	auto table_oid = GetTableOid(con, "dst");
+
+	auto prepared = con.Prepare("MERGE INTO dst USING src ON dst.id = src.id "
+	                            "WHEN MATCHED THEN UPDATE SET val = src.val "
+	                            "WHEN NOT MATCHED THEN INSERT VALUES (src.id, src.val)");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::MERGE);
+	REQUIRE(invalidator->table_oid == table_oid);
+	REQUIRE(invalidator->pre_insert_row_count == 100);
+}
+
+TEST_CASE("PhysicalCacheInvalidator - GetName returns CACHE_INVALIDATOR", "[physical_invalidator]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id FROM range(100) t(i)");
+
+	auto prepared = con.Prepare("DELETE FROM t WHERE id < 10");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->GetName() == "CACHE_INVALIDATOR");
+}
+
+TEST_CASE("PhysicalCacheInvalidator - ParamsToString contains mode and table OID", "[physical_invalidator]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id FROM range(100) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	auto prepared = con.Prepare("DELETE FROM t WHERE id < 10");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	auto params = invalidator->ParamsToString();
+	REQUIRE(params["Table OID"] == to_string(table_oid));
+	REQUIRE(params["Mode"] == "ROW_ID");
+}
+
+TEST_CASE("PhysicalCacheInvalidator - ParallelOperator returns true", "[physical_invalidator]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id FROM range(100) t(i)");
+
+	auto prepared = con.Prepare("DELETE FROM t WHERE id < 10");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->ParallelOperator());
+	REQUIRE(invalidator->RequiresOperatorFinalize());
+}
+
+TEST_CASE("PhysicalCacheInvalidator - passthrough preserves data", "[physical_invalidator]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id FROM range(100) t(i)");
+
+	auto del_result = con.Query("DELETE FROM t WHERE id < 50");
+	REQUIRE_FALSE(del_result->HasError());
+
+	auto count_result = con.Query("SELECT count(*) FROM t");
+	REQUIRE_FALSE(count_result->HasError());
+	auto chunk = count_result->Fetch();
+	REQUIRE(chunk->GetValue(0, 0).GetValue<int64_t>() == 50);
+}
+
+TEST_CASE("PhysicalCacheInvalidator - parallel execution preserves correctness", "[physical_invalidator]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+
+	auto build_result = con.Query("SELECT * FROM condition_cache_build('t', 'val = 42')");
+	REQUIRE_FALSE(build_result->HasError());
+
+	auto table_oid = GetTableOid(con, "t");
+	auto store = ConditionCacheStore::GetOrCreate(*con.context);
+	auto entry = store->Lookup(*con.context, {table_oid, "val = 42"});
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->bitvectors.size() == 5);
+
+	auto del_result = con.Query("DELETE FROM t WHERE val = 42");
+	REQUIRE_FALSE(del_result->HasError());
+
+	auto after = store->Lookup(*con.context, {table_oid, "val = 42"});
+	REQUIRE(after == nullptr);
+}
+
+} // namespace duckdb


### PR DESCRIPTION
This pull request introduces comprehensive correctness and invalidation tests for the query condition cache feature, including expanded coverage for DML operations, edge cases, and optimizer behavior. The changes primarily add new test files and extend existing tests to ensure the cache remains correct and is properly invalidated across various SQL operations. Additionally, new unit tests are added for logical and physical cache invalidators, and the test build configuration is updated to include these new tests.

**Expanded SQL cache correctness and invalidation tests:**

* Added a new file `test/sql/condition_cache_correctness.test` with detailed scenarios covering UPDATE, DELETE, INSERT, MERGE, TRUNCATE, and DROP TABLE operations to verify that query results remain correct with the condition cache enabled.
* Extended `test/sql/condition_cache_invalidation.test` to include TRUNCATE and DROP TABLE cases, ensuring that stale cache entries do not cause crashes or incorrect results after these operations.

**Unit test additions for cache invalidators:**

* Added `test/unittest/test_logical_cache_invalidator.cpp` with tests for the construction and behavior of `LogicalCacheInvalidator`, including all supported modes and extension name checks.
* Updated `test/unittest/CMakeLists.txt` to include the new logical and physical cache invalidator unit test files in the build.

**Optimizer invalidation and plan injection tests:**

* Significantly expanded `test/unittest/test_optimizer_invalidation.cpp` with new tests for optimizer invalidation logic, covering MERGE, TRUNCATE, DROP TABLE, and partial row group INSERT scenarios. Also added plan injection tests to verify that the optimizer correctly injects physical cache invalidators for various DML statements.
* Included necessary header files for physical cache invalidator and plan generation in `test_optimizer_invalidation.cpp` to support the new tests.