### PR TITLE
Add CacheExpressionFilter for cache-based pruning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(src/include)
 
 set(EXTENSION_SOURCES
     src/query_condition_cache_extension.cpp
+    src/query_condition_cache_filter.cpp
     src/query_condition_cache_functions.cpp src/query_condition_cache_state.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})

--- a/src/include/query_condition_cache_filter.hpp
+++ b/src/include/query_condition_cache_filter.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/planner/expression.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
+
+namespace duckdb {
+
+// Holds a shared_ptr to the ConditionCacheEntry so the filter function
+// and CheckStatistics can access the bitvectors during execution.
+struct ConditionCacheFilterBindData : public FunctionData {
+	shared_ptr<ConditionCacheEntry> cache_entry;
+
+	explicit ConditionCacheFilterBindData(shared_ptr<ConditionCacheEntry> entry);
+
+	unique_ptr<FunctionData> Copy() const override;
+	bool Equals(const FunctionData &other_p) const override;
+};
+
+// Called during plan deserialization/verification when the optimizer's bind data
+// is not available. Returns an empty cache entry that passes all rows through.
+unique_ptr<FunctionData> ConditionCacheFilterBind(ClientContext &context, ScalarFunction &bound_function,
+                                                  vector<unique_ptr<Expression>> &arguments);
+
+// Per-thread local state (placeholder for future use)
+struct ConditionCacheFilterState : public FunctionLocalState {};
+
+unique_ptr<FunctionLocalState> ConditionCacheFilterInit(ExpressionState &state, const BoundFunctionExpression &expr,
+                                                        FunctionData *bind_data);
+
+// Vector-level filter: takes a ROW_ID column as input, looks up the bitvector
+// for that row group + vector index, and returns a constant BOOLEAN for the
+// entire vector. Defaults to true for row groups not in cache.
+void ConditionCacheFilterFn(DataChunk &args, ExpressionState &state, Vector &result);
+
+// Row-group level pruning via CheckStatistics. If all row groups covered by
+// the stats range are cached and empty, returns FILTER_ALWAYS_FALSE to skip
+// the entire row group. Otherwise returns NO_PRUNING_POSSIBLE.
+class CacheExpressionFilter : public ExpressionFilter {
+public:
+	shared_ptr<ConditionCacheEntry> cache_entry;
+
+	CacheExpressionFilter(unique_ptr<Expression> expr, shared_ptr<ConditionCacheEntry> entry);
+
+	FilterPropagateResult CheckStatistics(BaseStatistics &stats) const override;
+	unique_ptr<TableFilter> Copy() const override;
+};
+
+} // namespace duckdb

