### PR TITLE
Add condition_cache_info table function

### DIFF
--- a/src/include/query_condition_cache_functions.hpp
+++ b/src/include/query_condition_cache_functions.hpp
@@ -17,5 +17,6 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
                                                 Expression &bound_expr);
 
 TableFunction ConditionCacheBuildFunction();
+TableFunction ConditionCacheInfoFunction();
 
 } // namespace duckdb

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -20,6 +20,7 @@ void EnableQueryConditionCacheCallback(ClientContext &context, SetScope scope, V
 
 void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(ConditionCacheBuildFunction());
+	loader.RegisterFunction(ConditionCacheInfoFunction());
 
 	// Register extension settings
 	auto &db_instance = loader.GetDatabaseInstance();

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -278,8 +278,8 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	CheckBinder check_binder(*binder, context, bind_data.table, table_entry.GetColumns(), bound_columns);
 	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-	// Canonical key: bound expression normalizes whitespace and formatting
-	string canonical_key = bound_expr->ToString();
+	// Bound expression ToString() normalizes whitespace and formatting for cache key
+	string bound_expr_str = bound_expr->ToString();
 
 	// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN for SelectExpression.
 	bound_expr =
@@ -289,7 +289,7 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	auto stats = entry->ComputeStats(bind_data.total_rows);
 
 	// TODO: Invalidate cache on table modification (INSERT/DELETE/UPDATE/VACUUM)
-	CacheKey key {bind_data.table_oid, canonical_key};
+	CacheKey key {bind_data.table_oid, std::move(bound_expr_str)};
 	auto store = ConditionCacheStore::GetOrCreate(context);
 	store->Upsert(context, key, std::move(entry));
 

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -100,10 +100,9 @@ struct ScanColumn {
 class CacheBuildTask : public BaseExecutorTask {
 public:
 	CacheBuildTask(TaskExecutor &executor_p, ClientContext &context_p, DataTable &storage_p,
-	               DuckTransaction &transaction_p, ParallelTableScanState &parallel_state_p,
-	               Expression &bound_expr_p, const vector<StorageIndex> &column_ids_p,
-	               const vector<LogicalType> &scan_types_p, idx_t rowid_col_idx_p,
-	               ConditionCacheEntry &local_entry_p)
+	               DuckTransaction &transaction_p, ParallelTableScanState &parallel_state_p, Expression &bound_expr_p,
+	               const vector<StorageIndex> &column_ids_p, const vector<LogicalType> &scan_types_p,
+	               idx_t rowid_col_idx_p, ConditionCacheEntry &local_entry_p)
 	    : BaseExecutorTask(executor_p), context(context_p), storage(storage_p), transaction(transaction_p),
 	      parallel_state(parallel_state_p), bound_expr(bound_expr_p), column_ids(column_ids_p),
 	      scan_types(scan_types_p), rowid_col_idx(rowid_col_idx_p), local_entry(local_entry_p) {
@@ -304,6 +303,83 @@ TableFunction ConditionCacheBuildFunction() {
 	    "condition_cache_build",
 	    {LogicalType {LogicalTypeId::VARCHAR} /*table*/, LogicalType {LogicalTypeId::VARCHAR} /*predicate_sql*/},
 	    ConditionCacheBuildExecute, ConditionCacheBuildBind, ConditionCacheBuildInit);
+	return func;
+}
+
+// ------- condition_cache_info(table_name VARCHAR, predicate VARCHAR) -------
+// Returns cache statistics for a given (table, predicate) pair.
+
+struct ConditionCacheInfoBindData : public TableFunctionData {
+	idx_t table_oid;
+	idx_t total_rows;
+	string predicate_sql;
+};
+
+struct ConditionCacheInfoState : public GlobalTableFunctionState {
+	bool done = false;
+};
+
+unique_ptr<FunctionData> ConditionCacheInfoBind(ClientContext &context, TableFunctionBindInput &input,
+                                                vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_uniq<ConditionCacheInfoBindData>();
+	result->predicate_sql = input.inputs[1].GetValue<string>();
+
+	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
+	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
+
+	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, qname.catalog, qname.schema, qname.name);
+	result->table_oid = table_entry.oid;
+	result->total_rows = table_entry.GetStorage().GetTotalRows();
+
+	names.reserve(4);
+	return_types.reserve(4);
+	names.emplace_back("cached_row_groups");
+	return_types.emplace_back(LogicalType {LogicalTypeId::INTEGER});
+	names.emplace_back("total_row_groups");
+	return_types.emplace_back(LogicalType {LogicalTypeId::INTEGER});
+	names.emplace_back("qualifying_vectors");
+	return_types.emplace_back(LogicalType {LogicalTypeId::INTEGER});
+	names.emplace_back("total_vectors");
+	return_types.emplace_back(LogicalType {LogicalTypeId::INTEGER});
+
+	return result;
+}
+
+unique_ptr<GlobalTableFunctionState> ConditionCacheInfoInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_uniq<ConditionCacheInfoState>();
+}
+
+void ConditionCacheInfoExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &gstate = data_p.global_state->Cast<ConditionCacheInfoState>();
+	if (gstate.done) {
+		return;
+	}
+	gstate.done = true;
+
+	const auto &bind_data = data_p.bind_data->Cast<ConditionCacheInfoBindData>();
+	CacheKey key {bind_data.table_oid, bind_data.predicate_sql};
+	auto store = ConditionCacheStore::GetOrCreate(context);
+	auto entry = store->Lookup(context, key);
+
+	output.SetCardinality(1);
+	if (entry) {
+		auto stats = entry->ComputeStats(bind_data.total_rows);
+		output.data[0].SetValue(0, Value::INTEGER(static_cast<int32_t>(stats.qualifying_row_groups)));
+		output.data[1].SetValue(0, Value::INTEGER(static_cast<int32_t>(stats.total_row_groups)));
+		output.data[2].SetValue(0, Value::INTEGER(static_cast<int32_t>(stats.qualifying_vectors)));
+		output.data[3].SetValue(0, Value::INTEGER(static_cast<int32_t>(stats.total_vectors)));
+	} else {
+		for (idx_t col = 0; col < 4; ++col) {
+			output.data[col].SetValue(0, Value::INTEGER(0));
+		}
+	}
+}
+
+TableFunction ConditionCacheInfoFunction() {
+	TableFunction func(
+	    "condition_cache_info",
+	    {LogicalType {LogicalTypeId::VARCHAR} /*table*/, LogicalType {LogicalTypeId::VARCHAR} /*predicate_sql*/},
+	    ConditionCacheInfoExecute, ConditionCacheInfoBind, ConditionCacheInfoInit);
 	return func;
 }
 

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -278,6 +278,9 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	CheckBinder check_binder(*binder, context, bind_data.table, table_entry.GetColumns(), bound_columns);
 	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
