### PR TITLE
[Demo] perf: optimizer early return and filter always true

### DIFF
--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -31,6 +31,7 @@ struct RowGroupFilter {
 	bool VectorHasRows(idx_t vector_index) const;
 	bool IsEmpty() const;
 	void MergeFrom(const RowGroupFilter &other);
+	bool IsFull() const;
 };
 
 // Composite key for cache lookup: (table_oid, filter_key)

--- a/src/query_condition_cache_filter.cpp
+++ b/src/query_condition_cache_filter.cpp
@@ -90,11 +90,14 @@ FilterPropagateResult CacheExpressionFilter::CheckStatistics(BaseStatistics &sta
 	auto min_val = NumericStats::GetMin<int64_t>(stats);
 	idx_t rg = NumericCast<idx_t>(min_val) / DEFAULT_ROW_GROUP_SIZE;
 	auto it = cache_entry->bitvectors.find(rg);
-	if (it != cache_entry->bitvectors.end() && it->second.IsEmpty()) {
-		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
-	}
 	if (it == cache_entry->bitvectors.end()) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	if (it->second.IsEmpty()) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	if (it->second.IsFull()) {
+		return FilterPropagateResult::FILTER_ALWAYS_TRUE;
 	}
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -101,8 +101,8 @@ class CacheBuildTask : public BaseExecutorTask {
 public:
 	CacheBuildTask(TaskExecutor &executor, ClientContext &context, DataTable &storage, DuckTransaction &transaction,
 	               ParallelTableScanState &parallel_state, Expression &bound_expr,
-	               const vector<StorageIndex> &column_ids, const vector<LogicalType> &scan_types,
-	               idx_t rowid_col_idx, ConditionCacheEntry &local_entry)
+	               const vector<StorageIndex> &column_ids, const vector<LogicalType> &scan_types, idx_t rowid_col_idx,
+	               ConditionCacheEntry &local_entry)
 	    : BaseExecutorTask(executor), context(context), storage(storage), transaction(transaction),
 	      parallel_state(parallel_state), bound_expr(bound_expr), column_ids(column_ids), scan_types(scan_types),
 	      rowid_col_idx(rowid_col_idx), local_entry(local_entry) {

--- a/src/query_condition_cache_optimizer.cpp
+++ b/src/query_condition_cache_optimizer.cpp
@@ -15,6 +15,8 @@
 #include "duckdb/planner/expression/bound_between_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/expression_binder/check_binder.hpp"
@@ -80,7 +82,7 @@ void QueryConditionCacheOptimizer::CollectGets(unique_ptr<LogicalOperator> &plan
 
 // Check if an expression will be natively pushed down by DuckDB's FilterPushdown optimizer,
 // meaning the condition cache provides no additional benefit.
-// Covers: col op constant, BETWEEN with constant bounds, IS NULL, IS NOT NULL.
+// Mirrors the logic in FilterCombiner::AddFilter + TryPushdownExpression.
 static bool IsTriviallyPushable(const Expression &expr) {
 	// Comparisons with a constant side: col op const, const op col
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
@@ -95,6 +97,50 @@ static bool IsTriviallyPushable(const Expression &expr) {
 	// IS NULL / IS NOT NULL
 	if (expr.type == ExpressionType::OPERATOR_IS_NULL || expr.type == ExpressionType::OPERATOR_IS_NOT_NULL) {
 		return true;
+	}
+	// IN with constant children: col IN (const, const, ...)
+	if (expr.type == ExpressionType::COMPARE_IN && expr.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR) {
+		auto &op = expr.Cast<BoundOperatorExpression>();
+		if (op.children.size() > 1 && op.children[0]->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+			bool all_const = true;
+			for (idx_t i = 1; i < op.children.size(); i++) {
+				if (op.children[i]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
+					all_const = false;
+					break;
+				}
+			}
+			return all_const;
+		}
+	}
+	// LIKE with constant pattern: col LIKE 'literal' (function name "~~")
+	// prefix(col, 'literal')
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+		auto &func = expr.Cast<BoundFunctionExpression>();
+		if ((func.function.name == "~~" || func.function.name == "prefix") && func.children.size() == 2 &&
+		    func.children[0]->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
+		    func.children[1]->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+			return true;
+		}
+	}
+	// OR of simple comparisons: col = 1 OR col = 2 OR ...
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION) {
+		auto &conj = expr.Cast<BoundConjunctionExpression>();
+		if (conj.GetExpressionType() == ExpressionType::CONJUNCTION_OR) {
+			for (auto &child : conj.children) {
+				if (child->GetExpressionClass() != ExpressionClass::BOUND_COMPARISON) {
+					return false;
+				}
+				auto &comp = child->Cast<BoundComparisonExpression>();
+				bool has_col_and_const = (comp.left->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
+				                          comp.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) ||
+				                         (comp.left->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT &&
+				                          comp.right->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF);
+				if (!has_col_and_const) {
+					return false;
+				}
+			}
+			return !conj.children.empty();
+		}
 	}
 	return false;
 }

--- a/src/query_condition_cache_optimizer.cpp
+++ b/src/query_condition_cache_optimizer.cpp
@@ -12,7 +12,10 @@
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/expression/bound_between_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/expression_binder/check_binder.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
@@ -75,6 +78,27 @@ void QueryConditionCacheOptimizer::CollectGets(unique_ptr<LogicalOperator> &plan
 	}
 }
 
+// Check if an expression will be natively pushed down by DuckDB's FilterPushdown optimizer,
+// meaning the condition cache provides no additional benefit.
+// Covers: col op constant, BETWEEN with constant bounds, IS NULL, IS NOT NULL.
+static bool IsTriviallyPushable(const Expression &expr) {
+	// Comparisons with a constant side: col op const, const op col
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
+		auto &comp = expr.Cast<BoundComparisonExpression>();
+		return comp.left->IsFoldable() || comp.right->IsFoldable();
+	}
+	// BETWEEN with constant bounds
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_BETWEEN) {
+		auto &between = expr.Cast<BoundBetweenExpression>();
+		return between.lower->IsFoldable() && between.upper->IsFoldable();
+	}
+	// IS NULL / IS NOT NULL
+	if (expr.type == ExpressionType::OPERATOR_IS_NULL || expr.type == ExpressionType::OPERATOR_IS_NOT_NULL) {
+		return true;
+	}
+	return false;
+}
+
 void QueryConditionCacheOptimizer::ExtractBindings(Expression &expr, unordered_set<idx_t> &table_bindings) {
 	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
 		auto &colref = expr.Cast<BoundColumnRefExpression>();
@@ -111,6 +135,20 @@ void QueryConditionCacheOptimizer::ProcessFilters(ClientContext &context, unique
 			idx_t table_index = pair.first;
 			auto &expressions = pair.second;
 			auto get = gets[table_index];
+
+			// Skip cache processing if all predicates are trivially pushable by DuckDB's
+			// native FilterPushdown (comparisons with constants, BETWEEN, IS NULL/NOT NULL).
+			// The cache provides no benefit for these — DuckDB already handles them efficiently.
+			bool all_trivially_pushable = true;
+			for (auto &e : expressions) {
+				if (!IsTriviallyPushable(*e)) {
+					all_trivially_pushable = false;
+					break;
+				}
+			}
+			if (all_trivially_pushable) {
+				continue;
+			}
 
 			auto table = get->GetTable();
 			if (!table) {

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -36,6 +36,22 @@ void RowGroupFilter::MergeFrom(const RowGroupFilter &other) {
 		matching_vectors[i] |= other.matching_vectors[i];
 	}
 }
+bool RowGroupFilter::IsFull() const {
+	// Check if all VECTORS_PER_ROW_GROUP bits are set
+	for (idx_t i = 0; i < BITVECTOR_ARRAY_SIZE; i++) {
+		idx_t remaining = VECTORS_PER_ROW_GROUP - i * 64;
+		uint64_t expected;
+		if (remaining >= 64) {
+			expected = ~uint64_t(0);
+		} else {
+			expected = (1ULL << remaining) - 1;
+		}
+		if (matching_vectors[i] != expected) {
+			return false;
+		}
+	}
+	return true;
+}
 
 // ------- CONDITION_CACHE_ENTRY -------
 


### PR DESCRIPTION
This pull request improves the efficiency and correctness of the query condition cache and its integration with DuckDB's filter pushdown logic. The main changes include adding a check for fully-matching row group filters, optimizing when the cache is used by skipping cases already handled natively by DuckDB, and refactoring to support these enhancements.

**Improvements to filter pruning logic:**

* Added a new `IsFull()` method to the `RowGroupFilter` class, allowing detection when all vectors in a row group match, and implemented its logic in `src/query_condition_cache_state.cpp`. [[1]](diffhunk://#diff-88a03539ebda86ce9381b8dd9b5d0a8fa9639b5a97acb89191dbe91175a0e53bR33) [[2]](diffhunk://#diff-dafe1beabdcd8b768bb9fd3f2c978e072c365c11ae84dfd4b65e858b4362fca1R34-R50)
* Updated the filter pruning decision in `CacheExpressionFilter::CheckStatistics` to return `FILTER_ALWAYS_TRUE` if a row group filter is fully matching, and refactored the logic for clarity and correctness.

**Optimization of cache usage:**

* Introduced the `IsTriviallyPushable` function to detect filter expressions that DuckDB's native optimizer already handles efficiently (e.g., comparisons with constants, BETWEEN, IS NULL/NOT NULL), and skip cache processing for these cases in `QueryConditionCacheOptimizer::ProcessFilters`. [[1]](diffhunk://#diff-0160a3c7dde6d7f85717e21ff8cb39bbcf3f68e0ea8385d540d43c2fb86a4446R81-R101) [[2]](diffhunk://#diff-0160a3c7dde6d7f85717e21ff8cb39bbcf3f68e0ea8385d540d43c2fb86a4446R139-R152)
* Added necessary includes for new expression types used in the pushdown detection logic.