--- a/src/include/query_condition_cache_filter.hpp
+++ b/src/include/query_condition_cache_filter.hpp
@@ -25,9 +25,6 @@ struct ConditionCacheFilterBindData : public FunctionData {
 unique_ptr<FunctionData> ConditionCacheFilterBind(ClientContext &context, ScalarFunction &bound_function,
                                                   vector<unique_ptr<Expression>> &arguments);
 
-// Per-thread local state (placeholder for future use)
-struct ConditionCacheFilterState : public FunctionLocalState {};
-
 unique_ptr<FunctionLocalState> ConditionCacheFilterInit(ExpressionState &state, const BoundFunctionExpression &expr,
                                                         FunctionData *bind_data);
 

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -57,6 +57,7 @@ struct CacheEntryStats {
 
 // A single cache entry: the bitvectors for one (table, predicate) combination.
 struct ConditionCacheEntry : public ObjectCacheEntry {
+	mutex lock;
 	unordered_map<idx_t, RowGroupFilter> bitvectors; // rg_idx -> bitvector
 
 	static string ObjectType() {

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "concurrency/annotated_lock.hpp"
+#include "concurrency/annotated_mutex.hpp"
+#include "concurrency/thread_annotation.hpp"
+
 #include "duckdb/common/array.hpp"
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/unordered_map.hpp"
@@ -56,8 +60,8 @@ struct CacheEntryStats {
 
 // A single cache entry: the bitvectors for one (table, predicate) combination.
 struct ConditionCacheEntry : public ObjectCacheEntry {
-	mutex lock;
-	unordered_map<idx_t, RowGroupFilter> bitvectors; // rg_idx -> bitvector
+	concurrency::mutex lock;
+	unordered_map<idx_t, RowGroupFilter> bitvectors DUCKDB_GUARDED_BY(lock); // rg_idx -> bitvector
 
 	static string ObjectType() {
 		return "query_condition_cache_entry";

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -2,9 +2,10 @@
 
 #include "query_condition_cache_extension.hpp"
 
-#include "duckdb/main/extension/extension_loader.hpp"
-#include "duckdb/main/config.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "query_condition_cache_filter.hpp"
 #include "query_condition_cache_functions.hpp"
 
 namespace duckdb {
@@ -21,6 +22,12 @@ void EnableQueryConditionCacheCallback(ClientContext &context, SetScope scope, V
 void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(ConditionCacheBuildFunction());
 	loader.RegisterFunction(ConditionCacheInfoFunction());
+
+	// Register the internal filter function so it survives plan serialization/verification
+	ScalarFunction cache_filter_func("__condition_cache_filter", {LogicalType {LogicalTypeId::BIGINT}},
+	                                 LogicalType {LogicalTypeId::BOOLEAN}, ConditionCacheFilterFn,
+	                                 ConditionCacheFilterBind, nullptr, nullptr, ConditionCacheFilterInit);
+	loader.RegisterFunction(cache_filter_func);
 
 	// Register extension settings
 	auto &db_instance = loader.GetDatabaseInstance();

--- a/src/query_condition_cache_filter.cpp
+++ b/src/query_condition_cache_filter.cpp
@@ -1,0 +1,90 @@
+#include "query_condition_cache_filter.hpp"
+
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+namespace duckdb {
+
+ConditionCacheFilterBindData::ConditionCacheFilterBindData(shared_ptr<ConditionCacheEntry> entry)
+    : cache_entry(std::move(entry)) {
+}
+
+unique_ptr<FunctionData> ConditionCacheFilterBindData::Copy() const {
+	return make_uniq<ConditionCacheFilterBindData>(cache_entry);
+}
+
+bool ConditionCacheFilterBindData::Equals(const FunctionData &other_p) const {
+	auto &other = other_p.Cast<ConditionCacheFilterBindData>();
+	return cache_entry == other.cache_entry;
+}
+
+// Returns an empty cache entry so the filter passes all rows through,
+// since the optimizer's bind data is not available during plan verification.
+unique_ptr<FunctionData> ConditionCacheFilterBind(ClientContext &context, ScalarFunction &bound_function,
+                                                  vector<unique_ptr<Expression>> &arguments) {
+	auto empty_entry = make_shared_ptr<ConditionCacheEntry>();
+	return make_uniq<ConditionCacheFilterBindData>(std::move(empty_entry));
+}
+
+unique_ptr<FunctionLocalState> ConditionCacheFilterInit(ExpressionState &state, const BoundFunctionExpression &expr,
+                                                        FunctionData *bind_data) {
+	return make_uniq<ConditionCacheFilterState>();
+}
+
+void ConditionCacheFilterFn(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<ConditionCacheFilterBindData>();
+	auto &entry = *bind_data.cache_entry;
+
+	auto &input_vec = args.data[0];
+
+	// All row_ids in a single vector belong to the same row group + vector range,
+	// so checking the first row_id is sufficient.
+	UnifiedVectorFormat vdata;
+	input_vec.ToUnifiedFormat(args.size(), vdata);
+	auto row_ids = UnifiedVectorFormat::GetData<int64_t>(vdata);
+
+	auto first_idx = vdata.sel->get_index(0);
+	int64_t first_row_id = row_ids[first_idx];
+
+	idx_t rg_idx = NumericCast<idx_t>(first_row_id) / DEFAULT_ROW_GROUP_SIZE;
+	idx_t vec_idx = (NumericCast<idx_t>(first_row_id) % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
+	bool passes = true;
+	auto it = entry.bitvectors.find(rg_idx);
+	if (it != entry.bitvectors.end()) {
+		passes = it->second.VectorHasRows(vec_idx);
+	}
+
+	result.Reference(Value::BOOLEAN(passes));
+}
+
+CacheExpressionFilter::CacheExpressionFilter(unique_ptr<Expression> expr_p, shared_ptr<ConditionCacheEntry> entry)
+    : ExpressionFilter(std::move(expr_p)), cache_entry(std::move(entry)) {
+}
+
+FilterPropagateResult CacheExpressionFilter::CheckStatistics(BaseStatistics &stats) const {
+	if (!NumericStats::HasMinMax(stats)) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+
+	auto min_val = NumericStats::GetMin<int64_t>(stats);
+	auto max_val = NumericStats::GetMax<int64_t>(stats);
+
+	idx_t min_rg = NumericCast<idx_t>(min_val) / DEFAULT_ROW_GROUP_SIZE;
+	idx_t max_rg = NumericCast<idx_t>(max_val) / DEFAULT_ROW_GROUP_SIZE;
+
+	// If any row group is not in cache (e.g. newly inserted) or has matching vectors, we can't prune
+	for (idx_t rg = min_rg; rg <= max_rg; ++rg) {
+		auto it = cache_entry->bitvectors.find(rg);
+		if (it == cache_entry->bitvectors.end() || !it->second.IsEmpty()) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+	}
+	return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+}
+
+unique_ptr<TableFilter> CacheExpressionFilter::Copy() const {
+	return make_uniq<CacheExpressionFilter>(expr->Copy(), cache_entry);
+}
+
+} // namespace duckdb

--- a/src/query_condition_cache_filter.cpp
+++ b/src/query_condition_cache_filter.cpp
@@ -33,8 +33,11 @@ unique_ptr<FunctionLocalState> ConditionCacheFilterInit(ExpressionState &state, 
 }
 
 void ConditionCacheFilterFn(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.size() > 0);
+	D_ASSERT(args.ColumnCount() > 0);
 	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<ConditionCacheFilterBindData>();
 	auto &entry = *bind_data.cache_entry;
+	lock_guard<mutex> guard(entry.lock);
 
 	auto &input_vec = args.data[0];
 
@@ -63,6 +66,7 @@ CacheExpressionFilter::CacheExpressionFilter(unique_ptr<Expression> expr_p, shar
 }
 
 FilterPropagateResult CacheExpressionFilter::CheckStatistics(BaseStatistics &stats) const {
+	lock_guard<mutex> guard(cache_entry->lock);
 	if (!NumericStats::HasMinMax(stats)) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}

--- a/src/query_condition_cache_filter.cpp
+++ b/src/query_condition_cache_filter.cpp
@@ -27,6 +27,9 @@ unique_ptr<FunctionData> ConditionCacheFilterBind(ClientContext &context, Scalar
 	return make_uniq<ConditionCacheFilterBindData>(std::move(empty_entry));
 }
 
+// Per-thread local state (placeholder for future use)
+struct ConditionCacheFilterState : public FunctionLocalState {};
+
 unique_ptr<FunctionLocalState> ConditionCacheFilterInit(ExpressionState &state, const BoundFunctionExpression &expr,
                                                         FunctionData *bind_data) {
 	return make_uniq<ConditionCacheFilterState>();

--- a/src/query_condition_cache_filter.cpp
+++ b/src/query_condition_cache_filter.cpp
@@ -37,7 +37,7 @@ void ConditionCacheFilterFn(DataChunk &args, ExpressionState &state, Vector &res
 	D_ASSERT(args.ColumnCount() > 0);
 	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<ConditionCacheFilterBindData>();
 	auto &entry = *bind_data.cache_entry;
-	lock_guard<mutex> guard(entry.lock);
+	concurrency::lock_guard<concurrency::mutex> guard(entry.lock);
 
 	auto &input_vec = args.data[0];
 
@@ -66,7 +66,7 @@ CacheExpressionFilter::CacheExpressionFilter(unique_ptr<Expression> expr_p, shar
 }
 
 FilterPropagateResult CacheExpressionFilter::CheckStatistics(BaseStatistics &stats) const {
-	lock_guard<mutex> guard(cache_entry->lock);
+	concurrency::lock_guard<concurrency::mutex> guard(cache_entry->lock);
 	if (!NumericStats::HasMinMax(stats)) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -6,7 +6,8 @@ include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
 set(QUERY_CACHE_UNITTEST_OBJECTS
-    main.cpp test_bitvector.cpp test_build_cache_entry.cpp test_cache_store.cpp)
+    main.cpp test_bitvector.cpp test_build_cache_entry.cpp test_cache_store.cpp
+    test_filter.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})
 

--- a/test/unittest/test_cache_store.cpp
+++ b/test/unittest/test_cache_store.cpp
@@ -4,7 +4,7 @@
 #include "duckdb/common/exception.hpp"
 #include "test_helpers.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
 TEST_CASE("ConditionCacheStore - basic operations", "[cache_store]") {
 	DuckDB db;
@@ -58,3 +58,5 @@ TEST_CASE("ConditionCacheStore - basic operations", "[cache_store]") {
 		REQUIRE_THROWS_AS(store->Upsert(context, {1, "col:>5"}, nullptr), InvalidInputException);
 	}
 }
+
+} // namespace duckdb

--- a/test/unittest/test_filter.cpp
+++ b/test/unittest/test_filter.cpp
@@ -1,0 +1,49 @@
+#include "catch/catch.hpp"
+#include "query_condition_cache_filter.hpp"
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/storage/statistics/numeric_stats.hpp"
+
+namespace duckdb {
+
+TEST_CASE("CacheExpressionFilter - CheckStatistics", "[query_condition_cache]") {
+	// Build a cache entry with qualifying vectors in row group 0 and 2,
+	// and an explicitly cached empty row group 1.
+	auto entry = make_shared_ptr<ConditionCacheEntry>();
+	entry->bitvectors[0].SetVector(0);
+	entry->bitvectors[0].SetVector(5);
+	entry->bitvectors[1];
+	entry->bitvectors[2].SetVector(10);
+
+	// Create a dummy expression for the filter (won't be evaluated in stats check)
+	auto dummy_expr = make_uniq<BoundReferenceExpression>(LogicalType {LogicalTypeId::BIGINT}, 0);
+	CacheExpressionFilter filter(std::move(dummy_expr), entry);
+
+	SECTION("row group with qualifying vectors: no pruning") {
+		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
+		NumericStats::SetMin(stats, Value::BIGINT(0));
+		NumericStats::SetMax(stats, Value::BIGINT(100));
+		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::NO_PRUNING_POSSIBLE);
+	}
+
+	SECTION("known-empty row group: prune") {
+		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
+		NumericStats::SetMin(stats, Value::BIGINT(122880));
+		NumericStats::SetMax(stats, Value::BIGINT(200000));
+		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::FILTER_ALWAYS_FALSE);
+	}
+
+	SECTION("row group 2 with qualifying vectors: no pruning") {
+		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
+		NumericStats::SetMin(stats, Value::BIGINT(245760));
+		NumericStats::SetMax(stats, Value::BIGINT(300000));
+		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::NO_PRUNING_POSSIBLE);
+	}
+
+	SECTION("stats without min/max: no pruning") {
+		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
+		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::NO_PRUNING_POSSIBLE);
+	}
+}
+} // namespace duckdb


### PR DESCRIPTION
## Summary

This PR adds `CacheExpressionFilter`, a two-level filter mechanism that uses cached bitvectors to skip scanning data that has no qualifying rows.

- **Row-group level** (`CheckStatistics`): If all row groups in the stats range are cached and have no matches, returns `FILTER_ALWAYS_FALSE` to skip the entire row group.
- **Vector level** (`ConditionCacheFilterFn`): For each vector, checks the bitvector and returns a constant boolean — `false` skips the vector entirely.

The filter defaults to pass-through for row groups not in the cache (e.g. newly inserted data) to ensure correctness.

## Note
 This PR only implements the filter logic. It is not yet injected into query plans — the upcoming `QueryConditionCacheOptimizer` PR will inject `CacheExpressionFilter` into `LogicalGet` nodes during the post-optimize phase, making the cache automatically applied when `SET use_query_condition_cache = true`.