+	// Canonical key: bound expression normalizes whitespace and formatting
+	string canonical_key = bound_expr->ToString();
+
 	// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN for SelectExpression.
 	bound_expr =
 	    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
@@ -285,10 +288,8 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 	auto stats = entry->ComputeStats(bind_data.total_rows);
 
-	// Store in cache
-	// TODO: Use canonical predicate key (sorted expressions) so that "a AND b" and "b AND a" hit same entry
 	// TODO: Invalidate cache on table modification (INSERT/DELETE/UPDATE/VACUUM)
-	CacheKey key {bind_data.table_oid, bind_data.predicate_sql};
+	CacheKey key {bind_data.table_oid, canonical_key};
 	auto store = ConditionCacheStore::GetOrCreate(context);
 	store->Upsert(context, key, std::move(entry));
 
@@ -312,7 +313,7 @@ TableFunction ConditionCacheBuildFunction() {
 struct ConditionCacheInfoBindData : public TableFunctionData {
 	idx_t table_oid;
 	idx_t total_rows;
-	string predicate_sql;
+	string canonical_key;
 };
 
 struct ConditionCacheInfoState : public GlobalTableFunctionState {
@@ -322,7 +323,7 @@ struct ConditionCacheInfoState : public GlobalTableFunctionState {
 unique_ptr<FunctionData> ConditionCacheInfoBind(ClientContext &context, TableFunctionBindInput &input,
                                                 vector<LogicalType> &return_types, vector<string> &names) {
 	auto result = make_uniq<ConditionCacheInfoBindData>();
-	result->predicate_sql = input.inputs[1].GetValue<string>();
+	auto predicate_sql = input.inputs[1].GetValue<string>();
 
 	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
 	Binder::BindSchemaOrCatalog(context, qname.catalog, qname.schema);
@@ -330,6 +331,16 @@ unique_ptr<FunctionData> ConditionCacheInfoBind(ClientContext &context, TableFun
 	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, qname.catalog, qname.schema, qname.name);
 	result->table_oid = table_entry.oid;
 	result->total_rows = table_entry.GetStorage().GetTotalRows();
+
+	// Parse and bind predicate to produce a canonical key
+	auto parsed_exprs = Parser::ParseExpressionList(predicate_sql);
+	if (!parsed_exprs.empty()) {
+		auto binder = Binder::CreateBinder(context);
+		physical_index_set_t bound_columns;
+		CheckBinder check_binder(*binder, context, qname.name, table_entry.GetColumns(), bound_columns);
+		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+		result->canonical_key = bound_expr->ToString();
+	}
 
 	names.reserve(4);
 	return_types.reserve(4);
@@ -357,7 +368,7 @@ void ConditionCacheInfoExecute(ClientContext &context, TableFunctionInput &data_
 	gstate.done = true;
 
 	const auto &bind_data = data_p.bind_data->Cast<ConditionCacheInfoBindData>();
-	CacheKey key {bind_data.table_oid, bind_data.predicate_sql};
+	CacheKey key {bind_data.table_oid, bind_data.canonical_key};
 	auto store = ConditionCacheStore::GetOrCreate(context);
 	auto entry = store->Lookup(context, key);
 

--- a/test/sql/condition_cache_info.test
+++ b/test/sql/condition_cache_info.test
@@ -44,6 +44,17 @@ SELECT * FROM condition_cache_info('main.t', 'val = 42');
 ----
 5	5	245	245
 
+# Canonical key: different whitespace hits same cache entry
+query IIII
+SELECT * FROM condition_cache_info('t', 'val=42');
+----
+5	5	245	245
+
+query IIII
+SELECT * FROM condition_cache_info('t', 'val  =   42');
+----
+5	5	245	245
+
 # Nonexistent table throws error
 statement error
 SELECT * FROM condition_cache_info('nonexistent', 'val = 42');

--- a/test/sql/condition_cache_info.test
+++ b/test/sql/condition_cache_info.test
@@ -1,0 +1,51 @@
+# name: test/sql/condition_cache_info.test
+# description: Test condition_cache_info table function
+# group: [sql]
+
+require query_condition_cache
+
+statement ok
+CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i);
+
+# No cache entry yet
+query IIII
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+0	0	0	0
+
+# Build cache
+statement ok
+SELECT * FROM condition_cache_build('t', 'val = 42');
+
+# Cache entry exists
+query IIII
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+5	5	245	245
+
+# Different predicate has no cache
+query IIII
+SELECT * FROM condition_cache_info('t', 'val = 99');
+----
+0	0	0	0
+
+# Selective predicate
+statement ok
+SELECT * FROM condition_cache_build('t', 'id < 3000');
+
+query IIII
+SELECT * FROM condition_cache_info('t', 'id < 3000');
+----
+1	5	2	245
+
+# Qualified table name works
+query IIII
+SELECT * FROM condition_cache_info('main.t', 'val = 42');
+----
+5	5	245	245
+
+# Nonexistent table throws error
+statement error
+SELECT * FROM condition_cache_info('nonexistent', 'val = 42');
+----
+Table with name nonexistent does not exist


### PR DESCRIPTION
## Summary

This PR adds the `condition_cache_info(table_name, predicate)` table function, which returns cache statistics for a given (table, predicate) pair using `ComputeStats`. This provides a SQL interface to inspect the current cache state for users and for validating cache correctness after DML operations.

### Example Usage

```sql
-- Before building cache: all zeros
SELECT * FROM condition_cache_info('t', 'val = 42');
┌───────────────────┬──────────────────┬────────────────────┬───────────────┐
│ cached_row_groups │ total_row_groups │ qualifying_vectors │ total_vectors │
│       int32       │      int32       │       int32        │     int32     │
├───────────────────┼──────────────────┼────────────────────┼───────────────┤
│                 0 │                0 │                  0 │             0 │
└───────────────────┴──────────────────┴────────────────────┴───────────────┘

-- After building cache
SELECT * FROM condition_cache_build('t', 'val = 42');
SELECT * FROM condition_cache_info('t', 'val = 42');
┌───────────────────┬──────────────────┬────────────────────┬───────────────┐
│ cached_row_groups │ total_row_groups │ qualifying_vectors │ total_vectors │
│       int32       │      int32       │       int32        │     int32     │
├───────────────────┼──────────────────┼────────────────────┼───────────────┤
│                 5 │                5 │                245 │           245 │
└───────────────────┴──────────────────┴────────────────────┴───────────────┘
```
### Note
This function is intended for inspecting cache state and validating cache invalidation after DML operations (INSERT/UPDATE/DELETE).


