### PR TITLE
Add optimizer pre-optimize and predicate key normalization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,9 @@ include_directories(src/include)
 
 set(EXTENSION_SOURCES
     src/query_condition_cache_extension.cpp
-    src/query_condition_cache_functions.cpp src/query_condition_cache_state.cpp)
+    src/query_condition_cache_functions.cpp
+    src/query_condition_cache_optimizer.cpp
+    src/query_condition_cache_state.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,7 @@ include_directories(src/include)
 set(EXTENSION_SOURCES
     src/query_condition_cache_extension.cpp
     src/query_condition_cache_functions.cpp
-    src/query_condition_cache_optimizer.cpp
-    src/query_condition_cache_state.cpp)
+    src/query_condition_cache_optimizer.cpp src/query_condition_cache_state.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 include_directories(src/include)
 
 set(EXTENSION_SOURCES
+    src/predicate_key_utils.cpp
     src/query_condition_cache_extension.cpp
     src/query_condition_cache_filter.cpp
     src/query_condition_cache_functions.cpp

--- a/Makefile
+++ b/Makefile
@@ -9,21 +9,21 @@ include extension-ci-tools/makefiles/duckdb_extension.Makefile
 
 test_release_all:
 	@echo "Running tests from duckdb/test..."
-	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/enable_query_condition_cache.json ./build/release/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
+	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/use_query_condition_cache.json ./build/release/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
 	@echo "Running tests from test/sql..."
-	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/enable_query_condition_cache.json ./build/release/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
+	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/use_query_condition_cache.json ./build/release/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
 
 test_debug_all:
 	@echo "Running tests from duckdb/test..."
-	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/enable_query_condition_cache.json ./build/debug/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
+	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/use_query_condition_cache.json ./build/debug/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
 	@echo "Running tests from test/sql..."
-	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/enable_query_condition_cache.json ./build/debug/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
+	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/use_query_condition_cache.json ./build/debug/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
 
 test_reldebug_all:
 	@echo "Running tests from duckdb/test..."
-	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/enable_query_condition_cache.json ./build/reldebug/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
+	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/use_query_condition_cache.json ./build/reldebug/$(TEST_PATH) --test-dir $(PROJ_DIR)duckdb "test/*"
 	@echo "Running tests from test/sql..."
-	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/enable_query_condition_cache.json ./build/reldebug/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
+	DUCKDB_TEST_CONFIG=$(PROJ_DIR)test/configs/use_query_condition_cache.json ./build/reldebug/$(TEST_PATH) --test-dir $(PROJ_DIR) "$(TESTS_BASE_DIRECTORY)*"
 
 format-all: format
 	find test/unittest -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i

--- a/src/include/predicate_key_utils.hpp
+++ b/src/include/predicate_key_utils.hpp
@@ -7,12 +7,14 @@ namespace duckdb {
 class DuckTableEntry;
 
 // Parse a predicate SQL string, bind it against a table using CheckBinder,
-// and return the bound expression. Returns nullptr if parsing fails.
+// and return the bound expression. Returns nullptr if predicate_sql is empty
+// or parsing fails.
 unique_ptr<Expression> BindPredicate(ClientContext &context, DuckTableEntry &table_entry, const string &predicate_sql);
 
 // Compute a canonical cache key string from a predicate SQL.
 // Parses, binds, normalizes (comparison operand order + conjunction sort),
-// and returns the normalized ToString(). Returns empty string on failure.
+// and returns the normalized ToString(). Returns empty string if predicate_sql
+// is empty or parsing fails.
 string ComputeCanonicalPredicateKey(ClientContext &context, DuckTableEntry &table_entry, const string &predicate_sql);
 
 // Normalize a bound expression tree in-place for canonical cache key generation.

--- a/src/include/predicate_key_utils.hpp
+++ b/src/include/predicate_key_utils.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "duckdb/planner/expression.hpp"
+
+namespace duckdb {
+
+class DuckTableEntry;
+
+// Parse a predicate SQL string, bind it against a table using CheckBinder,
+// and return the bound expression. Returns nullptr if parsing fails.
+unique_ptr<Expression> BindPredicate(ClientContext &context, DuckTableEntry &table_entry, const string &predicate_sql);
+
+// Compute a canonical cache key string from a predicate SQL.
+// Parses, binds, normalizes (comparison operand order + conjunction sort),
+// and returns the normalized ToString(). Returns empty string on failure.
+string ComputeCanonicalPredicateKey(ClientContext &context, DuckTableEntry &table_entry, const string &predicate_sql);
+
+// Normalize a bound expression tree in-place for canonical cache key generation.
+// Ensures equivalent predicates produce the same ToString() output:
+//   - Comparison operands: constants moved to the right ("42 = val" -> "val = 42")
+//   - Conjunction children (AND/OR): sorted by ToString() ("b = 2 OR a = 1" -> "a = 1 OR b = 2")
+void NormalizeExpressionForCacheKey(Expression &expr);
+
+} // namespace duckdb

--- a/src/include/query_condition_cache_functions.hpp
+++ b/src/include/query_condition_cache_functions.hpp
@@ -9,12 +9,6 @@ namespace duckdb {
 class DuckTableEntry;
 class Expression;
 
-// Normalize a bound expression tree in-place for canonical cache key generation.
-// Ensures equivalent predicates produce the same ToString() output:
-//   - Comparison operands: constants moved to the right ("42 = val" → "val = 42")
-//   - Conjunction children (AND/OR): sorted by ToString() ("b = 2 OR a = 1" -> "a = 1 OR b = 2")
-void NormalizeExpressionForKey(Expression &expr);
-
 // TODO: Exposed for future reuse and C++ unit testing.
 // Scan all rows in the table, evaluate bound_expr, and build a ConditionCacheEntry
 // recording which vectors contain qualifying rows.

--- a/src/include/query_condition_cache_functions.hpp
+++ b/src/include/query_condition_cache_functions.hpp
@@ -9,9 +9,10 @@ namespace duckdb {
 class DuckTableEntry;
 class Expression;
 
-// Normalize comparison operand order in-place: put foldable constants on the right
-// so that "42 = val" and "val = 42" produce the same ToString() for cache key.
-// Reference: duckdb/src/optimizer/rule/comparison_simplification.cpp
+// Normalize a bound expression tree in-place for canonical cache key generation.
+// Ensures equivalent predicates produce the same ToString() output:
+//   - Comparison operands: constants moved to the right ("42 = val" → "val = 42")
+//   - Conjunction children (AND/OR): sorted by ToString() ("b = 2 OR a = 1" -> "a = 1 OR b = 2")
 void NormalizeExpressionForKey(Expression &expr);
 
 // TODO: Exposed for future reuse and C++ unit testing.

--- a/src/include/query_condition_cache_functions.hpp
+++ b/src/include/query_condition_cache_functions.hpp
@@ -9,6 +9,11 @@ namespace duckdb {
 class DuckTableEntry;
 class Expression;
 
+// Normalize comparison operand order in-place: put foldable constants on the right
+// so that "42 = val" and "val = 42" produce the same ToString() for cache key.
+// Reference: duckdb/src/optimizer/rule/comparison_simplification.cpp
+void NormalizeExpressionForKey(Expression &expr);
+
 // TODO: Exposed for future reuse and C++ unit testing.
 // Scan all rows in the table, evaluate bound_expr, and build a ConditionCacheEntry
 // recording which vectors contain qualifying rows.

--- a/src/include/query_condition_cache_optimizer.hpp
+++ b/src/include/query_condition_cache_optimizer.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/main/client_context_state.hpp"
+#include "duckdb/optimizer/optimizer_extension.hpp"
+
+namespace duckdb {
+
+class LogicalGet;
+
+// Query-scoped state for passing cache entries between pre-optimize and post-optimize phases.
+// Stored in ClientContext::registered_state; automatically cleared on QueryEnd.
+struct CacheOptimizerQueryState : public ClientContextState {
+	// Maps table_index -> cache entry for tables matched during pre-optimize.
+	// Consumed by post-optimize to inject cache filters.
+	unordered_map<idx_t, shared_ptr<ConditionCacheEntry>> cache_apply_pending;
+
+	void QueryEnd(ClientContext &context, optional_ptr<ErrorData> error) override {
+		cache_apply_pending.clear();
+	}
+};
+
+class QueryConditionCacheOptimizer : public OptimizerExtension {
+public:
+	QueryConditionCacheOptimizer();
+
+	// Pre-optimize: compute canonical predicate keys before FilterPushdown splits the WHERE clause.
+	// On cache miss, builds cache inline so the first query benefits immediately.
+	static void PreOptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
+
+	// Post-optimize: inject cache filters into LogicalGet nodes that were matched pre-optimize.
+	static void OptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
+
+private:
+	static bool IsSettingEnabled(ClientContext &context);
+
+	// Walk plan before FilterPushdown: find LogicalFilter -> LogicalGet, compute key, lookup/build cache
+	static void PreOptimizeWalk(ClientContext &context, unique_ptr<LogicalOperator> &plan, bool inside_dml,
+	                            CacheOptimizerQueryState &state);
+
+	// Compute a canonical predicate key via parse+bind normalization,
+	// matching the key format used by condition_cache_build/info.
+	static CacheKey ComputePredicateKey(ClientContext &context, idx_t table_oid,
+	                                    const vector<unique_ptr<Expression>> &expressions, LogicalGet &get);
+
+	// Build cache entry for a predicate on a table
+	static shared_ptr<ConditionCacheEntry>
+	BuildCacheForPredicate(ClientContext &context, const vector<unique_ptr<Expression>> &expressions, LogicalGet &get);
+};
+
+} // namespace duckdb

--- a/src/include/query_condition_cache_optimizer.hpp
+++ b/src/include/query_condition_cache_optimizer.hpp
@@ -7,11 +7,14 @@
 
 namespace duckdb {
 
+class DuckTableEntry;
 class LogicalGet;
 
 // Query-scoped state for passing cache entries between pre-optimize and post-optimize phases.
 // Stored in ClientContext::registered_state; automatically cleared on QueryEnd.
 struct CacheOptimizerQueryState : public ClientContextState {
+	static constexpr const char *NAME = "qcc_optimizer_state";
+
 	// Maps table_index -> cache entry for tables matched during pre-optimize.
 	// Consumed by post-optimize to inject cache filters.
 	unordered_map<idx_t, shared_ptr<ConditionCacheEntry>> cache_apply_pending;
@@ -47,6 +50,9 @@ private:
 	// Build cache entry for a predicate on a table
 	static shared_ptr<ConditionCacheEntry>
 	BuildCacheForPredicate(ClientContext &context, const vector<unique_ptr<Expression>> &expressions, LogicalGet &get);
+
+	// Reconstruct SQL from filter expressions, sort for alphabetical ordering
+	static string ReconstructPredicateSQL(const vector<unique_ptr<Expression>> &expressions);
 };
 
 } // namespace duckdb

--- a/src/predicate_key_utils.cpp
+++ b/src/predicate_key_utils.cpp
@@ -1,0 +1,69 @@
+#include "predicate_key_utils.hpp"
+
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression_binder/check_binder.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+
+#include "duckdb/common/algorithm.hpp"
+
+namespace duckdb {
+
+unique_ptr<Expression> BindPredicate(ClientContext &context, DuckTableEntry &table_entry, const string &predicate_sql) {
+	auto parsed_exprs = Parser::ParseExpressionList(predicate_sql);
+	if (parsed_exprs.empty()) {
+		return nullptr;
+	}
+	auto binder = Binder::CreateBinder(context);
+	physical_index_set_t bound_columns;
+	CheckBinder check_binder(*binder, context, table_entry.name, table_entry.GetColumns(), bound_columns);
+	return check_binder.Bind(parsed_exprs[0]);
+}
+
+// Comparison flip replicates ComparisonSimplificationRule::Apply()
+// (duckdb/src/optimizer/rule/comparison_simplification.cpp) since
+// ExpressionRewriter runs after our pre-optimize pass.
+// Bottom-up: normalize children before sorting conjunction children.
+void NormalizeExpressionForCacheKey(Expression &expr) {
+	ExpressionIterator::EnumerateChildren(expr, [](Expression &child) { NormalizeExpressionForCacheKey(child); });
+
+	// Normalize comparison operand order
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
+		auto &comp = expr.Cast<BoundComparisonExpression>();
+		if (comp.left->IsFoldable() && !comp.right->IsFoldable()) {
+			std::swap(comp.left, comp.right);
+			comp.type = FlipComparisonExpression(comp.type);
+		} else if (comp.left->IsFoldable() && comp.right->IsFoldable()) {
+			// Both constants: sort by ToString for canonical ordering
+			if (comp.left->ToString() > comp.right->ToString()) {
+				std::swap(comp.left, comp.right);
+				comp.type = FlipComparisonExpression(comp.type);
+			}
+		}
+		return;
+	}
+
+	// Sort conjunction children for canonical ordering
+	// TODO: ToString() is called O(NlogN) times during sort
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION) {
+		auto &conj = expr.Cast<BoundConjunctionExpression>();
+		sort(conj.children.begin(), conj.children.end(),
+		     [](const unique_ptr<Expression> &a, const unique_ptr<Expression> &b) {
+			     return a->ToString() < b->ToString();
+		     });
+	}
+}
+
+string ComputeCanonicalPredicateKey(ClientContext &context, DuckTableEntry &table_entry, const string &predicate_sql) {
+	auto bound_expr = BindPredicate(context, table_entry, predicate_sql);
+	if (!bound_expr) {
+		return "";
+	}
+	NormalizeExpressionForCacheKey(*bound_expr);
+	return bound_expr->ToString();
+}
+
+} // namespace duckdb

--- a/src/predicate_key_utils.cpp
+++ b/src/predicate_key_utils.cpp
@@ -13,6 +13,9 @@
 namespace duckdb {
 
 unique_ptr<Expression> BindPredicate(ClientContext &context, DuckTableEntry &table_entry, const string &predicate_sql) {
+	if (predicate_sql.empty() || predicate_sql.find_first_not_of(' ') == string::npos) {
+		return nullptr;
+	}
 	auto parsed_exprs = Parser::ParseExpressionList(predicate_sql);
 	if (parsed_exprs.empty()) {
 		return nullptr;
@@ -30,14 +33,19 @@ unique_ptr<Expression> BindPredicate(ClientContext &context, DuckTableEntry &tab
 void NormalizeExpressionForCacheKey(Expression &expr) {
 	ExpressionIterator::EnumerateChildren(expr, [](Expression &child) { NormalizeExpressionForCacheKey(child); });
 
-	// Normalize comparison operand order
+	// Normalize comparison operand order:
+	// - constant and column: put constant on right
+	// - both same kind (both foldable or both non-foldable): sort by ToString
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
 		auto &comp = expr.Cast<BoundComparisonExpression>();
-		if (comp.left->IsFoldable() && !comp.right->IsFoldable()) {
+		bool left_foldable = comp.left->IsFoldable();
+		bool right_foldable = comp.right->IsFoldable();
+		if (left_foldable && !right_foldable) {
+			// Constant on left, column on right -> swap
 			std::swap(comp.left, comp.right);
 			comp.type = FlipComparisonExpression(comp.type);
-		} else if (comp.left->IsFoldable() && comp.right->IsFoldable()) {
-			// Both constants: sort by ToString for canonical ordering
+		} else if (left_foldable == right_foldable) {
+			// Both same kind -> sort by ToString for canonical ordering
 			if (comp.left->ToString() > comp.right->ToString()) {
 				std::swap(comp.left, comp.right);
 				comp.type = FlipComparisonExpression(comp.type);

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -2,31 +2,29 @@
 
 #include "query_condition_cache_extension.hpp"
 
-#include "duckdb/main/extension/extension_loader.hpp"
-#include "duckdb/main/config.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/optimizer/optimizer_extension.hpp"
 #include "query_condition_cache_functions.hpp"
+#include "query_condition_cache_optimizer.hpp"
 
 namespace duckdb {
 
 namespace {
-// Callback to verify the setting is being accessed
-// This callback throws an exception to confirm it's being called
-void EnableQueryConditionCacheCallback(ClientContext &context, SetScope scope, Value &parameter) {
-	// Throw an error to verify this callback is being called
-	throw InvalidInputException("enable_query_condition_cache callback was called! Setting value: %s",
-	                            parameter.ToString());
-}
 
 void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(ConditionCacheBuildFunction());
 	loader.RegisterFunction(ConditionCacheInfoFunction());
 
-	// Register extension settings
-	auto &db_instance = loader.GetDatabaseInstance();
-	auto &config = DBConfig::GetConfig(db_instance);
-	config.AddExtensionOption("enable_query_condition_cache", "Enable or disable the query condition cache feature",
-	                          LogicalType {LogicalTypeId::BOOLEAN}, Value(true), EnableQueryConditionCacheCallback);
+	// Register the use_query_condition_cache setting (default: false)
+	auto &db = loader.GetDatabaseInstance();
+	auto &config = DBConfig::GetConfig(db);
+	config.AddExtensionOption("use_query_condition_cache", "Enable automatic query condition cache build and apply",
+	                          LogicalType {LogicalTypeId::BOOLEAN}, Value::BOOLEAN(false));
+
+	// Register optimizer extension
+	OptimizerExtension::Register(config, QueryConditionCacheOptimizer());
 }
 } // namespace
 

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -24,11 +24,11 @@ void LoadInternal(ExtensionLoader &loader) {
 	                                 ConditionCacheFilterBind, nullptr, nullptr, ConditionCacheFilterInit);
 	loader.RegisterFunction(cache_filter_func);
 
-	// Register the use_query_condition_cache setting (default: false)
+	// Register the use_query_condition_cache setting (default: true)
 	auto &db = loader.GetDatabaseInstance();
 	auto &config = DBConfig::GetConfig(db);
 	config.AddExtensionOption("use_query_condition_cache", "Enable automatic query condition cache build and apply",
-	                          LogicalType {LogicalTypeId::BOOLEAN}, Value::BOOLEAN(false));
+	                          LogicalType {LogicalTypeId::BOOLEAN}, Value::BOOLEAN(true));
 
 	// Register optimizer extension
 	OptimizerExtension::Register(config, QueryConditionCacheOptimizer());

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -16,6 +16,7 @@
 #include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression_binder/check_binder.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
@@ -26,6 +27,22 @@
 #include "query_condition_cache_state.hpp"
 
 namespace duckdb {
+
+void NormalizeExpressionForKey(Expression &expr) {
+	// Recursively normalize children first
+	ExpressionIterator::EnumerateChildren(expr, [](Expression &child) { NormalizeExpressionForKey(child); });
+
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_COMPARISON) {
+		return;
+	}
+	auto &comp = expr.Cast<BoundComparisonExpression>();
+	// If left side is foldable (constant) and right side is not, swap them
+	if (comp.left->IsFoldable() && !comp.right->IsFoldable()) {
+		std::swap(comp.left, comp.right);
+		comp.type = FlipComparisonExpression(comp.type);
+	}
+}
+
 namespace {
 
 // ------- condition_cache_build(table_name VARCHAR, predicate VARCHAR) -------
@@ -277,6 +294,7 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	physical_index_set_t bound_columns;
 	CheckBinder check_binder(*binder, context, bind_data.table, table_entry.GetColumns(), bound_columns);
 	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+	NormalizeExpressionForKey(*bound_expr);
 
 	// Bound expression ToString() normalizes whitespace and formatting for cache key
 	string bound_expr_str = bound_expr->ToString();
@@ -339,6 +357,7 @@ unique_ptr<FunctionData> ConditionCacheInfoBind(ClientContext &context, TableFun
 		physical_index_set_t bound_columns;
 		CheckBinder check_binder(*binder, context, qname.name, table_entry.GetColumns(), bound_columns);
 		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+		NormalizeExpressionForKey(*bound_expr);
 		result->canonical_key = bound_expr->ToString();
 	}
 

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -1,5 +1,7 @@
 #include "query_condition_cache_functions.hpp"
 
+#include "predicate_key_utils.hpp"
+
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/common/allocator.hpp"
@@ -16,11 +18,8 @@
 #include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
-#include "duckdb/planner/expression/bound_comparison_expression.hpp"
-#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression_binder/check_binder.hpp"
-#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/storage_index.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
@@ -28,34 +27,6 @@
 #include "query_condition_cache_state.hpp"
 
 namespace duckdb {
-
-// Comparison flip replicates ComparisonSimplificationRule::Apply()
-// (duckdb/src/optimizer/rule/comparison_simplification.cpp) since
-// ExpressionRewriter runs after our pre-optimize pass.
-// Bottom-up: normalize children before sorting conjunction children.
-void NormalizeExpressionForKey(Expression &expr) {
-	ExpressionIterator::EnumerateChildren(expr, [](Expression &child) { NormalizeExpressionForKey(child); });
-
-	// Normalize comparison operand order
-	if (expr.GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
-		auto &comp = expr.Cast<BoundComparisonExpression>();
-		if (comp.left->IsFoldable() && !comp.right->IsFoldable()) {
-			std::swap(comp.left, comp.right);
-			comp.type = FlipComparisonExpression(comp.type);
-		}
-		return;
-	}
-
-	// Sort conjunction children for canonical ordering
-	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION) {
-		auto &conj = expr.Cast<BoundConjunctionExpression>();
-		sort(conj.children.begin(), conj.children.end(),
-		     [](const unique_ptr<Expression> &a, const unique_ptr<Expression> &b) {
-			     return a->ToString() < b->ToString();
-		     });
-	}
-}
-
 namespace {
 
 // ------- condition_cache_build(table_name VARCHAR, predicate VARCHAR) -------
@@ -298,20 +269,12 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	auto &table_entry =
 	    Catalog::GetEntry<DuckTableEntry>(context, bind_data.catalog, bind_data.schema, bind_data.table);
 
-	// Parse predicate SQL and bind column references to table columns
-	auto parsed_exprs = Parser::ParseExpressionList(bind_data.predicate_sql);
-	if (parsed_exprs.empty()) {
+	string canonical_key = ComputeCanonicalPredicateKey(context, table_entry, bind_data.predicate_sql);
+	if (canonical_key.empty()) {
 		throw InvalidInputException("condition_cache_build: failed to parse predicate");
 	}
-	auto binder = Binder::CreateBinder(context);
-	physical_index_set_t bound_columns;
-	CheckBinder check_binder(*binder, context, bind_data.table, table_entry.GetColumns(), bound_columns);
-	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
-	NormalizeExpressionForKey(*bound_expr);
 
-	// Bound expression ToString() normalizes whitespace and formatting for cache key
-	string bound_expr_str = bound_expr->ToString();
-
+	auto bound_expr = BindPredicate(context, table_entry, bind_data.predicate_sql);
 	// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN for SelectExpression.
 	bound_expr =
 	    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
@@ -319,8 +282,7 @@ void ConditionCacheBuildExecute(ClientContext &context, TableFunctionInput &data
 	auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 	auto stats = entry->ComputeStats(bind_data.total_rows);
 
-	// TODO: Invalidate cache on table modification (INSERT/DELETE/UPDATE/VACUUM)
-	CacheKey key {bind_data.table_oid, std::move(bound_expr_str)};
+	CacheKey key {bind_data.table_oid, std::move(canonical_key)};
 	auto store = ConditionCacheStore::GetOrCreate(context);
 	store->Upsert(context, key, std::move(entry));
 
@@ -363,16 +325,7 @@ unique_ptr<FunctionData> ConditionCacheInfoBind(ClientContext &context, TableFun
 	result->table_oid = table_entry.oid;
 	result->total_rows = table_entry.GetStorage().GetTotalRows();
 
-	// Parse and bind predicate to produce a canonical key
-	auto parsed_exprs = Parser::ParseExpressionList(predicate_sql);
-	if (!parsed_exprs.empty()) {
-		auto binder = Binder::CreateBinder(context);
-		physical_index_set_t bound_columns;
-		CheckBinder check_binder(*binder, context, qname.name, table_entry.GetColumns(), bound_columns);
-		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
-		NormalizeExpressionForKey(*bound_expr);
-		result->canonical_key = bound_expr->ToString();
-	}
+	result->canonical_key = ComputeCanonicalPredicateKey(context, table_entry, predicate_sql);
 
 	names.reserve(4);
 	return_types.reserve(4);

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression_binder/check_binder.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
@@ -28,18 +29,30 @@
 
 namespace duckdb {
 
+// Comparison flip replicates ComparisonSimplificationRule::Apply()
+// (duckdb/src/optimizer/rule/comparison_simplification.cpp) since
+// ExpressionRewriter runs after our pre-optimize pass.
+// Bottom-up: normalize children before sorting conjunction children.
 void NormalizeExpressionForKey(Expression &expr) {
-	// Recursively normalize children first
 	ExpressionIterator::EnumerateChildren(expr, [](Expression &child) { NormalizeExpressionForKey(child); });
 
-	if (expr.GetExpressionClass() != ExpressionClass::BOUND_COMPARISON) {
+	// Normalize comparison operand order
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
+		auto &comp = expr.Cast<BoundComparisonExpression>();
+		if (comp.left->IsFoldable() && !comp.right->IsFoldable()) {
+			std::swap(comp.left, comp.right);
+			comp.type = FlipComparisonExpression(comp.type);
+		}
 		return;
 	}
-	auto &comp = expr.Cast<BoundComparisonExpression>();
-	// If left side is foldable (constant) and right side is not, swap them
-	if (comp.left->IsFoldable() && !comp.right->IsFoldable()) {
-		std::swap(comp.left, comp.right);
-		comp.type = FlipComparisonExpression(comp.type);
+
+	// Sort conjunction children for canonical ordering
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION) {
+		auto &conj = expr.Cast<BoundConjunctionExpression>();
+		sort(conj.children.begin(), conj.children.end(),
+		     [](const unique_ptr<Expression> &a, const unique_ptr<Expression> &b) {
+			     return a->ToString() < b->ToString();
+		     });
 	}
 }
 

--- a/src/query_condition_cache_optimizer.cpp
+++ b/src/query_condition_cache_optimizer.cpp
@@ -1,5 +1,6 @@
 #include "query_condition_cache_optimizer.hpp"
 
+#include "predicate_key_utils.hpp"
 #include "query_condition_cache_functions.hpp"
 #include "query_condition_cache_state.hpp"
 
@@ -7,10 +8,7 @@
 #include "duckdb/common/algorithm.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector.hpp"
-#include "duckdb/parser/parser.hpp"
-#include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
-#include "duckdb/planner/expression_binder/check_binder.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 
@@ -38,15 +36,10 @@ void QueryConditionCacheOptimizer::PreOptimizeFunction(OptimizerExtensionInput &
 	if (!IsSettingEnabled(input.context)) {
 		return;
 	}
-	auto query_state = input.context.registered_state->GetOrCreate<CacheOptimizerQueryState>("qcc_optimizer_state");
+	auto query_state =
+	    input.context.registered_state->GetOrCreate<CacheOptimizerQueryState>(CacheOptimizerQueryState::NAME);
 	query_state->cache_apply_pending.clear();
-	try {
-		PreOptimizeWalk(input.context, plan, /*inside_dml=*/false, *query_state);
-	} catch (...) {
-		// If anything goes wrong, clear pending entries and let the query
-		// proceed without cache optimization
-		query_state->cache_apply_pending.clear();
-	}
+	PreOptimizeWalk(input.context, plan, /*inside_dml=*/false, *query_state);
 }
 
 void QueryConditionCacheOptimizer::PreOptimizeWalk(ClientContext &context, unique_ptr<LogicalOperator> &plan,
@@ -84,15 +77,7 @@ void QueryConditionCacheOptimizer::PreOptimizeWalk(ClientContext &context, uniqu
 		return;
 	}
 
-	auto &duck_table = table->Cast<DuckTableEntry>();
-	auto &storage = duck_table.GetStorage();
-
-	// Skip caching for tables with indexes — index scans are typically more efficient
-	if (storage.HasIndexes()) {
-		return;
-	}
-
-	// Compute canonical key using parse+bind normalization (same format as condition_cache_build/info)
+	// TODO: Use std::optional when DuckDB upgrades to C++17 in v2.0
 	auto key = ComputePredicateKey(context, table->oid, filter.expressions, get);
 	if (key.filter_key.empty()) {
 		return;
@@ -102,7 +87,8 @@ void QueryConditionCacheOptimizer::PreOptimizeWalk(ClientContext &context, uniqu
 	auto entry = store->Lookup(context, key);
 
 	if (!entry) {
-		// Cache miss: build cache inline
+		// TODO: Consider building cache in the background and syncing later
+		// to avoid blocking the first query.
 		entry = BuildCacheForPredicate(context, filter.expressions, get);
 		if (entry) {
 			store->Upsert(context, key, entry);
@@ -114,6 +100,17 @@ void QueryConditionCacheOptimizer::PreOptimizeWalk(ClientContext &context, uniqu
 	}
 }
 
+// Reconstruct SQL from filter expressions, sort for alphabetical ordering.
+string QueryConditionCacheOptimizer::ReconstructPredicateSQL(const vector<unique_ptr<Expression>> &expressions) {
+	vector<string> parts;
+	parts.reserve(expressions.size());
+	for (const auto &expr : expressions) {
+		parts.push_back(expr->ToString());
+	}
+	sort(parts.begin(), parts.end());
+	return StringUtil::Join(parts, " AND ");
+}
+
 CacheKey QueryConditionCacheOptimizer::ComputePredicateKey(ClientContext &context, idx_t table_oid,
                                                            const vector<unique_ptr<Expression>> &expressions,
                                                            LogicalGet &get) {
@@ -121,30 +118,9 @@ CacheKey QueryConditionCacheOptimizer::ComputePredicateKey(ClientContext &contex
 	if (!table_ptr) {
 		return CacheKey {table_oid, ""};
 	}
-	auto &table_entry = table_ptr->Cast<DuckTableEntry>();
-
-	// Reconstruct SQL from expressions, sort for canonical ordering
-	vector<string> parts;
-	parts.reserve(expressions.size());
-	for (const auto &expr : expressions) {
-		parts.push_back(expr->ToString());
-	}
-	sort(parts.begin(), parts.end());
-	string predicate_sql = StringUtil::Join(parts, " AND ");
-
-	// Parse and bind to produce the same normalized key as condition_cache_build/info
-	auto parsed_exprs = Parser::ParseExpressionList(predicate_sql);
-	if (parsed_exprs.empty()) {
-		return CacheKey {table_oid, ""};
-	}
-
-	auto binder = Binder::CreateBinder(context);
-	physical_index_set_t bound_columns;
-	CheckBinder check_binder(*binder, context, table_entry.name, table_entry.GetColumns(), bound_columns);
-	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
-	NormalizeExpressionForKey(*bound_expr);
-
-	return CacheKey {table_oid, bound_expr->ToString()};
+	string predicate_sql = ReconstructPredicateSQL(expressions);
+	string canonical = ComputeCanonicalPredicateKey(context, table_ptr->Cast<DuckTableEntry>(), predicate_sql);
+	return CacheKey {table_oid, std::move(canonical)};
 }
 
 shared_ptr<ConditionCacheEntry> QueryConditionCacheOptimizer::BuildCacheForPredicate(
@@ -153,27 +129,12 @@ shared_ptr<ConditionCacheEntry> QueryConditionCacheOptimizer::BuildCacheForPredi
 	if (!table_ptr) {
 		return nullptr;
 	}
-
 	auto &table_entry = table_ptr->Cast<DuckTableEntry>();
-
-	// Reconstruct predicate SQL from the bound expressions
-	vector<string> parts;
-	parts.reserve(expressions.size());
-	for (const auto &expr : expressions) {
-		parts.push_back(expr->ToString());
-	}
-	string predicate_sql = StringUtil::Join(parts, " AND ");
-
-	// Parse, bind, and build cache entry (same flow as condition_cache_build)
-	auto parsed_exprs = Parser::ParseExpressionList(predicate_sql);
-	if (parsed_exprs.empty()) {
+	string predicate_sql = ReconstructPredicateSQL(expressions);
+	auto bound_expr = BindPredicate(context, table_entry, predicate_sql);
+	if (!bound_expr) {
 		return nullptr;
 	}
-
-	auto binder = Binder::CreateBinder(context);
-	physical_index_set_t bound_columns;
-	CheckBinder check_binder(*binder, context, table_entry.name, table_entry.GetColumns(), bound_columns);
-	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
 	// CheckBinder sets target_type = INTEGER, re-cast to BOOLEAN
 	bound_expr =

--- a/src/query_condition_cache_optimizer.cpp
+++ b/src/query_condition_cache_optimizer.cpp
@@ -38,8 +38,7 @@ void QueryConditionCacheOptimizer::PreOptimizeFunction(OptimizerExtensionInput &
 	if (!IsSettingEnabled(input.context)) {
 		return;
 	}
-	auto query_state =
-	    input.context.registered_state->GetOrCreate<CacheOptimizerQueryState>("qcc_optimizer_state");
+	auto query_state = input.context.registered_state->GetOrCreate<CacheOptimizerQueryState>("qcc_optimizer_state");
 	query_state->cache_apply_pending.clear();
 	try {
 		PreOptimizeWalk(input.context, plan, /*inside_dml=*/false, *query_state);
@@ -185,8 +184,7 @@ shared_ptr<ConditionCacheEntry> QueryConditionCacheOptimizer::BuildCacheForPredi
 
 // TODO: Implement PostOptimizeWalk + InjectCacheFilter to inject cache filters
 // into LogicalGet nodes using cache_apply_pending entries.
-void QueryConditionCacheOptimizer::OptimizeFunction(OptimizerExtensionInput &input,
-                                                     unique_ptr<LogicalOperator> &plan) {
+void QueryConditionCacheOptimizer::OptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
 }
 
 } // namespace duckdb

--- a/src/query_condition_cache_optimizer.cpp
+++ b/src/query_condition_cache_optimizer.cpp
@@ -1,0 +1,192 @@
+#include "query_condition_cache_optimizer.hpp"
+
+#include "query_condition_cache_functions.hpp"
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/common/algorithm.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression_binder/check_binder.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+
+namespace duckdb {
+
+QueryConditionCacheOptimizer::QueryConditionCacheOptimizer() {
+	pre_optimize_function = PreOptimizeFunction;
+	optimize_function = OptimizeFunction;
+}
+
+bool QueryConditionCacheOptimizer::IsSettingEnabled(ClientContext &context) {
+	Value val;
+	auto result = context.TryGetCurrentSetting("use_query_condition_cache", val);
+	if (!result) {
+		return false;
+	}
+	return val.GetValue<bool>();
+}
+
+// Pre-optimize runs BEFORE built-in passes (including FilterPushdown).
+// The full WHERE clause is still in LogicalFilter.expressions, so we can
+// compute a canonical key that covers the entire predicate.
+void QueryConditionCacheOptimizer::PreOptimizeFunction(OptimizerExtensionInput &input,
+                                                       unique_ptr<LogicalOperator> &plan) {
+	if (!IsSettingEnabled(input.context)) {
+		return;
+	}
+	auto query_state =
+	    input.context.registered_state->GetOrCreate<CacheOptimizerQueryState>("qcc_optimizer_state");
+	query_state->cache_apply_pending.clear();
+	try {
+		PreOptimizeWalk(input.context, plan, /*inside_dml=*/false, *query_state);
+	} catch (...) {
+		// If anything goes wrong, clear pending entries and let the query
+		// proceed without cache optimization
+		query_state->cache_apply_pending.clear();
+	}
+}
+
+void QueryConditionCacheOptimizer::PreOptimizeWalk(ClientContext &context, unique_ptr<LogicalOperator> &plan,
+                                                   bool inside_dml, CacheOptimizerQueryState &state) {
+	// Skip cache building inside DML subplans
+	bool is_dml =
+	    plan->type == LogicalOperatorType::LOGICAL_DELETE || plan->type == LogicalOperatorType::LOGICAL_UPDATE ||
+	    plan->type == LogicalOperatorType::LOGICAL_INSERT || plan->type == LogicalOperatorType::LOGICAL_MERGE_INTO;
+	bool child_inside_dml = inside_dml || is_dml;
+
+	for (auto &child : plan->children) {
+		PreOptimizeWalk(context, child, child_inside_dml, state);
+	}
+
+	if (inside_dml) {
+		return;
+	}
+
+	// Only handle direct table scans with a filter (LogicalFilter -> LogicalGet).
+	// Joins, subqueries, and other patterns are not supported currently.
+	if (plan->type != LogicalOperatorType::LOGICAL_FILTER || plan->children.empty()) {
+		return;
+	}
+	if (plan->children[0]->type != LogicalOperatorType::LOGICAL_GET) {
+		return;
+	}
+
+	auto &filter = plan->Cast<LogicalFilter>();
+	auto &get = plan->children[0]->Cast<LogicalGet>();
+	auto table = get.GetTable();
+	if (!table) {
+		return; // not a DuckDB table (e.g. system table, external)
+	}
+	if (filter.expressions.empty()) {
+		return;
+	}
+
+	auto &duck_table = table->Cast<DuckTableEntry>();
+	auto &storage = duck_table.GetStorage();
+
+	// Skip caching for tables with indexes — index scans are typically more efficient
+	if (storage.HasIndexes()) {
+		return;
+	}
+
+	// Compute canonical key using parse+bind normalization (same format as condition_cache_build/info)
+	auto key = ComputePredicateKey(context, table->oid, filter.expressions, get);
+	if (key.filter_key.empty()) {
+		return;
+	}
+
+	auto store = ConditionCacheStore::GetOrCreate(context);
+	auto entry = store->Lookup(context, key);
+
+	if (!entry) {
+		// Cache miss: build cache inline
+		entry = BuildCacheForPredicate(context, filter.expressions, get);
+		if (entry) {
+			store->Upsert(context, key, entry);
+		}
+	}
+
+	if (entry) {
+		state.cache_apply_pending[get.table_index] = std::move(entry);
+	}
+}
+
+CacheKey QueryConditionCacheOptimizer::ComputePredicateKey(ClientContext &context, idx_t table_oid,
+                                                           const vector<unique_ptr<Expression>> &expressions,
+                                                           LogicalGet &get) {
+	auto table_ptr = get.GetTable();
+	if (!table_ptr) {
+		return CacheKey {table_oid, ""};
+	}
+	auto &table_entry = table_ptr->Cast<DuckTableEntry>();
+
+	// Reconstruct SQL from expressions, sort for canonical ordering
+	vector<string> parts;
+	parts.reserve(expressions.size());
+	for (const auto &expr : expressions) {
+		parts.push_back(expr->ToString());
+	}
+	sort(parts.begin(), parts.end());
+	string predicate_sql = StringUtil::Join(parts, " AND ");
+
+	// Parse and bind to produce the same normalized key as condition_cache_build/info
+	auto parsed_exprs = Parser::ParseExpressionList(predicate_sql);
+	if (parsed_exprs.empty()) {
+		return CacheKey {table_oid, ""};
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	physical_index_set_t bound_columns;
+	CheckBinder check_binder(*binder, context, table_entry.name, table_entry.GetColumns(), bound_columns);
+	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+	NormalizeExpressionForKey(*bound_expr);
+
+	return CacheKey {table_oid, bound_expr->ToString()};
+}
+
+shared_ptr<ConditionCacheEntry> QueryConditionCacheOptimizer::BuildCacheForPredicate(
+    ClientContext &context, const vector<unique_ptr<Expression>> &expressions, LogicalGet &get) {
+	auto table_ptr = get.GetTable();
+	if (!table_ptr) {
+		return nullptr;
+	}
+
+	auto &table_entry = table_ptr->Cast<DuckTableEntry>();
+
+	// Reconstruct predicate SQL from the bound expressions
+	vector<string> parts;
+	parts.reserve(expressions.size());
+	for (const auto &expr : expressions) {
+		parts.push_back(expr->ToString());
+	}
+	string predicate_sql = StringUtil::Join(parts, " AND ");
+
+	// Parse, bind, and build cache entry (same flow as condition_cache_build)
+	auto parsed_exprs = Parser::ParseExpressionList(predicate_sql);
+	if (parsed_exprs.empty()) {
+		return nullptr;
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	physical_index_set_t bound_columns;
+	CheckBinder check_binder(*binder, context, table_entry.name, table_entry.GetColumns(), bound_columns);
+	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+
+	// CheckBinder sets target_type = INTEGER, re-cast to BOOLEAN
+	bound_expr =
+	    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
+
+	return BuildCacheEntry(context, table_entry, *bound_expr);
+}
+
+// TODO: Implement PostOptimizeWalk + InjectCacheFilter to inject cache filters
+// into LogicalGet nodes using cache_apply_pending entries.
+void QueryConditionCacheOptimizer::OptimizeFunction(OptimizerExtensionInput &input,
+                                                     unique_ptr<LogicalOperator> &plan) {
+}
+
+} // namespace duckdb

--- a/test/configs/use_query_condition_cache.json
+++ b/test/configs/use_query_condition_cache.json
@@ -1,12 +1,11 @@
 {
-  "description": "Run tests with enable_query_condition_cache setting enabled",
+  "description": "Run tests with use_query_condition_cache setting enabled",
   "statically_loaded_extensions": [
     "core_functions",
     "parquet",
-    "httpfs",
     "query_condition_cache"
   ],
   "on_init": "LOAD query_condition_cache;",
-  "on_new_connection": "SET enable_query_condition_cache = true;",
+  "on_new_connection": "SET use_query_condition_cache = true;",
   "skip_compiled": "true"
 }

--- a/test/sql/condition_cache_auto.test
+++ b/test/sql/condition_cache_auto.test
@@ -7,17 +7,7 @@ require query_condition_cache
 statement ok
 CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i);
 
-# Cache disabled by default
-query IIII
-SELECT * FROM condition_cache_info('t', 'val = 42');
-----
-0	0	0	0
-
-# Enable auto cache
-statement ok
-SET use_query_condition_cache = true;
-
-# Query triggers auto cache build
+# Cache enabled by default, query triggers auto cache build
 statement ok
 SELECT count(*) FROM t WHERE val = 42;
 

--- a/test/sql/condition_cache_auto.test
+++ b/test/sql/condition_cache_auto.test
@@ -1,0 +1,55 @@
+# name: test/sql/condition_cache_auto.test
+# description: Test automatic cache build via optimizer
+# group: [sql]
+
+require query_condition_cache
+
+statement ok
+CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i);
+
+# Cache disabled by default
+query IIII
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+0	0	0	0
+
+# Enable auto cache
+statement ok
+SET use_query_condition_cache = true;
+
+# Query triggers auto cache build
+statement ok
+SELECT count(*) FROM t WHERE val = 42;
+
+# Cache was built automatically
+query IIII
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+5	5	245	245
+
+# Different predicate gets its own cache entry
+statement ok
+SELECT count(*) FROM t WHERE id < 3000;
+
+query IIII
+SELECT * FROM condition_cache_info('t', 'id < 3000');
+----
+1	5	2	245
+
+# Disable setting, new predicates should not be cached
+statement ok
+SET use_query_condition_cache = false;
+
+statement ok
+SELECT count(*) FROM t WHERE val = 99;
+
+query IIII
+SELECT * FROM condition_cache_info('t', 'val = 99');
+----
+0	0	0	0
+
+# Previously built cache still exists
+query IIII
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+5	5	245	245

--- a/test/sql/condition_cache_build.test
+++ b/test/sql/condition_cache_build.test
@@ -62,6 +62,18 @@ SELECT * FROM condition_cache_build('bad_catalog.main.t', 'val = 42');
 ----
 Catalog "bad_catalog" does not exist
 
+# Empty predicate throws error
+statement error
+SELECT * FROM condition_cache_build('t', '');
+----
+failed to parse predicate
+
+# Whitespace-only predicate throws error
+statement error
+SELECT * FROM condition_cache_build('t', '   ');
+----
+failed to parse predicate
+
 # Non-castable column as predicate throws error
 statement ok
 CREATE TABLE t_str AS SELECT 'hello' AS name;

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -6,7 +6,8 @@ include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
 set(QUERY_CACHE_UNITTEST_OBJECTS
-    main.cpp test_bitvector.cpp test_build_cache_entry.cpp test_cache_store.cpp test_normalize_expression.cpp)
+    main.cpp test_bitvector.cpp test_build_cache_entry.cpp test_cache_store.cpp
+    test_normalize_expression.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})
 

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
 set(QUERY_CACHE_UNITTEST_OBJECTS
-    main.cpp test_bitvector.cpp test_build_cache_entry.cpp test_cache_store.cpp)
+    main.cpp test_bitvector.cpp test_build_cache_entry.cpp test_cache_store.cpp test_normalize_expression.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})
 

--- a/test/unittest/test_normalize_expression.cpp
+++ b/test/unittest/test_normalize_expression.cpp
@@ -59,10 +59,10 @@ TEST_CASE("NormalizeExpressionForCacheKey - comparison operand order", "[normali
 		REQUIRE(key1 == key2);
 	}
 
-	SECTION("no swap when both sides are columns") {
-		// Both sides are non-foldable, should stay as-is
-		auto key = ComputeCanonicalPredicateKey(context, table_entry, "id = val");
-		REQUIRE(key == ComputeCanonicalPredicateKey(context, table_entry, "id = val"));
+	SECTION("both non-foldable: sorted by ToString") {
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "id = val");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "val = id");
+		REQUIRE(key1 == key2);
 	}
 
 	SECTION("nested comparison in AND is normalized") {
@@ -129,6 +129,14 @@ TEST_CASE("NormalizeExpressionForCacheKey - comparison operand order", "[normali
 		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "1 < 2");
 		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "2 > 1");
 		REQUIRE(key1 == key2);
+	}
+
+	SECTION("empty predicate returns empty key") {
+		REQUIRE(ComputeCanonicalPredicateKey(context, table_entry, "").empty());
+	}
+
+	SECTION("whitespace-only predicate returns empty key") {
+		REQUIRE(ComputeCanonicalPredicateKey(context, table_entry, "   ").empty());
 	}
 }
 

--- a/test/unittest/test_normalize_expression.cpp
+++ b/test/unittest/test_normalize_expression.cpp
@@ -99,6 +99,30 @@ TEST_CASE("NormalizeExpressionForKey - comparison operand order", "[normalize]")
 		auto key2 = NormalizedKey(context, table_entry, "'hello' = name");
 		REQUIRE(key1 == key2);
 	}
+
+	SECTION("OR children are sorted") {
+		auto key1 = NormalizedKey(context, table_entry, "val = 42 OR val = 99");
+		auto key2 = NormalizedKey(context, table_entry, "val = 99 OR val = 42");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("AND children are sorted") {
+		auto key1 = NormalizedKey(context, table_entry, "val = 42 AND id < 100");
+		auto key2 = NormalizedKey(context, table_entry, "id < 100 AND val = 42");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("nested AND inside OR is normalized") {
+		auto key1 = NormalizedKey(context, table_entry, "(val = 42 AND id < 100) OR val = 99");
+		auto key2 = NormalizedKey(context, table_entry, "val = 99 OR (id < 100 AND val = 42)");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("reversed comparisons inside OR are normalized") {
+		auto key1 = NormalizedKey(context, table_entry, "val = 42 OR val = 99");
+		auto key2 = NormalizedKey(context, table_entry, "99 = val OR 42 = val");
+		REQUIRE(key1 == key2);
+	}
 }
 
 } // namespace duckdb

--- a/test/unittest/test_normalize_expression.cpp
+++ b/test/unittest/test_normalize_expression.cpp
@@ -1,0 +1,104 @@
+#include "catch/catch.hpp"
+#include "query_condition_cache_functions.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression_binder/check_binder.hpp"
+
+namespace duckdb {
+namespace {
+
+// Helper: parse SQL predicate, bind against table "t", normalize, return ToString()
+string NormalizedKey(ClientContext &context, DuckTableEntry &table_entry, const string &predicate_sql) {
+	auto parsed_exprs = Parser::ParseExpressionList(predicate_sql);
+	auto binder = Binder::CreateBinder(context);
+	physical_index_set_t bound_columns;
+	CheckBinder check_binder(*binder, context, table_entry.name, table_entry.GetColumns(), bound_columns);
+	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
+	NormalizeExpressionForKey(*bound_expr);
+	return bound_expr->ToString();
+}
+
+} // namespace
+
+TEST_CASE("NormalizeExpressionForKey - comparison operand order", "[normalize]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.Query("CREATE TABLE t (id INTEGER, val INTEGER, name VARCHAR)");
+
+	auto &context = *con.context;
+	con.BeginTransaction();
+	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, "t");
+
+	SECTION("equality: constant on left is swapped to right") {
+		auto key1 = NormalizedKey(context, table_entry, "val = 42");
+		auto key2 = NormalizedKey(context, table_entry, "42 = val");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("less-than / greater-than flip") {
+		auto key1 = NormalizedKey(context, table_entry, "id < 100");
+		auto key2 = NormalizedKey(context, table_entry, "100 > id");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("less-than-or-equal / greater-than-or-equal flip") {
+		auto key1 = NormalizedKey(context, table_entry, "val <= 50");
+		auto key2 = NormalizedKey(context, table_entry, "50 >= val");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("greater-than / less-than flip") {
+		auto key1 = NormalizedKey(context, table_entry, "val > 10");
+		auto key2 = NormalizedKey(context, table_entry, "10 < val");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("greater-than-or-equal / less-than-or-equal flip") {
+		auto key1 = NormalizedKey(context, table_entry, "val >= 10");
+		auto key2 = NormalizedKey(context, table_entry, "10 <= val");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("not-equal is order-independent") {
+		auto key1 = NormalizedKey(context, table_entry, "val != 0");
+		auto key2 = NormalizedKey(context, table_entry, "0 != val");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("no swap when column is already on left") {
+		auto key1 = NormalizedKey(context, table_entry, "val = 42");
+		auto key2 = NormalizedKey(context, table_entry, "val = 42");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("no swap when both sides are columns") {
+		// Both sides are non-foldable, should stay as-is
+		auto key = NormalizedKey(context, table_entry, "id = val");
+		REQUIRE(key == NormalizedKey(context, table_entry, "id = val"));
+	}
+
+	SECTION("nested comparison in AND is normalized") {
+		auto key1 = NormalizedKey(context, table_entry, "val = 42 AND id < 100");
+		auto key2 = NormalizedKey(context, table_entry, "42 = val AND 100 > id");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("nested comparison in OR is normalized") {
+		auto key1 = NormalizedKey(context, table_entry, "val = 42 OR id > 100");
+		auto key2 = NormalizedKey(context, table_entry, "42 = val OR 100 < id");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("string constant is normalized") {
+		auto key1 = NormalizedKey(context, table_entry, "name = 'hello'");
+		auto key2 = NormalizedKey(context, table_entry, "'hello' = name");
+		REQUIRE(key1 == key2);
+	}
+}
+
+} // namespace duckdb

--- a/test/unittest/test_normalize_expression.cpp
+++ b/test/unittest/test_normalize_expression.cpp
@@ -1,31 +1,14 @@
 #include "catch/catch.hpp"
-#include "query_condition_cache_functions.hpp"
+#include "predicate_key_utils.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
-#include "duckdb/parser/parser.hpp"
-#include "duckdb/planner/binder.hpp"
-#include "duckdb/planner/expression_binder/check_binder.hpp"
 
 namespace duckdb {
-namespace {
 
-// Helper: parse SQL predicate, bind against table "t", normalize, return ToString()
-string NormalizedKey(ClientContext &context, DuckTableEntry &table_entry, const string &predicate_sql) {
-	auto parsed_exprs = Parser::ParseExpressionList(predicate_sql);
-	auto binder = Binder::CreateBinder(context);
-	physical_index_set_t bound_columns;
-	CheckBinder check_binder(*binder, context, table_entry.name, table_entry.GetColumns(), bound_columns);
-	auto bound_expr = check_binder.Bind(parsed_exprs[0]);
-	NormalizeExpressionForKey(*bound_expr);
-	return bound_expr->ToString();
-}
-
-} // namespace
-
-TEST_CASE("NormalizeExpressionForKey - comparison operand order", "[normalize]") {
+TEST_CASE("NormalizeExpressionForCacheKey - comparison operand order", "[normalize]") {
 	DuckDB db(nullptr);
 	Connection con(db);
 	con.Query("CREATE TABLE t (id INTEGER, val INTEGER, name VARCHAR)");
@@ -35,92 +18,116 @@ TEST_CASE("NormalizeExpressionForKey - comparison operand order", "[normalize]")
 	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, "t");
 
 	SECTION("equality: constant on left is swapped to right") {
-		auto key1 = NormalizedKey(context, table_entry, "val = 42");
-		auto key2 = NormalizedKey(context, table_entry, "42 = val");
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "val = 42");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "42 = val");
 		REQUIRE(key1 == key2);
 	}
 
 	SECTION("less-than / greater-than flip") {
-		auto key1 = NormalizedKey(context, table_entry, "id < 100");
-		auto key2 = NormalizedKey(context, table_entry, "100 > id");
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "id < 100");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "100 > id");
 		REQUIRE(key1 == key2);
 	}
 
 	SECTION("less-than-or-equal / greater-than-or-equal flip") {
-		auto key1 = NormalizedKey(context, table_entry, "val <= 50");
-		auto key2 = NormalizedKey(context, table_entry, "50 >= val");
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "val <= 50");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "50 >= val");
 		REQUIRE(key1 == key2);
 	}
 
 	SECTION("greater-than / less-than flip") {
-		auto key1 = NormalizedKey(context, table_entry, "val > 10");
-		auto key2 = NormalizedKey(context, table_entry, "10 < val");
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "val > 10");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "10 < val");
 		REQUIRE(key1 == key2);
 	}
 
 	SECTION("greater-than-or-equal / less-than-or-equal flip") {
-		auto key1 = NormalizedKey(context, table_entry, "val >= 10");
-		auto key2 = NormalizedKey(context, table_entry, "10 <= val");
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "val >= 10");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "10 <= val");
 		REQUIRE(key1 == key2);
 	}
 
 	SECTION("not-equal is order-independent") {
-		auto key1 = NormalizedKey(context, table_entry, "val != 0");
-		auto key2 = NormalizedKey(context, table_entry, "0 != val");
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "val != 0");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "0 != val");
 		REQUIRE(key1 == key2);
 	}
 
 	SECTION("no swap when column is already on left") {
-		auto key1 = NormalizedKey(context, table_entry, "val = 42");
-		auto key2 = NormalizedKey(context, table_entry, "val = 42");
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "val = 42");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "val = 42");
 		REQUIRE(key1 == key2);
 	}
 
 	SECTION("no swap when both sides are columns") {
 		// Both sides are non-foldable, should stay as-is
-		auto key = NormalizedKey(context, table_entry, "id = val");
-		REQUIRE(key == NormalizedKey(context, table_entry, "id = val"));
+		auto key = ComputeCanonicalPredicateKey(context, table_entry, "id = val");
+		REQUIRE(key == ComputeCanonicalPredicateKey(context, table_entry, "id = val"));
 	}
 
 	SECTION("nested comparison in AND is normalized") {
-		auto key1 = NormalizedKey(context, table_entry, "val = 42 AND id < 100");
-		auto key2 = NormalizedKey(context, table_entry, "42 = val AND 100 > id");
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "val = 42 AND id < 100");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "42 = val AND 100 > id");
 		REQUIRE(key1 == key2);
 	}
 
 	SECTION("nested comparison in OR is normalized") {
-		auto key1 = NormalizedKey(context, table_entry, "val = 42 OR id > 100");
-		auto key2 = NormalizedKey(context, table_entry, "42 = val OR 100 < id");
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "val = 42 OR id > 100");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "42 = val OR 100 < id");
 		REQUIRE(key1 == key2);
 	}
 
 	SECTION("string constant is normalized") {
-		auto key1 = NormalizedKey(context, table_entry, "name = 'hello'");
-		auto key2 = NormalizedKey(context, table_entry, "'hello' = name");
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "name = 'hello'");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "'hello' = name");
 		REQUIRE(key1 == key2);
 	}
 
 	SECTION("OR children are sorted") {
-		auto key1 = NormalizedKey(context, table_entry, "val = 42 OR val = 99");
-		auto key2 = NormalizedKey(context, table_entry, "val = 99 OR val = 42");
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "val = 42 OR val = 99");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "val = 99 OR val = 42");
 		REQUIRE(key1 == key2);
 	}
 
 	SECTION("AND children are sorted") {
-		auto key1 = NormalizedKey(context, table_entry, "val = 42 AND id < 100");
-		auto key2 = NormalizedKey(context, table_entry, "id < 100 AND val = 42");
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "val = 42 AND id < 100");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "id < 100 AND val = 42");
 		REQUIRE(key1 == key2);
 	}
 
 	SECTION("nested AND inside OR is normalized") {
-		auto key1 = NormalizedKey(context, table_entry, "(val = 42 AND id < 100) OR val = 99");
-		auto key2 = NormalizedKey(context, table_entry, "val = 99 OR (id < 100 AND val = 42)");
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "(val = 42 AND id < 100) OR val = 99");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "val = 99 OR (id < 100 AND val = 42)");
 		REQUIRE(key1 == key2);
 	}
 
 	SECTION("reversed comparisons inside OR are normalized") {
-		auto key1 = NormalizedKey(context, table_entry, "val = 42 OR val = 99");
-		auto key2 = NormalizedKey(context, table_entry, "99 = val OR 42 = val");
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "val = 42 OR val = 99");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "99 = val OR 42 = val");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("whitespace variations produce same key") {
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "val = 42");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "val  =   42");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("three conjunction children are sorted") {
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "val = 42 AND id < 100 AND name = 'hello'");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "name = 'hello' AND val = 42 AND id < 100");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("both sides foldable: equality") {
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "1 = 2");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "2 = 1");
+		REQUIRE(key1 == key2);
+	}
+
+	SECTION("both sides foldable: less-than") {
+		auto key1 = ComputeCanonicalPredicateKey(context, table_entry, "1 < 2");
+		auto key2 = ComputeCanonicalPredicateKey(context, table_entry, "2 > 1");
 		REQUIRE(key1 == key2);
 	}
 }


### PR DESCRIPTION
## Summary

This PR adds the optimizer pre-optimize phase for automatic predicate caching. When `use_query_condition_cache` is enabled, queries with `WHERE` clauses automatically build cache entries without manual `condition_cache_build` calls.

- Add `QueryConditionCacheOptimizer` that runs before FilterPushdown to capture the full WHERE clause, detect `LogicalFilter -> LogicalGet` patterns, and build cache entries inline on cache miss
- Add `NormalizeExpressionForKey` to canonicalize comparison operand order (constants on the right) so equivalent predicates share the same cache key
- Rename setting from `enable_query_condition_cache` to `use_query_condition_cache` 

This PR only builds the cache — it does not yet apply it during scans. A follow-up PR will add the post-optimize phase to inject `CacheExpressionFilter` for row-group/vector skipping.