### PR TITLE
Add cache invalidation support to store

### DIFF
--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -84,7 +84,7 @@ struct ConditionCacheEntry : public ObjectCacheEntry {
 // invalidation lookup when DML modifies the table.
 struct TableFilterKeyIndex : public ObjectCacheEntry {
 	concurrency::mutex lock;
-	vector<string> filter_keys DUCKDB_GUARDED_BY(lock);
+	unordered_set<string> filter_keys DUCKDB_GUARDED_BY(lock);
 
 	static string ObjectType() {
 		return "query_condition_cache_filter_key_index";
@@ -98,10 +98,12 @@ struct TableFilterKeyIndex : public ObjectCacheEntry {
 		return optional_idx {};
 	}
 
+	// Add a filter key. No-op if it already exists (deduplication).
 	void Add(const string &filter_key);
+	// Remove a filter key. No-op if it doesn't exist.
 	void Remove(const string &filter_key);
 	bool IsEmpty();
-	vector<string> GetAll();
+	unordered_set<string> GetAll();
 };
 
 // Stored in DuckDB's per-database ObjectCache

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -83,8 +83,8 @@ struct ConditionCacheEntry : public ObjectCacheEntry {
 // filter_keys have cache entries for a given table, enabling fast
 // invalidation lookup when DML modifies the table.
 struct TableFilterKeyIndex : public ObjectCacheEntry {
-	mutex lock;
-	vector<string> filter_keys;
+	concurrency::mutex lock;
+	vector<string> filter_keys DUCKDB_GUARDED_BY(lock);
 
 	static string ObjectType() {
 		return "query_condition_cache_filter_key_index";
@@ -133,13 +133,18 @@ public:
 	// Check if any entries exist for a given table OID
 	bool HasEntriesForTable(ClientContext &context, idx_t table_oid);
 
+	// Clear all cache entries and filter key indexes
+	void ClearAll(ClientContext &context);
+
 	// Get or create the store from a client context
 	static shared_ptr<ConditionCacheStore> GetOrCreate(ClientContext &context);
 
 private:
-	// Generate a unique cache key string from CacheKey
+	concurrency::mutex lock;
+	// Tracks all table OIDs that have been cached, for ClearAll
+	unordered_set<idx_t> cached_table_oids DUCKDB_GUARDED_BY(lock);
+
 	static string MakeCacheKeyString(const CacheKey &key);
-	// Generate a unique filter key index key from table OID
 	static string MakeFilterKeyIndexKey(idx_t table_oid);
 };
 

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -84,6 +84,8 @@ struct ConditionCacheEntry : public ObjectCacheEntry {
 // invalidation lookup when DML modifies the table.
 struct TableFilterKeyIndex : public ObjectCacheEntry {
 	concurrency::mutex lock;
+	// Keys that have been cached for this table; entries may have been evicted by LRU.
+	// Absence of a key guarantees it is not cached.
 	unordered_set<string> filter_keys DUCKDB_GUARDED_BY(lock);
 
 	static string ObjectType() {
@@ -98,9 +100,9 @@ struct TableFilterKeyIndex : public ObjectCacheEntry {
 		return optional_idx {};
 	}
 
-	// Add a filter key. No-op if it already exists (deduplication).
+	// Add a filter key. No-op if it already exists.
 	void Add(const string &filter_key);
-	// Remove a filter key. No-op if it doesn't exist.
+	// Remove a filter key. Assumes the key must appear in the set.
 	void Remove(const string &filter_key);
 	bool IsEmpty();
 	unordered_set<string> GetAll();

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -100,6 +100,7 @@ struct TableFilterKeyIndex : public ObjectCacheEntry {
 
 	void Add(const string &filter_key);
 	void Remove(const string &filter_key);
+	bool IsEmpty();
 	vector<string> GetAll();
 };
 
@@ -133,7 +134,7 @@ public:
 	// Check if any entries exist for a given table OID
 	bool HasEntriesForTable(ClientContext &context, idx_t table_oid);
 
-	// Clear all cache entries and filter key indexes
+	// Clear all cache entries and filter key indices
 	void ClearAll(ClientContext &context);
 
 	// Get or create the store from a client context

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/storage/object_cache.hpp"
 
 namespace duckdb {
@@ -74,6 +75,30 @@ struct ConditionCacheEntry : public ObjectCacheEntry {
 	CacheEntryStats ComputeStats(idx_t total_rows) const;
 };
 
+// Per-table index stored in ObjectCache (non-evictable). Tracks which
+// filter_keys have cache entries for a given table, enabling fast
+// invalidation lookup when DML modifies the table.
+struct TableFilterKeyIndex : public ObjectCacheEntry {
+	mutex lock;
+	vector<string> filter_keys;
+
+	static string ObjectType() {
+		return "query_condition_cache_filter_key_index";
+	}
+
+	string GetObjectType() override {
+		return ObjectType();
+	}
+
+	optional_idx GetEstimatedCacheMemory() const override {
+		return optional_idx {};
+	}
+
+	void Add(const string &filter_key);
+	void Remove(const string &filter_key);
+	vector<string> GetAll();
+};
+
 // Stored in DuckDB's per-database ObjectCache
 class ConditionCacheStore : public ObjectCacheEntry {
 public:
@@ -97,12 +122,21 @@ public:
 	// Upsert an entry
 	void Upsert(ClientContext &context, const CacheKey &key, shared_ptr<ConditionCacheEntry> entry);
 
+	// Remove specific row groups from all entries for a table. Returns count of row groups removed.
+	idx_t RemoveRowGroupsForTable(ClientContext &context, idx_t table_oid,
+	                              const unordered_set<idx_t> &row_group_indices);
+
+	// Check if any entries exist for a given table OID
+	bool HasEntriesForTable(ClientContext &context, idx_t table_oid);
+
 	// Get or create the store from a client context
 	static shared_ptr<ConditionCacheStore> GetOrCreate(ClientContext &context);
 
 private:
 	// Generate a unique cache key string from CacheKey
 	static string MakeCacheKeyString(const CacheKey &key);
+	// Generate a unique filter key index key from table OID
+	static string MakeFilterKeyIndexKey(idx_t table_oid);
 };
 
 } // namespace duckdb

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -9,10 +9,19 @@
 #include "query_condition_cache_filter.hpp"
 #include "query_condition_cache_functions.hpp"
 #include "query_condition_cache_optimizer.hpp"
+#include "query_condition_cache_state.hpp"
 
 namespace duckdb {
 
 namespace {
+
+// Clear all cache entries when the setting is disabled
+void OnQueryConditionCacheSettingChange(ClientContext &context, SetScope scope, Value &parameter) {
+	if (!parameter.GetValue<bool>()) {
+		auto store = ConditionCacheStore::GetOrCreate(context);
+		store->ClearAll(context);
+	}
+}
 
 void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(ConditionCacheBuildFunction());
@@ -28,7 +37,8 @@ void LoadInternal(ExtensionLoader &loader) {
 	auto &db = loader.GetDatabaseInstance();
 	auto &config = DBConfig::GetConfig(db);
 	config.AddExtensionOption("use_query_condition_cache", "Enable automatic query condition cache build and apply",
-	                          LogicalType {LogicalTypeId::BOOLEAN}, Value::BOOLEAN(true));
+	                          LogicalType {LogicalTypeId::BOOLEAN}, Value::BOOLEAN(true),
+	                          OnQueryConditionCacheSettingChange);
 
 	// Register optimizer extension
 	OptimizerExtension::Register(config, QueryConditionCacheOptimizer());

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -79,17 +79,47 @@ CacheEntryStats ConditionCacheEntry::ComputeStats(idx_t total_rows) const {
 	};
 }
 
+// ------- TABLE_FILTER_KEY_INDEX -------
+
+void TableFilterKeyIndex::Add(const string &filter_key) {
+	lock_guard<mutex> guard(lock);
+	for (const auto &existing : filter_keys) {
+		if (existing == filter_key) {
+			return;
+		}
+	}
+	filter_keys.push_back(filter_key);
+}
+
+void TableFilterKeyIndex::Remove(const string &filter_key) {
+	lock_guard<mutex> guard(lock);
+	for (auto it = filter_keys.begin(); it != filter_keys.end(); ++it) {
+		if (*it == filter_key) {
+			filter_keys.erase(it);
+			return;
+		}
+	}
+}
+
+vector<string> TableFilterKeyIndex::GetAll() {
+	lock_guard<mutex> guard(lock);
+	return filter_keys;
+}
+
 // ------- CONDITION_CACHE_STORE -------
 
+// Format: "query_condition_cache_entry:{table_oid}:{filter_key}"
 string ConditionCacheStore::MakeCacheKeyString(const CacheKey &key) {
-	// Format: "query_condition_cache_entry:{table_oid}:{filter_key}"
 	return StringUtil::Format("query_condition_cache_entry:%llu:%s", key.table_oid, key.filter_key);
+}
+
+string ConditionCacheStore::MakeFilterKeyIndexKey(idx_t table_oid) {
+	return StringUtil::Format("query_condition_cache_filter_key_index:%llu", table_oid);
 }
 
 shared_ptr<ConditionCacheEntry> ConditionCacheStore::Lookup(ClientContext &context, const CacheKey &key) {
 	auto &cache = ObjectCache::GetObjectCache(context);
-	string cache_key = MakeCacheKeyString(key);
-	return cache.Get<ConditionCacheEntry>(cache_key);
+	return cache.Get<ConditionCacheEntry>(MakeCacheKeyString(key));
 }
 
 void ConditionCacheStore::Upsert(ClientContext &context, const CacheKey &key, shared_ptr<ConditionCacheEntry> entry) {
@@ -97,8 +127,50 @@ void ConditionCacheStore::Upsert(ClientContext &context, const CacheKey &key, sh
 		throw InvalidInputException("ConditionCacheStore::Upsert: entry must not be null");
 	}
 	auto &cache = ObjectCache::GetObjectCache(context);
-	string cache_key = MakeCacheKeyString(key);
-	cache.Put(cache_key, std::move(entry));
+	cache.Put(MakeCacheKeyString(key), std::move(entry));
+
+	// Maintain per-table index for invalidation lookup
+	auto index = cache.GetOrCreate<TableFilterKeyIndex>(MakeFilterKeyIndexKey(key.table_oid));
+	index->Add(key.filter_key);
+}
+
+idx_t ConditionCacheStore::RemoveRowGroupsForTable(ClientContext &context, idx_t table_oid,
+                                                   const unordered_set<idx_t> &row_group_indices) {
+	auto &cache = ObjectCache::GetObjectCache(context);
+
+	auto index = cache.Get<TableFilterKeyIndex>(MakeFilterKeyIndexKey(table_oid));
+	if (!index) {
+		return 0;
+	}
+
+	auto filter_keys = index->GetAll();
+	idx_t removed_count = 0;
+
+	for (const auto &filter_key : filter_keys) {
+		CacheKey key {table_oid, filter_key};
+		string cache_key = MakeCacheKeyString(key);
+		auto entry = cache.Get<ConditionCacheEntry>(cache_key);
+		if (!entry) {
+			index->Remove(filter_key);
+			continue;
+		}
+		for (auto rg_idx : row_group_indices) {
+			if (entry->bitvectors.erase(rg_idx) > 0) {
+				++removed_count;
+			}
+		}
+		if (entry->bitvectors.empty()) {
+			cache.Delete(cache_key);
+			index->Remove(filter_key);
+		}
+	}
+	return removed_count;
+}
+
+bool ConditionCacheStore::HasEntriesForTable(ClientContext &context, idx_t table_oid) {
+	auto &cache = ObjectCache::GetObjectCache(context);
+	auto index = cache.Get<TableFilterKeyIndex>(MakeFilterKeyIndexKey(table_oid));
+	return index && !index->GetAll().empty();
 }
 
 shared_ptr<ConditionCacheStore> ConditionCacheStore::GetOrCreate(ClientContext &context) {

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -83,24 +83,12 @@ CacheEntryStats ConditionCacheEntry::ComputeStats(idx_t total_rows) const {
 
 void TableFilterKeyIndex::Add(const string &filter_key) {
 	concurrency::lock_guard<concurrency::mutex> guard(lock);
-	for (const auto &existing : filter_keys) {
-		if (existing == filter_key) {
-			return;
-		}
-	}
-	filter_keys.push_back(filter_key);
+	filter_keys.insert(filter_key);
 }
 
 void TableFilterKeyIndex::Remove(const string &filter_key) {
 	concurrency::lock_guard<concurrency::mutex> guard(lock);
-	for (idx_t idx = 0; idx < filter_keys.size(); ++idx) {
-		if (filter_keys[idx] == filter_key) {
-			// Swap with last element to pop_back
-			std::swap(filter_keys[idx], filter_keys.back());
-			filter_keys.pop_back();
-			return;
-		}
-	}
+	filter_keys.erase(filter_key);
 }
 
 bool TableFilterKeyIndex::IsEmpty() {
@@ -108,7 +96,7 @@ bool TableFilterKeyIndex::IsEmpty() {
 	return filter_keys.empty();
 }
 
-vector<string> TableFilterKeyIndex::GetAll() {
+unordered_set<string> TableFilterKeyIndex::GetAll() {
 	concurrency::lock_guard<concurrency::mutex> guard(lock);
 	return filter_keys;
 }
@@ -166,16 +154,23 @@ idx_t ConditionCacheStore::RemoveRowGroupsForTable(ClientContext &context, idx_t
 			index->Remove(filter_key);
 			continue;
 		}
+		concurrency::lock_guard<concurrency::mutex> entry_guard(entry->lock);
 		for (auto rg_idx : row_group_indices) {
-			if (entry->bitvectors.erase(rg_idx) > 0) {
-				++removed_count;
-			}
+			removed_count += entry->bitvectors.erase(rg_idx);
 		}
 		if (entry->bitvectors.empty()) {
 			cache.Delete(cache_key);
 			index->Remove(filter_key);
 		}
 	}
+
+	// Clean up cached_table_oids if all entries for this table are gone
+	if (index->IsEmpty()) {
+		cache.Delete(MakeFilterKeyIndexKey(table_oid));
+		concurrency::lock_guard<concurrency::mutex> guard(lock);
+		cached_table_oids.erase(table_oid);
+	}
+
 	return removed_count;
 }
 

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -93,12 +93,19 @@ void TableFilterKeyIndex::Add(const string &filter_key) {
 
 void TableFilterKeyIndex::Remove(const string &filter_key) {
 	concurrency::lock_guard<concurrency::mutex> guard(lock);
-	for (auto it = filter_keys.begin(); it != filter_keys.end(); ++it) {
-		if (*it == filter_key) {
-			filter_keys.erase(it);
+	for (idx_t idx = 0; idx < filter_keys.size(); ++idx) {
+		if (filter_keys[idx] == filter_key) {
+			// Swap with last element to pop_back
+			std::swap(filter_keys[idx], filter_keys.back());
+			filter_keys.pop_back();
 			return;
 		}
 	}
+}
+
+bool TableFilterKeyIndex::IsEmpty() {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	return filter_keys.empty();
 }
 
 vector<string> TableFilterKeyIndex::GetAll() {
@@ -155,6 +162,7 @@ idx_t ConditionCacheStore::RemoveRowGroupsForTable(ClientContext &context, idx_t
 		string cache_key = MakeCacheKeyString(key);
 		auto entry = cache.Get<ConditionCacheEntry>(cache_key);
 		if (!entry) {
+			// Entry was evicted by LRU, clean up stale index
 			index->Remove(filter_key);
 			continue;
 		}
@@ -174,7 +182,7 @@ idx_t ConditionCacheStore::RemoveRowGroupsForTable(ClientContext &context, idx_t
 bool ConditionCacheStore::HasEntriesForTable(ClientContext &context, idx_t table_oid) {
 	auto &cache = ObjectCache::GetObjectCache(context);
 	auto index = cache.Get<TableFilterKeyIndex>(MakeFilterKeyIndexKey(table_oid));
-	return index && !index->GetAll().empty();
+	return index && !index->IsEmpty();
 }
 
 void ConditionCacheStore::ClearAll(ClientContext &context) {

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -88,6 +88,7 @@ void TableFilterKeyIndex::Add(const string &filter_key) {
 
 void TableFilterKeyIndex::Remove(const string &filter_key) {
 	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	D_ASSERT(filter_keys.count(filter_key) > 0);
 	filter_keys.erase(filter_key);
 }
 

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -82,7 +82,7 @@ CacheEntryStats ConditionCacheEntry::ComputeStats(idx_t total_rows) const {
 // ------- TABLE_FILTER_KEY_INDEX -------
 
 void TableFilterKeyIndex::Add(const string &filter_key) {
-	lock_guard<mutex> guard(lock);
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
 	for (const auto &existing : filter_keys) {
 		if (existing == filter_key) {
 			return;
@@ -92,7 +92,7 @@ void TableFilterKeyIndex::Add(const string &filter_key) {
 }
 
 void TableFilterKeyIndex::Remove(const string &filter_key) {
-	lock_guard<mutex> guard(lock);
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
 	for (auto it = filter_keys.begin(); it != filter_keys.end(); ++it) {
 		if (*it == filter_key) {
 			filter_keys.erase(it);
@@ -102,7 +102,7 @@ void TableFilterKeyIndex::Remove(const string &filter_key) {
 }
 
 vector<string> TableFilterKeyIndex::GetAll() {
-	lock_guard<mutex> guard(lock);
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
 	return filter_keys;
 }
 
@@ -132,6 +132,10 @@ void ConditionCacheStore::Upsert(ClientContext &context, const CacheKey &key, sh
 	// Maintain per-table index for invalidation lookup
 	auto index = cache.GetOrCreate<TableFilterKeyIndex>(MakeFilterKeyIndexKey(key.table_oid));
 	index->Add(key.filter_key);
+
+	// Track table OID for ClearAll
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	cached_table_oids.insert(key.table_oid);
 }
 
 idx_t ConditionCacheStore::RemoveRowGroupsForTable(ClientContext &context, idx_t table_oid,
@@ -171,6 +175,24 @@ bool ConditionCacheStore::HasEntriesForTable(ClientContext &context, idx_t table
 	auto &cache = ObjectCache::GetObjectCache(context);
 	auto index = cache.Get<TableFilterKeyIndex>(MakeFilterKeyIndexKey(table_oid));
 	return index && !index->GetAll().empty();
+}
+
+void ConditionCacheStore::ClearAll(ClientContext &context) {
+	auto &cache = ObjectCache::GetObjectCache(context);
+
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	for (auto table_oid : cached_table_oids) {
+		auto index = cache.Get<TableFilterKeyIndex>(MakeFilterKeyIndexKey(table_oid));
+		if (!index) {
+			continue;
+		}
+		auto filter_keys = index->GetAll();
+		for (const auto &filter_key : filter_keys) {
+			cache.Delete(MakeCacheKeyString(CacheKey {table_oid, filter_key}));
+		}
+		cache.Delete(MakeFilterKeyIndexKey(table_oid));
+	}
+	cached_table_oids.clear();
 }
 
 shared_ptr<ConditionCacheStore> ConditionCacheStore::GetOrCreate(ClientContext &context) {

--- a/test/sql/condition_cache_auto.test
+++ b/test/sql/condition_cache_auto.test
@@ -38,8 +38,8 @@ SELECT * FROM condition_cache_info('t', 'val = 99');
 ----
 0	0	0	0
 
-# Previously built cache still exists
+# Cache was cleared when setting was disabled
 query IIII
 SELECT * FROM condition_cache_info('t', 'val = 42');
 ----
-5	5	245	245
+0	0	0	0

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -6,9 +6,13 @@ include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
 set(QUERY_CACHE_UNITTEST_OBJECTS
-    main.cpp test_bitvector.cpp test_build_cache_entry.cpp
-    test_cache_invalidation.cpp test_cache_store.cpp
-    test_filter.cpp test_normalize_expression.cpp)
+    main.cpp
+    test_bitvector.cpp
+    test_build_cache_entry.cpp
+    test_cache_invalidation.cpp
+    test_cache_store.cpp
+    test_filter.cpp
+    test_normalize_expression.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})
 

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -6,7 +6,8 @@ include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
 set(QUERY_CACHE_UNITTEST_OBJECTS
-    main.cpp test_bitvector.cpp test_build_cache_entry.cpp test_cache_store.cpp)
+    main.cpp test_bitvector.cpp test_build_cache_entry.cpp
+    test_cache_invalidation.cpp test_cache_store.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})
 

--- a/test/unittest/test_cache_invalidation.cpp
+++ b/test/unittest/test_cache_invalidation.cpp
@@ -14,7 +14,7 @@ TEST_CASE("RemoveRowGroupsForTable - basic operations", "[invalidation]") {
 
 	SECTION("empty store returns 0") {
 		unordered_set<idx_t> rg_indices = {0, 1, 2};
-		REQUIRE(store->RemoveRowGroupsForTable(context, 1, rg_indices) == 0);
+		REQUIRE(store->RemoveRowGroupsForTable(context, /*table_oid=*/1, rg_indices) == 0);
 	}
 
 	SECTION("removes specified row groups from matching table entries") {
@@ -22,13 +22,13 @@ TEST_CASE("RemoveRowGroupsForTable - basic operations", "[invalidation]") {
 		entry->bitvectors[0].SetVector(0);
 		entry->bitvectors[1].SetVector(0);
 		entry->bitvectors[2].SetVector(0);
-		store->Upsert(context, {1, "val > 5"}, entry);
+		store->Upsert(context, {/*table_oid=*/1, "val > 5"}, entry);
 
 		unordered_set<idx_t> rg_indices = {0, 2};
-		auto removed = store->RemoveRowGroupsForTable(context, 1, rg_indices);
+		auto removed = store->RemoveRowGroupsForTable(context, /*table_oid=*/1, rg_indices);
 		REQUIRE(removed == 2);
 
-		auto found = store->Lookup(context, {1, "val > 5"});
+		auto found = store->Lookup(context, {/*table_oid=*/1, "val > 5"});
 		REQUIRE(found != nullptr);
 		REQUIRE(found->bitvectors.count(0) == 0);
 		REQUIRE(found->bitvectors.count(1) == 1);
@@ -38,28 +38,28 @@ TEST_CASE("RemoveRowGroupsForTable - basic operations", "[invalidation]") {
 	SECTION("removes entire entry when all row groups are removed") {
 		auto entry = make_shared_ptr<ConditionCacheEntry>();
 		entry->bitvectors[0].SetVector(0);
-		store->Upsert(context, {1, "val > 5"}, entry);
+		store->Upsert(context, {/*table_oid=*/1, "val > 5"}, entry);
 
 		unordered_set<idx_t> rg_indices = {0};
-		store->RemoveRowGroupsForTable(context, 1, rg_indices);
+		store->RemoveRowGroupsForTable(context, /*table_oid=*/1, rg_indices);
 
-		REQUIRE(store->Lookup(context, {1, "val > 5"}) == nullptr);
+		REQUIRE(store->Lookup(context, {/*table_oid=*/1, "val > 5"}) == nullptr);
 	}
 
 	SECTION("does not affect entries for other tables") {
 		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
 		entry1->bitvectors[0].SetVector(0);
-		store->Upsert(context, {1, "val > 5"}, entry1);
+		store->Upsert(context, {/*table_oid=*/1, "val > 5"}, entry1);
 
 		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
 		entry2->bitvectors[0].SetVector(0);
-		store->Upsert(context, {2, "val > 5"}, entry2);
+		store->Upsert(context, {/*table_oid=*/2, "val > 5"}, entry2);
 
 		unordered_set<idx_t> rg_indices = {0};
-		store->RemoveRowGroupsForTable(context, 1, rg_indices);
+		store->RemoveRowGroupsForTable(context, /*table_oid=*/1, rg_indices);
 
-		REQUIRE(store->Lookup(context, {1, "val > 5"}) == nullptr);
-		auto found2 = store->Lookup(context, {2, "val > 5"});
+		REQUIRE(store->Lookup(context, {/*table_oid=*/1, "val > 5"}) == nullptr);
+		auto found2 = store->Lookup(context, {/*table_oid=*/2, "val > 5"});
 		REQUIRE(found2 != nullptr);
 		REQUIRE(found2->bitvectors.count(0) == 1);
 	}
@@ -68,23 +68,23 @@ TEST_CASE("RemoveRowGroupsForTable - basic operations", "[invalidation]") {
 		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
 		entry1->bitvectors[0].SetVector(0);
 		entry1->bitvectors[1].SetVector(0);
-		store->Upsert(context, {1, "val > 5"}, entry1);
+		store->Upsert(context, {/*table_oid=*/1, "val > 5"}, entry1);
 
 		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
 		entry2->bitvectors[0].SetVector(0);
 		entry2->bitvectors[1].SetVector(0);
-		store->Upsert(context, {1, "val < 10"}, entry2);
+		store->Upsert(context, {/*table_oid=*/1, "val < 10"}, entry2);
 
 		unordered_set<idx_t> rg_indices = {0};
-		auto removed = store->RemoveRowGroupsForTable(context, 1, rg_indices);
+		auto removed = store->RemoveRowGroupsForTable(context, /*table_oid=*/1, rg_indices);
 		REQUIRE(removed == 2); // one from each entry
 
-		auto found1 = store->Lookup(context, {1, "val > 5"});
+		auto found1 = store->Lookup(context, {/*table_oid=*/1, "val > 5"});
 		REQUIRE(found1 != nullptr);
 		REQUIRE(found1->bitvectors.count(0) == 0);
 		REQUIRE(found1->bitvectors.count(1) == 1);
 
-		auto found2 = store->Lookup(context, {1, "val < 10"});
+		auto found2 = store->Lookup(context, {/*table_oid=*/1, "val < 10"});
 		REQUIRE(found2 != nullptr);
 		REQUIRE(found2->bitvectors.count(0) == 0);
 		REQUIRE(found2->bitvectors.count(1) == 1);

--- a/test/unittest/test_cache_invalidation.cpp
+++ b/test/unittest/test_cache_invalidation.cpp
@@ -1,0 +1,93 @@
+#include "catch/catch.hpp"
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+
+namespace duckdb {
+
+TEST_CASE("RemoveRowGroupsForTable - basic operations", "[invalidation]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &context = *con.context;
+	auto store = ConditionCacheStore::GetOrCreate(context);
+
+	SECTION("empty store returns 0") {
+		unordered_set<idx_t> rg_indices = {0, 1, 2};
+		REQUIRE(store->RemoveRowGroupsForTable(context, 1, rg_indices) == 0);
+	}
+
+	SECTION("removes specified row groups from matching table entries") {
+		auto entry = make_shared_ptr<ConditionCacheEntry>();
+		entry->bitvectors[0].SetVector(0);
+		entry->bitvectors[1].SetVector(0);
+		entry->bitvectors[2].SetVector(0);
+		store->Upsert(context, {1, "val > 5"}, entry);
+
+		unordered_set<idx_t> rg_indices = {0, 2};
+		auto removed = store->RemoveRowGroupsForTable(context, 1, rg_indices);
+		REQUIRE(removed == 2);
+
+		auto found = store->Lookup(context, {1, "val > 5"});
+		REQUIRE(found != nullptr);
+		REQUIRE(found->bitvectors.count(0) == 0);
+		REQUIRE(found->bitvectors.count(1) == 1);
+		REQUIRE(found->bitvectors.count(2) == 0);
+	}
+
+	SECTION("removes entire entry when all row groups are removed") {
+		auto entry = make_shared_ptr<ConditionCacheEntry>();
+		entry->bitvectors[0].SetVector(0);
+		store->Upsert(context, {1, "val > 5"}, entry);
+
+		unordered_set<idx_t> rg_indices = {0};
+		store->RemoveRowGroupsForTable(context, 1, rg_indices);
+
+		REQUIRE(store->Lookup(context, {1, "val > 5"}) == nullptr);
+	}
+
+	SECTION("does not affect entries for other tables") {
+		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
+		entry1->bitvectors[0].SetVector(0);
+		store->Upsert(context, {1, "val > 5"}, entry1);
+
+		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
+		entry2->bitvectors[0].SetVector(0);
+		store->Upsert(context, {2, "val > 5"}, entry2);
+
+		unordered_set<idx_t> rg_indices = {0};
+		store->RemoveRowGroupsForTable(context, 1, rg_indices);
+
+		REQUIRE(store->Lookup(context, {1, "val > 5"}) == nullptr);
+		auto found2 = store->Lookup(context, {2, "val > 5"});
+		REQUIRE(found2 != nullptr);
+		REQUIRE(found2->bitvectors.count(0) == 1);
+	}
+
+	SECTION("removes from multiple entries for the same table") {
+		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
+		entry1->bitvectors[0].SetVector(0);
+		entry1->bitvectors[1].SetVector(0);
+		store->Upsert(context, {1, "val > 5"}, entry1);
+
+		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
+		entry2->bitvectors[0].SetVector(0);
+		entry2->bitvectors[1].SetVector(0);
+		store->Upsert(context, {1, "val < 10"}, entry2);
+
+		unordered_set<idx_t> rg_indices = {0};
+		auto removed = store->RemoveRowGroupsForTable(context, 1, rg_indices);
+		REQUIRE(removed == 2); // one from each entry
+
+		auto found1 = store->Lookup(context, {1, "val > 5"});
+		REQUIRE(found1 != nullptr);
+		REQUIRE(found1->bitvectors.count(0) == 0);
+		REQUIRE(found1->bitvectors.count(1) == 1);
+
+		auto found2 = store->Lookup(context, {1, "val < 10"});
+		REQUIRE(found2 != nullptr);
+		REQUIRE(found2->bitvectors.count(0) == 0);
+		REQUIRE(found2->bitvectors.count(1) == 1);
+	}
+}
+} // namespace duckdb


### PR DESCRIPTION
## Summary

This PR adds cache invalidation support to `ConditionCacheStore`, enabling row-group-level removal of cached predicate bitvectors when table data changes.

- `TableFilterKeyIndex`: A per-table reverse index (stored in `ObjectCache`) that tracks which `filter_key`s have cache entries for a given table OID. This enables efficient lookup of all cache entries affected by a table mutation without scanning the entire cache.
- `RemoveRowGroupsForTable(context, table_oid, row_group_indices)`: Removes the specified row groups from all cache entries belonging to a table. If an entry has no remaining row groups after removal, the entry and its index reference are cleaned up entirely.
- `HasEntriesForTable(context, table_oid)`: Quick check for whether any cache entries exist for a table.

When DML operations (INSERT, DELETE, UPDATE, VACUUM) modify a table, the affected row groups' cached bitvectors become stale. This PR provides the invalidation primitives that future DML hooks will use to call `RemoveRowGroupsForTable` with the touched row group indices.

## Related Issues

- None
