### PR TITLE
Add thread annoatation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ if(UNIX OR APPLE)
   )
 endif()
 
+if(CMAKE_CXX_COMPILER_ID_LOWER MATCHES "clang" OR CMAKE_CXX_COMPILER_LOWER
+                                                  MATCHES "clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wthread-safety")
+endif()
+
 include_directories(src/include)
 
 set(EXTENSION_SOURCES

--- a/src/include/concurrency/annotated_lock.hpp
+++ b/src/include/concurrency/annotated_lock.hpp
@@ -1,0 +1,65 @@
+// Wrapper around lock types in standard libraries.
+// See: https://clang.llvm.org/docs/ThreadSafetyAnalysis.html#mutex-h
+
+#pragma once
+
+#include <chrono>
+#include <mutex>
+
+#include "concurrency/internal/mutex_impl.hpp"
+#include "concurrency/thread_annotation.hpp"
+
+namespace duckdb {
+namespace concurrency {
+
+template <typename M>
+class DUCKDB_SCOPED_CAPABILITY lock_guard : public internal::lock_impl_t<lock_guard<M>> {
+private:
+	using Impl = internal::lock_impl_t<lock_guard<M>>;
+
+public:
+	explicit lock_guard(M &m) DUCKDB_ACQUIRE(m) : Impl(m) {
+	}
+	lock_guard(M &m, std::adopt_lock_t t) DUCKDB_REQUIRES(m) : Impl(m, t) {
+	}
+	~lock_guard() DUCKDB_RELEASE() = default;
+};
+
+template <typename M>
+class DUCKDB_SCOPED_CAPABILITY unique_lock : public internal::lock_impl_t<unique_lock<M>> {
+private:
+	using Impl = internal::lock_impl_t<unique_lock<M>>;
+
+public:
+	unique_lock() = default;
+	explicit unique_lock(M &m) DUCKDB_ACQUIRE(m) : Impl(m) {
+	}
+	unique_lock(M &m, std::defer_lock_t t) noexcept DUCKDB_EXCLUDES(m) : Impl(m, t) {
+	}
+	unique_lock(M &m, std::adopt_lock_t t) DUCKDB_REQUIRES(m) : Impl(m, t) {
+	}
+	unique_lock(M &m, std::try_to_lock_t t) DUCKDB_TRY_ACQUIRE(true, m) : Impl(m, t) {
+	}
+	~unique_lock() DUCKDB_RELEASE() = default;
+
+	void lock() DUCKDB_ACQUIRE() {
+		Impl::lock();
+	}
+	bool try_lock() DUCKDB_TRY_ACQUIRE(true) {
+		return Impl::try_lock();
+	}
+	template <typename R, typename P>
+	bool try_lock_for(const std::chrono::duration<R, P> &timeout) DUCKDB_TRY_ACQUIRE(true) {
+		return Impl::try_lock_for(timeout);
+	}
+	template <typename C, typename D>
+	bool try_lock_until(const std::chrono::time_point<C, D> &timeout) DUCKDB_TRY_ACQUIRE(true) {
+		return Impl::try_lock_until(timeout);
+	}
+	void unlock() DUCKDB_RELEASE() {
+		Impl::unlock();
+	}
+};
+
+} // namespace concurrency
+} // namespace duckdb

--- a/src/include/concurrency/annotated_mutex.hpp
+++ b/src/include/concurrency/annotated_mutex.hpp
@@ -1,0 +1,31 @@
+// Wrapper around mutex types within standard libraries.
+// See: https://clang.llvm.org/docs/ThreadSafetyAnalysis.html#mutex-h
+
+#pragma once
+
+#include <mutex>
+
+#include "concurrency/internal/mutex_impl.hpp"
+#include "concurrency/thread_annotation.hpp"
+
+namespace duckdb {
+namespace concurrency {
+
+class DUCKDB_CAPABILITY("mutex") mutex : public internal::mutex_impl_t<mutex> {
+private:
+	using Impl = internal::mutex_impl_t<mutex>;
+
+public:
+	void lock() DUCKDB_ACQUIRE() {
+		Impl::lock();
+	}
+	void unlock() DUCKDB_RELEASE() {
+		Impl::unlock();
+	}
+	bool try_lock() DUCKDB_TRY_ACQUIRE(true) {
+		return Impl::try_lock();
+	}
+};
+
+} // namespace concurrency
+} // namespace duckdb

--- a/src/include/concurrency/internal/mutex_impl.hpp
+++ b/src/include/concurrency/internal/mutex_impl.hpp
@@ -1,0 +1,57 @@
+// Bind annotated mutex and lock type with standard implementation, so that
+// duckdb::concurrency::unique_lock<duckdb::concurrency::mutex> could inherit std::unique_lock<std::mutex>.
+
+#pragma once
+
+#include <mutex>
+
+namespace duckdb {
+namespace concurrency {
+
+// Forward declaration for annotated mutex types.
+class mutex;
+
+// Forward declaration for annotated lock types.
+template <typename M>
+class unique_lock;
+template <typename M>
+class lock_guard;
+
+namespace internal {
+
+// Type alias for mutex types.
+template <typename T>
+struct standard_impl {
+	using type = T;
+};
+template <typename T>
+using standard_impl_t = typename standard_impl<T>::type;
+
+// Mutex specialization.
+template <>
+struct standard_impl<::duckdb::concurrency::mutex> {
+	using type = std::mutex;
+};
+
+// Type alias for lock types.
+template <typename M>
+using mutex_impl_t = standard_impl_t<M>;
+
+// Lock specialization.
+template <typename M>
+struct standard_impl<::duckdb::concurrency::unique_lock<M>> {
+	using type = std::unique_lock<mutex_impl_t<M>>;
+};
+
+template <typename M>
+struct standard_impl<::duckdb::concurrency::lock_guard<M>> {
+	using type = std::lock_guard<mutex_impl_t<M>>;
+};
+
+template <typename L>
+using lock_impl_t = standard_impl_t<L>;
+
+} // namespace internal
+
+} // namespace concurrency
+} // namespace duckdb

--- a/src/include/concurrency/internal/thread_annotation.hpp
+++ b/src/include/concurrency/internal/thread_annotation.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+// Enable thread safety attributes only with clang.
+// The attributes can be safely erased when compiling with other compilers.
+#if defined(__clang__) && (!defined(SWIG))
+#define THREAD_ANNOTATION_ATTRIBUTE__(x) __attribute__((x))
+#ifndef DUCKDB_THREAD_ANNOTATION_ENABLED
+#define DUCKDB_THREAD_ANNOTATION_ENABLED 1
+#endif
+#else
+#define THREAD_ANNOTATION_ATTRIBUTE__(x) // no-op
+#ifndef DUCKDB_THREAD_ANNOTATION_ENABLED
+#define DUCKDB_THREAD_ANNOTATION_ENABLED 0
+#endif
+#endif
+
+// CAPABILITY is an attribute on classes, which specifies that objects of the
+// class can be used as a capability. The string argument specifies the kind of
+// capability in error messages, e.g. "mutex".
+#define DUCKDB_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(capability(x))
+
+// SCOPED_CAPABILITY is an attribute on classes that implement RAII-style
+// locking, in which a capability is acquired in the constructor, and released
+// in the destructor. Such classes require special handling because the
+// constructor and destructor refer to the capability via different names.
+#define DUCKDB_SCOPED_CAPABILITY THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)

--- a/src/include/concurrency/mutex.hpp
+++ b/src/include/concurrency/mutex.hpp
@@ -1,0 +1,8 @@
+// Annotated mutex, lock_guard, unique_lock, and DUCKDB_* thread-safety macros.
+// Include this (or the individual headers) when you want Clang thread-safety analysis.
+
+#pragma once
+
+#include "concurrency/annotated_lock.hpp"
+#include "concurrency/annotated_mutex.hpp"
+#include "concurrency/thread_annotation.hpp"

--- a/src/include/concurrency/thread_annotation.hpp
+++ b/src/include/concurrency/thread_annotation.hpp
@@ -1,0 +1,79 @@
+// Define ghost specific thread safety attributes for clang.
+// See: https://clang.llvm.org/docs/ThreadSafetyAnalysis.html#reference-guide
+
+#pragma once
+
+#include "concurrency/internal/thread_annotation.hpp"
+
+// GUARDED_BY is an attribute on data members, which declares that the data
+// member is protected by the given capability. Read operations on the data
+// require shared access, while write operations require exclusive access.
+#define DUCKDB_GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
+
+// PT_GUARDED_BY is similar, but is intended for use on pointers and smart
+// pointers. There is no constraint on the data member itself, but the data
+// that it points to is protected by the given capability.
+#define DUCKDB_PT_GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_by(x))
+
+// REQUIRES is an attribute on functions or methods, which declares that the
+// calling thread must have exclusive access to the given capabilities. More
+// than one capability may be specified. The capabilities must be held on entry
+// to the function, and must still be held on exit.
+// REQUIRES_SHARED is similar, but requires only shared access.
+#define DUCKDB_REQUIRES(...)        THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
+#define DUCKDB_REQUIRES_SHARED(...) THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
+
+// ACQUIRE and ACQUIRE_SHARED are attributes on functions or methods declaring
+// that the function acquires a capability, but does not release it. The given
+// capability must not be held on entry, and will be held on exit (exclusively
+// for ACQUIRE, shared for ACQUIRE_SHARED).
+#define DUCKDB_ACQUIRE(...)        THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
+#define DUCKDB_ACQUIRE_SHARED(...) THREAD_ANNOTATION_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
+
+// ACQUIRED_BEFORE and ACQUIRED_AFTER are attributes on member declarations,
+// specifically declarations of mutexes or other capabilities. These
+// declarations enforce a particular order in which the mutexes must be
+// acquired, in order to prevent deadlock.
+#define DUCKDB_ACQUIRED_BEFORE(...) THREAD_ANNOTATION_ATTRIBUTE__(acquired_before(__VA_ARGS__))
+#define DUCKDB_ACQUIRED_AFTER(...)  THREAD_ANNOTATION_ATTRIBUTE__(acquired_after(__VA_ARGS__))
+
+// RELEASE, RELEASE_SHARED, and RELEASE_GENERIC declare that the function
+// releases the given capability. The capability must be held on entry
+// (exclusively for RELEASE, shared for RELEASE_SHARED, exclusively or shared
+// for RELEASE_GENERIC), and will no longer be held on exit.
+#define DUCKDB_RELEASE(...)         THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
+#define DUCKDB_RELEASE_SHARED(...)  THREAD_ANNOTATION_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
+#define DUCKDB_RELEASE_GENERIC(...) THREAD_ANNOTATION_ATTRIBUTE__(release_generic_capability(__VA_ARGS__))
+
+// EXCLUDES is an attribute on functions or methods, which declares that the
+// caller must not hold the given capabilities. This annotation is used to
+// prevent deadlock. Many mutex implementations are not re-entrant, so deadlock
+// can occur if the function acquires the mutex a second time.
+#define DUCKDB_EXCLUDES(...) THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+
+// NO_THREAD_SAFETY_ANALYSIS is an attribute on functions or methods, which
+// turns off thread safety checking for that method. It provides an escape
+// hatch for functions which are either (1) deliberately thread-unsafe, or
+// (2) are thread-safe, but too complicated for the analysis to understand.
+#define DUCKDB_NO_THREAD_SAFETY_ANALYSIS THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
+
+// RETURN_CAPABILITY is an attribute on functions or methods, which declares
+// that the function returns a reference to the given capability. It is used
+// to annotate getter methods that return mutexes.
+#define DUCKDB_RETURN_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+
+// These are attributes on a function or method that tries to acquire the given
+// capability, and returns a boolean value indicating success or failure. The
+// first argument must be true or false, to specify which return value indicates
+// success, and the remaining arguments are interpreted in the same way as
+// DUCKDB_ACQUIRE.
+#define DUCKDB_TRY_ACQUIRE(...)        THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
+#define DUCKDB_TRY_ACQUIRE_SHARED(...) THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_shared_capability(__VA_ARGS__))
+
+// These are attributes on a function or method which asserts the calling thread
+// already holds the given capability, for example by performing a run-time test
+// and terminating if the capability is not held. Presence of this annotation
+// causes the analysis to assume the capability is held after calls to the
+// annotated function.
+#define DUCKDB_ASSERT_CAPABILITY(x)        THREAD_ANNOTATION_ATTRIBUTE__(assert_capability(x))
+#define DUCKDB_ASSERT_SHARED_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_capability(x))

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "duckdb/common/array.hpp"
-#include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/storage/object_cache.hpp"


### PR DESCRIPTION
Add annotated mutex and compilation option to the repo, so we could get warning certain lock acquisition/release doesn't conform with the annotation.