### PR TITLE
Parallelize cache build and record all row groups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,3 +29,7 @@ install(
   ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
 
 add_subdirectory(test/unittest)
+
+add_executable(benchmark_cache_build EXCLUDE_FROM_ALL
+               benchmark/benchmark_cache_build.cpp)
+target_link_libraries(benchmark_cache_build duckdb ${EXTENSION_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ install(
 
 add_subdirectory(test/unittest)
 
-if(BUILD_BENCHMARK)
+if(${BUILD_BENCHMARKS})
   add_executable(benchmark_cache_build benchmark/benchmark_cache_build.cpp)
   target_link_libraries(benchmark_cache_build duckdb ${EXTENSION_NAME})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ install(
 
 add_subdirectory(test/unittest)
 
-add_executable(benchmark_cache_build EXCLUDE_FROM_ALL
-               benchmark/benchmark_cache_build.cpp)
-target_link_libraries(benchmark_cache_build duckdb ${EXTENSION_NAME})
+if(BUILD_BENCHMARK)
+  add_executable(benchmark_cache_build benchmark/benchmark_cache_build.cpp)
+  target_link_libraries(benchmark_cache_build duckdb ${EXTENSION_NAME})
+endif()

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ format-all: format
 	cmake-format -i test/unittest/CMakeLists.txt
 
 benchmark_cache_build:
-	cmake -DBUILD_BENCHMARK=ON -B build/release -S duckdb
+	cmake -DBUILD_BENCHMARKS=ON -B build/release -S duckdb
 	cmake --build build/release --target benchmark_cache_build
 	./build/release/extension/query_condition_cache/benchmark_cache_build
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ format-all: format
 	cmake-format -i test/unittest/CMakeLists.txt
 
 benchmark_cache_build:
+	cmake -DBUILD_BENCHMARK=ON -B build/release -S duckdb
 	cmake --build build/release --target benchmark_cache_build
 	./build/release/extension/query_condition_cache/benchmark_cache_build
 

--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,8 @@ format-all: format
 	cmake-format -i CMakeLists.txt
 	cmake-format -i test/unittest/CMakeLists.txt
 
-PHONY: format-all test_release_all test_debug_all test_reldebug_all
+benchmark_cache_build:
+	cmake --build build/release --target benchmark_cache_build
+	./build/release/extension/query_condition_cache/benchmark_cache_build
+
+PHONY: format-all test_release_all test_debug_all test_reldebug_all benchmark_cache_build

--- a/benchmark/benchmark_cache_build.cpp
+++ b/benchmark/benchmark_cache_build.cpp
@@ -1,0 +1,106 @@
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+
+#include <chrono>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace duckdb;
+
+static double BenchMs(Connection &con, const std::string &sql, int rounds = 5) {
+	con.Query(sql); // warmup
+	double total = 0;
+	for (int r = 0; r < rounds; ++r) {
+		auto start = std::chrono::steady_clock::now();
+		con.Query(sql);
+		auto end = std::chrono::steady_clock::now();
+		total += std::chrono::duration<double, std::milli>(end - start).count();
+	}
+	return total / rounds;
+}
+
+static void PrintSection(const char *title, const std::vector<std::pair<std::string, double>> &rows) {
+	printf("\n%s\n", title);
+	for (auto &[label, ms] : rows) {
+		printf("  %-45s %8.1f ms\n", label.c_str(), ms);
+	}
+}
+
+int main() {
+	DuckDB db;
+	Connection con(db);
+
+	const int rounds = 5;
+	const std::string build = "SELECT * FROM condition_cache_build('t', 'val = 42')";
+
+	// 0. Query baseline vs cache build cost
+	con.Query("CREATE OR REPLACE TABLE t AS SELECT i AS id, i%100 AS val FROM range(2000000) t(i)");
+	std::vector<std::pair<std::string, double>> results;
+	results.emplace_back("SELECT count(*) WHERE val = 42",
+	                     BenchMs(con, "SELECT count(*) FROM t WHERE val = 42", rounds));
+	results.emplace_back("SELECT count(*) WHERE val < 50",
+	                     BenchMs(con, "SELECT count(*) FROM t WHERE val < 50", rounds));
+	results.emplace_back("cache build (val = 42)", BenchMs(con, build, rounds));
+	results.emplace_back("cache build (val < 50)",
+	                     BenchMs(con, "SELECT * FROM condition_cache_build('t', 'val < 50')", rounds));
+	PrintSection("Query baseline vs cache build cost (2M rows, threads=default)", results);
+
+	// 1. Row count scaling
+	results.clear();
+	for (int64_t n : {100000, 500000, 2000000, 12288000}) {
+		con.Query("CREATE OR REPLACE TABLE t AS SELECT i AS id, i%100 AS val FROM range(" + std::to_string(n) + ") t(i)");
+		double ms = BenchMs(con, build, rounds);
+		int rgs = (n + 122879) / 122880;
+		char label[64];
+		snprintf(label, sizeof(label), "%'lld rows (%d RGs)", (long long)n, rgs);
+		results.emplace_back(label, ms);
+	}
+	PrintSection("Row count scaling (threads=default)", results);
+
+	// 2. Thread scaling
+	con.Query("CREATE OR REPLACE TABLE t AS SELECT i AS id, i%100 AS val FROM range(2000000) t(i)");
+	results.clear();
+	for (int threads : {1, 2, 4, 8}) {
+		con.Query("SET threads = " + std::to_string(threads));
+		double ms = BenchMs(con, build, rounds);
+		char label[32];
+		snprintf(label, sizeof(label), "threads = %d", threads);
+		results.emplace_back(label, ms);
+	}
+	PrintSection("Thread scaling (2M rows, 17 RGs)", results);
+	con.Query("RESET threads");
+
+	// 3. Column count in predicate
+	con.Query(R"(CREATE OR REPLACE TABLE t AS
+		SELECT i AS id, i%100 AS c1, i%200 AS c2, i%300 AS c3, i%400 AS c4, i%500 AS c5
+		FROM range(2000000) t(i))");
+	results.clear();
+	std::vector<std::pair<std::string, std::string>> col_tests = {
+	    {"1 col", "c1 = 42"},
+	    {"3 cols", "c1 = 42 AND c2 < 100 AND c3 > 50"},
+	    {"5 cols", "c1 = 42 AND c2 < 100 AND c3 > 50 AND c4 != 0 AND c5 < 250"},
+	};
+	for (auto &[label, pred] : col_tests) {
+		double ms = BenchMs(con, "SELECT * FROM condition_cache_build('t', '" + pred + "')", rounds);
+		results.emplace_back(label, ms);
+	}
+	PrintSection("Column count in predicate (2M rows, threads=default)", results);
+
+	// 4. Selectivity
+	con.Query("CREATE OR REPLACE TABLE t AS SELECT i AS id, i%100 AS val FROM range(2000000) t(i)");
+	results.clear();
+	std::vector<std::pair<std::string, std::string>> sel_tests = {
+	    {"1% match (val = 42)", "val = 42"},
+	    {"50% match (val < 50)", "val < 50"},
+	    {"100% match (val >= 0)", "val >= 0"},
+	    {"0% match (id < 0)", "id < 0"},
+	};
+	for (auto &[label, pred] : sel_tests) {
+		double ms = BenchMs(con, "SELECT * FROM condition_cache_build('t', '" + pred + "')", rounds);
+		results.emplace_back(label, ms);
+	}
+	PrintSection("Selectivity (2M rows, threads=default)", results);
+
+	return 0;
+}

--- a/benchmark/benchmark_cache_build.cpp
+++ b/benchmark/benchmark_cache_build.cpp
@@ -3,13 +3,17 @@
 
 #include <chrono>
 #include <cstdio>
-#include <string>
-#include <vector>
+
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/vector.hpp"
 
 using namespace duckdb;
 
-static double BenchMs(Connection &con, const std::string &sql, int rounds = 5) {
-	con.Query(sql); // warmup
+namespace {
+
+// Run sql `rounds` times, return average elapsed time in milliseconds.
+double BenchMs(Connection &con, const string &sql, int rounds = 5) {
 	double total = 0;
 	for (int r = 0; r < rounds; ++r) {
 		auto start = std::chrono::steady_clock::now();
@@ -20,41 +24,42 @@ static double BenchMs(Connection &con, const std::string &sql, int rounds = 5) {
 	return total / rounds;
 }
 
-static void PrintSection(const char *title, const std::vector<std::pair<std::string, double>> &rows) {
+void PrintSection(const char *title, const vector<std::pair<string, double>> &rows) {
 	printf("\n%s\n", title);
-	for (auto &[label, ms] : rows) {
+	for (const auto &[label, ms] : rows) {
 		printf("  %-45s %8.1f ms\n", label.c_str(), ms);
 	}
 }
+
+} // namespace
 
 int main() {
 	DuckDB db;
 	Connection con(db);
 
 	const int rounds = 5;
-	const std::string build = "SELECT * FROM condition_cache_build('t', 'val = 42')";
+	const string build_val42 = "SELECT * FROM condition_cache_build('t', 'val = 42')";
+	const string build_val50 = "SELECT * FROM condition_cache_build('t', 'val < 50')";
 
 	// 0. Query baseline vs cache build cost
 	con.Query("CREATE OR REPLACE TABLE t AS SELECT i AS id, i%100 AS val FROM range(2000000) t(i)");
-	std::vector<std::pair<std::string, double>> results;
+	vector<std::pair<string, double>> results;
 	results.emplace_back("SELECT count(*) WHERE val = 42",
 	                     BenchMs(con, "SELECT count(*) FROM t WHERE val = 42", rounds));
 	results.emplace_back("SELECT count(*) WHERE val < 50",
 	                     BenchMs(con, "SELECT count(*) FROM t WHERE val < 50", rounds));
-	results.emplace_back("cache build (val = 42)", BenchMs(con, build, rounds));
-	results.emplace_back("cache build (val < 50)",
-	                     BenchMs(con, "SELECT * FROM condition_cache_build('t', 'val < 50')", rounds));
+	results.emplace_back("cache build (val = 42)", BenchMs(con, build_val42, rounds));
+	results.emplace_back("cache build (val < 50)", BenchMs(con, build_val50, rounds));
 	PrintSection("Query baseline vs cache build cost (2M rows, threads=default)", results);
 
 	// 1. Row count scaling
 	results.clear();
 	for (int64_t n : {100000, 500000, 2000000, 12288000}) {
-		con.Query("CREATE OR REPLACE TABLE t AS SELECT i AS id, i%100 AS val FROM range(" + std::to_string(n) + ") t(i)");
-		double ms = BenchMs(con, build, rounds);
-		int rgs = (n + 122879) / 122880;
-		char label[64];
-		snprintf(label, sizeof(label), "%'lld rows (%d RGs)", (long long)n, rgs);
-		results.emplace_back(label, ms);
+		con.Query(StringUtil::Format(
+		    "CREATE OR REPLACE TABLE t AS SELECT i AS id, i%%100 AS val FROM range(%lld) t(i)", n));
+		double ms = BenchMs(con, build_val42, rounds);
+		int64_t rgs = (n + 122879) / 122880;
+		results.emplace_back(StringUtil::Format("%lld rows (%lld RGs)", n, rgs), ms);
 	}
 	PrintSection("Row count scaling (threads=default)", results);
 
@@ -62,11 +67,9 @@ int main() {
 	con.Query("CREATE OR REPLACE TABLE t AS SELECT i AS id, i%100 AS val FROM range(2000000) t(i)");
 	results.clear();
 	for (int threads : {1, 2, 4, 8}) {
-		con.Query("SET threads = " + std::to_string(threads));
-		double ms = BenchMs(con, build, rounds);
-		char label[32];
-		snprintf(label, sizeof(label), "threads = %d", threads);
-		results.emplace_back(label, ms);
+		con.Query(StringUtil::Format("SET threads = %d", threads));
+		double ms = BenchMs(con, build_val42, rounds);
+		results.emplace_back(StringUtil::Format("threads = %d", threads), ms);
 	}
 	PrintSection("Thread scaling (2M rows, 17 RGs)", results);
 	con.Query("RESET threads");
@@ -76,13 +79,13 @@ int main() {
 		SELECT i AS id, i%100 AS c1, i%200 AS c2, i%300 AS c3, i%400 AS c4, i%500 AS c5
 		FROM range(2000000) t(i))");
 	results.clear();
-	std::vector<std::pair<std::string, std::string>> col_tests = {
+	vector<std::pair<string, string>> col_tests = {
 	    {"1 col", "c1 = 42"},
 	    {"3 cols", "c1 = 42 AND c2 < 100 AND c3 > 50"},
 	    {"5 cols", "c1 = 42 AND c2 < 100 AND c3 > 50 AND c4 != 0 AND c5 < 250"},
 	};
-	for (auto &[label, pred] : col_tests) {
-		double ms = BenchMs(con, "SELECT * FROM condition_cache_build('t', '" + pred + "')", rounds);
+	for (const auto &[label, pred] : col_tests) {
+		double ms = BenchMs(con, StringUtil::Format("SELECT * FROM condition_cache_build('t', '%s')", pred), rounds);
 		results.emplace_back(label, ms);
 	}
 	PrintSection("Column count in predicate (2M rows, threads=default)", results);
@@ -90,14 +93,14 @@ int main() {
 	// 4. Selectivity
 	con.Query("CREATE OR REPLACE TABLE t AS SELECT i AS id, i%100 AS val FROM range(2000000) t(i)");
 	results.clear();
-	std::vector<std::pair<std::string, std::string>> sel_tests = {
+	vector<std::pair<string, string>> sel_tests = {
 	    {"1% match (val = 42)", "val = 42"},
 	    {"50% match (val < 50)", "val < 50"},
 	    {"100% match (val >= 0)", "val >= 0"},
 	    {"0% match (id < 0)", "id < 0"},
 	};
-	for (auto &[label, pred] : sel_tests) {
-		double ms = BenchMs(con, "SELECT * FROM condition_cache_build('t', '" + pred + "')", rounds);
+	for (const auto &[label, pred] : sel_tests) {
+		double ms = BenchMs(con, StringUtil::Format("SELECT * FROM condition_cache_build('t', '%s')", pred), rounds);
 		results.emplace_back(label, ms);
 	}
 	PrintSection("Selectivity (2M rows, threads=default)", results);

--- a/src/include/query_condition_cache_functions.hpp
+++ b/src/include/query_condition_cache_functions.hpp
@@ -16,16 +16,6 @@ class Expression;
 shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTableEntry &table_entry,
                                                 Expression &bound_expr);
 
-struct CacheEntryStats {
-	idx_t qualifying_vectors;
-	idx_t total_vectors;
-	idx_t qualifying_row_groups;
-	idx_t total_row_groups;
-};
-
-// TODO: Exposed for future reuse.
-CacheEntryStats ComputeCacheEntryStats(const ConditionCacheEntry &entry, idx_t total_rows);
-
 TableFunction ConditionCacheBuildFunction();
 
 } // namespace duckdb

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -29,6 +29,7 @@ struct RowGroupFilter {
 	void SetVector(idx_t vector_index);
 	bool VectorHasRows(idx_t vector_index) const;
 	bool IsEmpty() const;
+	void MergeFrom(const RowGroupFilter &other);
 };
 
 // Composite key for cache lookup: (table_oid, filter_key)

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -48,6 +48,13 @@ struct CacheKeyHashFunction {
 	}
 };
 
+struct CacheEntryStats {
+	idx_t qualifying_vectors;
+	idx_t total_vectors;
+	idx_t qualifying_row_groups;
+	idx_t total_row_groups;
+};
+
 // A single cache entry: the bitvectors for one (table, predicate) combination.
 struct ConditionCacheEntry : public ObjectCacheEntry {
 	unordered_map<idx_t, RowGroupFilter> bitvectors; // rg_idx -> bitvector
@@ -62,6 +69,9 @@ struct ConditionCacheEntry : public ObjectCacheEntry {
 
 	// Return estimated memory usage for LRU eviction
 	optional_idx GetEstimatedCacheMemory() const override;
+
+	// Compute statistics about qualifying vectors and row groups
+	CacheEntryStats ComputeStats(idx_t total_rows) const;
 };
 
 // Stored in DuckDB's per-database ObjectCache

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -138,6 +138,9 @@ public:
 					continue;
 				}
 				auto first_row_id = NumericCast<idx_t>(rowids[first_rowid_idx]);
+				if (first_row_id >= NumericCast<idx_t>(MAX_ROW_ID)) {
+					continue; // skip transaction-local storage rows
+				}
 				idx_t row_group_idx = first_row_id / DEFAULT_ROW_GROUP_SIZE;
 				// Access to instantiate default RowGroupFilter for this row group
 				(void)local_entry.bitvectors[row_group_idx];

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -10,6 +10,8 @@
 #include "duckdb/common/vector.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/table_function.hpp"
+#include "duckdb/parallel/task_executor.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/planner/binder.hpp"
@@ -17,6 +19,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression_binder/check_binder.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/storage_index.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
@@ -93,9 +96,87 @@ struct ScanColumn {
 	LogicalType type;
 };
 
+// Task that scans a subset of row groups in parallel and builds a local ConditionCacheEntry.
+class CacheBuildTask : public BaseExecutorTask {
+public:
+	CacheBuildTask(TaskExecutor &executor, ClientContext &context, DataTable &storage, DuckTransaction &transaction,
+	               ParallelTableScanState &parallel_state, Expression &bound_expr,
+	               const vector<StorageIndex> &column_ids, const vector<LogicalType> &scan_types, idx_t rowid_col_idx,
+	               ConditionCacheEntry &local_entry)
+	    : BaseExecutorTask(executor), context(context), storage(storage), transaction(transaction),
+	      parallel_state(parallel_state), bound_expr(bound_expr), column_ids(column_ids), scan_types(scan_types),
+	      rowid_col_idx(rowid_col_idx), local_entry(local_entry) {
+	}
+
+	void ExecuteTask() override {
+		TableScanState scan_state;
+		scan_state.Initialize(column_ids);
+
+		ExpressionExecutor expr_executor(context, bound_expr);
+
+		DataChunk chunk;
+		chunk.Initialize(Allocator::Get(context), scan_types);
+
+		while (storage.NextParallelScan(context, parallel_state, scan_state)) {
+			while (true) {
+				chunk.Reset();
+				storage.Scan(transaction, chunk, scan_state);
+				if (chunk.size() == 0) {
+					break;
+				}
+
+				auto &rowid_vec = chunk.data[rowid_col_idx];
+				UnifiedVectorFormat rowid_data;
+				rowid_vec.ToUnifiedFormat(chunk.size(), rowid_data);
+				auto rowids = UnifiedVectorFormat::GetData<row_t>(rowid_data);
+
+				// Determine row group from first row_id and instantiate its entry
+				// so that fully excluded row groups are recorded with empty bitvectors.
+				auto first_rowid_idx = rowid_data.sel->get_index(0);
+				if (!rowid_data.validity.RowIsValid(first_rowid_idx)) {
+					continue;
+				}
+				auto first_row_id = NumericCast<idx_t>(rowids[first_rowid_idx]);
+				idx_t row_group_idx = first_row_id / DEFAULT_ROW_GROUP_SIZE;
+				// Access to instantiate default RowGroupFilter for this row group
+				(void)local_entry.bitvectors[row_group_idx];
+
+				SelectionVector sel(chunk.size());
+				idx_t match_count = expr_executor.SelectExpression(chunk, sel);
+
+				for (idx_t idx = 0; idx < match_count; ++idx) {
+					auto rowid_entry = rowid_data.sel->get_index(sel.get_index(idx));
+					if (!rowid_data.validity.RowIsValid(rowid_entry)) {
+						continue;
+					}
+					auto row_id = NumericCast<idx_t>(rowids[rowid_entry]);
+					idx_t rg_idx = row_id / DEFAULT_ROW_GROUP_SIZE;
+					idx_t vector_idx = (row_id % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
+					local_entry.bitvectors[rg_idx].SetVector(vector_idx);
+				}
+			}
+		}
+	}
+
+	string TaskType() const override {
+		return "CacheBuildTask";
+	}
+
+private:
+	ClientContext &context;
+	DataTable &storage;
+	DuckTransaction &transaction;
+	ParallelTableScanState &parallel_state;
+	Expression &bound_expr;
+	const vector<StorageIndex> &column_ids;
+	const vector<LogicalType> &scan_types;
+	idx_t rowid_col_idx;
+	ConditionCacheEntry &local_entry;
+};
+
 } // namespace
 
-// Scan all rows, evaluate predicate, and build a ConditionCacheEntry.
+// Scan all rows in parallel, evaluate predicate, and build a ConditionCacheEntry.
 // Modifies bound_expr in-place (remaps column indices to scan positions).
 shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTableEntry &table_entry,
                                                 Expression &bound_expr) {
@@ -134,41 +215,38 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 
 	RemapColumnIndices(bound_expr, storage_to_scan_idx);
 
-	// Direct table scan with predicate evaluation via ExpressionExecutor
+	// Parallel table scan with TaskExecutor
 	auto &transaction = DuckTransaction::Get(context, table_entry.ParentCatalog().GetAttached());
-	TableScanState scan_state;
-	storage.InitializeScan(context, transaction, scan_state, column_ids);
 
-	// Scan and evaluate predicate
-	ExpressionExecutor executor(context, bound_expr);
+	// Build ColumnIndex vector for parallel scan initialization
+	vector<ColumnIndex> column_indexes;
+	column_indexes.reserve(column_ids.size());
+	for (const auto &si : column_ids) {
+		column_indexes.emplace_back(si.GetPrimaryIndex());
+	}
 
+	ParallelTableScanState parallel_state;
+	storage.InitializeParallelScan(context, parallel_state, column_indexes);
+
+	auto num_threads = NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
+	idx_t num_tasks = MinValue(storage.MaxThreads(context), num_threads);
+	num_tasks = MaxValue<idx_t>(num_tasks, 1);
+
+	vector<ConditionCacheEntry> local_entries(num_tasks);
+
+	TaskExecutor task_executor(context);
+	for (idx_t i = 0; i < num_tasks; ++i) {
+		task_executor.ScheduleTask(make_uniq<CacheBuildTask>(task_executor, context, storage, transaction,
+		                                                     parallel_state, bound_expr, column_ids, scan_types,
+		                                                     rowid_col_idx, local_entries[i]));
+	}
+	task_executor.WorkOnTasks();
+
+	// Merge local entries into final result
 	auto entry = make_shared_ptr<ConditionCacheEntry>();
-
-	while (true) {
-		DataChunk chunk;
-		chunk.Initialize(Allocator::Get(context), scan_types);
-		storage.Scan(transaction, chunk, scan_state);
-		if (chunk.size() == 0) {
-			break;
-		}
-
-		SelectionVector sel(chunk.size());
-		idx_t match_count = executor.SelectExpression(chunk, sel);
-
-		auto &rowid_vec = chunk.data[rowid_col_idx];
-		UnifiedVectorFormat rowid_data;
-		rowid_vec.ToUnifiedFormat(chunk.size(), rowid_data);
-		auto rowids = UnifiedVectorFormat::GetData<row_t>(rowid_data);
-
-		for (idx_t idx = 0; idx < match_count; ++idx) {
-			auto rowid_entry = rowid_data.sel->get_index(sel.get_index(idx));
-			if (!rowid_data.validity.RowIsValid(rowid_entry)) {
-				continue;
-			}
-			auto row_id = NumericCast<idx_t>(rowids[rowid_entry]);
-			idx_t row_group_idx = row_id / DEFAULT_ROW_GROUP_SIZE;
-			idx_t vector_idx = (row_id % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
-			entry->bitvectors[row_group_idx].SetVector(vector_idx);
+	for (const auto &local : local_entries) {
+		for (const auto &pair : local.bitvectors) {
+			entry->bitvectors[pair.first].MergeFrom(pair.second);
 		}
 	}
 
@@ -194,7 +272,12 @@ CacheEntryStats ComputeCacheEntryStats(const ConditionCacheEntry &entry, idx_t t
 		total_vectors += (remaining_rows + STANDARD_VECTOR_SIZE - 1) / STANDARD_VECTOR_SIZE;
 	}
 
-	idx_t qualifying_row_groups = entry.bitvectors.size();
+	idx_t qualifying_row_groups = 0;
+	for (const auto &bitvector_pair : entry.bitvectors) {
+		if (!bitvector_pair.second.IsEmpty()) {
+			++qualifying_row_groups;
+		}
+	}
 	idx_t total_row_groups = (total_rows + DEFAULT_ROW_GROUP_SIZE - 1) / DEFAULT_ROW_GROUP_SIZE;
 
 	return CacheEntryStats {

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -246,47 +246,12 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 	// Merge local entries into final result
 	auto entry = make_shared_ptr<ConditionCacheEntry>();
 	for (const auto &local : local_entries) {
-		for (const auto &pair : local.bitvectors) {
-			entry->bitvectors[pair.first].MergeFrom(pair.second);
+		for (const auto &[rg_idx, filter] : local.bitvectors) {
+			entry->bitvectors[rg_idx].MergeFrom(filter);
 		}
 	}
 
 	return entry;
-}
-
-CacheEntryStats ComputeCacheEntryStats(const ConditionCacheEntry &entry, idx_t total_rows) {
-	constexpr idx_t vectors_per_row_group = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
-
-	idx_t qualifying_vectors = 0;
-	for (const auto &bitvector_pair : entry.bitvectors) {
-		for (idx_t v = 0; v < vectors_per_row_group; ++v) {
-			if (bitvector_pair.second.VectorHasRows(v)) {
-				++qualifying_vectors;
-			}
-		}
-	}
-
-	idx_t full_row_groups = total_rows / DEFAULT_ROW_GROUP_SIZE;
-	idx_t remaining_rows = total_rows % DEFAULT_ROW_GROUP_SIZE;
-	idx_t total_vectors = full_row_groups * vectors_per_row_group;
-	if (remaining_rows > 0) {
-		total_vectors += (remaining_rows + STANDARD_VECTOR_SIZE - 1) / STANDARD_VECTOR_SIZE;
-	}
-
-	idx_t qualifying_row_groups = 0;
-	for (const auto &bitvector_pair : entry.bitvectors) {
-		if (!bitvector_pair.second.IsEmpty()) {
-			++qualifying_row_groups;
-		}
-	}
-	idx_t total_row_groups = (total_rows + DEFAULT_ROW_GROUP_SIZE - 1) / DEFAULT_ROW_GROUP_SIZE;
-
-	return CacheEntryStats {
-	    .qualifying_vectors = qualifying_vectors,
-	    .total_vectors = total_vectors,
-	    .qualifying_row_groups = qualifying_row_groups,
-	    .total_row_groups = total_row_groups,
-	};
 }
 
 void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
@@ -316,7 +281,7 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
 
 	auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
-	auto stats = ComputeCacheEntryStats(*entry, bind_data.total_rows);
+	auto stats = entry->ComputeStats(bind_data.total_rows);
 
 	// Store in cache
 	// TODO: Use canonical predicate key (sorted expressions) so that "a AND b" and "b AND a" hit same entry

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -99,13 +99,14 @@ struct ScanColumn {
 // Task that scans a subset of row groups in parallel and builds a local ConditionCacheEntry.
 class CacheBuildTask : public BaseExecutorTask {
 public:
-	CacheBuildTask(TaskExecutor &executor, ClientContext &context, DataTable &storage, DuckTransaction &transaction,
-	               ParallelTableScanState &parallel_state, Expression &bound_expr,
-	               const vector<StorageIndex> &column_ids, const vector<LogicalType> &scan_types, idx_t rowid_col_idx,
-	               ConditionCacheEntry &local_entry)
-	    : BaseExecutorTask(executor), context(context), storage(storage), transaction(transaction),
-	      parallel_state(parallel_state), bound_expr(bound_expr), column_ids(column_ids), scan_types(scan_types),
-	      rowid_col_idx(rowid_col_idx), local_entry(local_entry) {
+	CacheBuildTask(TaskExecutor &executor_p, ClientContext &context_p, DataTable &storage_p,
+	               DuckTransaction &transaction_p, ParallelTableScanState &parallel_state_p,
+	               Expression &bound_expr_p, const vector<StorageIndex> &column_ids_p,
+	               const vector<LogicalType> &scan_types_p, idx_t rowid_col_idx_p,
+	               ConditionCacheEntry &local_entry_p)
+	    : BaseExecutorTask(executor_p), context(context_p), storage(storage_p), transaction(transaction_p),
+	      parallel_state(parallel_state_p), bound_expr(bound_expr_p), column_ids(column_ids_p),
+	      scan_types(scan_types_p), rowid_col_idx(rowid_col_idx_p), local_entry(local_entry_p) {
 	}
 
 	void ExecuteTask() override {

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -47,6 +47,38 @@ optional_idx ConditionCacheEntry::GetEstimatedCacheMemory() const {
 	return optional_idx(estimated_size);
 }
 
+CacheEntryStats ConditionCacheEntry::ComputeStats(idx_t total_rows) const {
+	constexpr idx_t vectors_per_row_group = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
+
+	idx_t qualifying_vectors = 0;
+	idx_t qualifying_row_groups = 0;
+	for (const auto &[rg_idx, filter] : bitvectors) {
+		if (!filter.IsEmpty()) {
+			++qualifying_row_groups;
+		}
+		for (idx_t v = 0; v < vectors_per_row_group; ++v) {
+			if (filter.VectorHasRows(v)) {
+				++qualifying_vectors;
+			}
+		}
+	}
+
+	idx_t full_row_groups = total_rows / DEFAULT_ROW_GROUP_SIZE;
+	idx_t remaining_rows = total_rows % DEFAULT_ROW_GROUP_SIZE;
+	idx_t total_vectors = full_row_groups * vectors_per_row_group;
+	if (remaining_rows > 0) {
+		total_vectors += (remaining_rows + STANDARD_VECTOR_SIZE - 1) / STANDARD_VECTOR_SIZE;
+	}
+	idx_t total_row_groups = (total_rows + DEFAULT_ROW_GROUP_SIZE - 1) / DEFAULT_ROW_GROUP_SIZE;
+
+	return CacheEntryStats {
+	    .qualifying_vectors = qualifying_vectors,
+	    .total_vectors = total_vectors,
+	    .qualifying_row_groups = qualifying_row_groups,
+	    .total_row_groups = total_row_groups,
+	};
+}
+
 // ------- CONDITION_CACHE_STORE -------
 
 string ConditionCacheStore::MakeCacheKeyString(const CacheKey &key) {

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -31,6 +31,12 @@ bool RowGroupFilter::IsEmpty() const {
 	return true;
 }
 
+void RowGroupFilter::MergeFrom(const RowGroupFilter &other) {
+	for (idx_t i = 0; i < BITVECTOR_ARRAY_SIZE; ++i) {
+		matching_vectors[i] |= other.matching_vectors[i];
+	}
+}
+
 // ------- CONDITION_CACHE_ENTRY -------
 
 optional_idx ConditionCacheEntry::GetEstimatedCacheMemory() const {

--- a/test/sql/condition_cache_build.test
+++ b/test/sql/condition_cache_build.test
@@ -54,7 +54,7 @@ Cache Built: 245/245 vectors, 5/5 row groups
 statement error
 SELECT * FROM condition_cache_build('bad_schema.t', 'val = 42');
 ----
-Table with name t does not exist
+does not exist
 
 # Invalid database name
 statement error

--- a/test/sql/condition_cache_build.test
+++ b/test/sql/condition_cache_build.test
@@ -54,7 +54,7 @@ Cache Built: 245/245 vectors, 5/5 row groups
 statement error
 SELECT * FROM condition_cache_build('bad_schema.t', 'val = 42');
 ----
-does not exist
+schema "bad_schema" does not exist
 
 # Invalid database name
 statement error

--- a/test/unittest/test_bitvector.cpp
+++ b/test/unittest/test_bitvector.cpp
@@ -1,7 +1,7 @@
 #include "catch/catch.hpp"
 #include "query_condition_cache_state.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
 TEST_CASE("RowGroupFilter - basic operations", "[bitvector]") {
 	SECTION("default constructor is empty") {
@@ -45,4 +45,15 @@ TEST_CASE("RowGroupFilter - basic operations", "[bitvector]") {
 		REQUIRE(bv.VectorHasRows(5));
 		REQUIRE_FALSE(bv.VectorHasRows(6));
 	}
+
+	SECTION("MergeFrom combines two filters") {
+		RowGroupFilter a({1, 3});
+		RowGroupFilter b({2, 3});
+		a.MergeFrom(b);
+		REQUIRE(a.VectorHasRows(1));
+		REQUIRE(a.VectorHasRows(2));
+		REQUIRE(a.VectorHasRows(3));
+		REQUIRE_FALSE(a.VectorHasRows(0));
+	}
 }
+} // namespace duckdb

--- a/test/unittest/test_build_cache_entry.cpp
+++ b/test/unittest/test_build_cache_entry.cpp
@@ -10,7 +10,7 @@
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression_binder/check_binder.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
 TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 	DuckDB db(nullptr);
@@ -54,7 +54,11 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
 		REQUIRE(entry != nullptr);
-		REQUIRE(entry->bitvectors.size() == 1); // only row group 0
+		REQUIRE(entry->bitvectors.size() == 5); // all row groups are cached
+		REQUIRE(entry->bitvectors.at(0).VectorHasRows(0));
+		REQUIRE(entry->bitvectors.at(0).VectorHasRows(1));
+		REQUIRE_FALSE(entry->bitvectors.at(0).VectorHasRows(2));
+		REQUIRE(entry->bitvectors.at(1).IsEmpty());
 	}
 
 	SECTION("odd values pass, even values don't") {
@@ -89,6 +93,9 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
 		REQUIRE(entry != nullptr);
-		REQUIRE(entry->bitvectors.empty());
+		REQUIRE(entry->bitvectors.size() == 5);
+		REQUIRE(entry->bitvectors.at(0).IsEmpty());
+		REQUIRE(entry->bitvectors.at(4).IsEmpty());
 	}
 }
+} // namespace duckdb


### PR DESCRIPTION
## Summary

This PR parallelizes `BuildCacheEntry` using `TaskExecutor` with per-thread local entries merged via a new `RowGroupFilter::MergeFrom`, and records all scanned row groups in cache entries including those with no qualifying rows.
