### PR TITLE
Add caching for TPC-H data and command line regeneration option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ test/python/__pycache__/
 .Rhistory
 .vscode
 .claude
+.tmp/
+benchmark/tpch_sf*.duckdb*
+benchmark/clickbench.duckdb*

--- a/benchmark/run_tpch_benchmark.py
+++ b/benchmark/run_tpch_benchmark.py
@@ -105,7 +105,34 @@ def get_duckdb_connection(sf: int, args=None):
         cfg["threads"] = args.threads
     if args and args.memory_limit:
         cfg["memory_limit"] = args.memory_limit
-    con = duckdb.connect(config=cfg)
+
+    # Cache TPC-H data on disk to avoid regenerating it each run
+    db_path = WORKSPACE / "benchmark" / f"tpch_sf{sf}.duckdb"
+    regenerate = args.regenerate if args else False
+    if regenerate and db_path.exists():
+        db_path.unlink()
+        # Also remove WAL file if present
+        wal = db_path.with_suffix(".duckdb.wal")
+        if wal.exists():
+            wal.unlink()
+    needs_generate = not db_path.exists()
+
+    if needs_generate:
+        print(f"Generating TPC-H data (SF={sf}) into {db_path}...", flush=True)
+        gen_con = duckdb.connect(str(db_path), config={"allow_unsigned_extensions": True})
+        # Load extension in generator connection so tpch extension is available
+        if EXT_PATH.exists():
+            gen_con.execute(f"LOAD '{EXT_PATH}';")
+        else:
+            gen_con.execute("LOAD query_condition_cache;")
+        gen_con.execute("CALL dbgen(sf=%d);" % sf)
+        gen_con.execute("CHECKPOINT;")
+        gen_con.close()
+        print("Data generated and cached on disk.", flush=True)
+    else:
+        print(f"Reusing cached TPC-H data (SF={sf}) from {db_path}", flush=True)
+
+    con = duckdb.connect(str(db_path), config=cfg)
 
     # Load the locally-built extension if available, otherwise fall back to installed
     if EXT_PATH.exists():
@@ -115,10 +142,6 @@ def get_duckdb_connection(sf: int, args=None):
         print("Attempting to LOAD from installed extensions...")
         con.execute("LOAD query_condition_cache;")
 
-    # Generate TPC-H data (tpch extension is linked into the build)
-    print(f"Generating TPC-H data (SF={sf})...", flush=True)
-    con.execute("CALL dbgen(sf=%d);" % sf)
-    con.execute("CHECKPOINT;")
     print("Data ready.", flush=True)
 
     return con
@@ -296,6 +319,11 @@ def main():
         help="Skip dashboard queries, run standard TPC-H only",
     )
     parser.add_argument("--no-chart", action="store_true", help="Skip chart generation")
+    parser.add_argument(
+        "--regenerate",
+        action="store_true",
+        help="Force regeneration of TPC-H data even if cached on disk",
+    )
     parser.add_argument(
         "--threads",
         type=int,


### PR DESCRIPTION
This pull request improves the efficiency of the TPC-H benchmark setup by introducing on-disk caching for generated data and providing an option to force regeneration. This avoids unnecessary regeneration of TPC-H data on every run, significantly speeding up repeated benchmark executions. Additionally, a new command-line argument is added to control data regeneration.

**Benchmark data caching and regeneration:**

* Modified `get_duckdb_connection` in `benchmark/run_tpch_benchmark.py` to cache generated TPC-H data on disk, reusing it for subsequent runs unless regeneration is explicitly requested. This includes logic to remove existing data and WAL files when regeneration is triggered.
* Removed the unconditional TPC-H data generation from `get_duckdb_connection`, as data is now generated only when needed.

**Command-line interface improvements:**

* Added a `--regenerate` argument to the benchmark script to allow users to force regeneration of TPC-H data even if a cached version exists.