### PR TITLE
Fix data race

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,7 @@ if(UNIX OR APPLE)
   )
 endif()
 
-if(CMAKE_CXX_COMPILER_ID_LOWER MATCHES "clang" OR CMAKE_CXX_COMPILER_LOWER
-                                                  MATCHES "clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wthread-safety")
 endif()
 

--- a/src/include/query_condition_cache_filter.hpp
+++ b/src/include/query_condition_cache_filter.hpp
@@ -10,7 +10,7 @@
 namespace duckdb {
 
 // Holds a shared_ptr to the ConditionCacheEntry so the filter function
-// and CheckStatistics can access the bitvectors during execution.
+// and CheckStatistics can query the cache via ConditionCacheEntry's thread-safe API.
 struct ConditionCacheFilterBindData : public FunctionData {
 	shared_ptr<ConditionCacheEntry> cache_entry;
 

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -69,27 +69,38 @@ struct ConditionCacheEntry : public ObjectCacheEntry {
 		return ObjectType();
 	}
 
+	// Return estimated memory usage for LRU eviction
 	optional_idx GetEstimatedCacheMemory() const override;
+
+	// Compute statistics about qualifying vectors and row groups
 	CacheEntryStats ComputeStats(idx_t total_rows) const;
 
-	// Thread-safe API (each method acquires `lock` internally).
+	// --- Thread-safe API (each method acquires `lock` internally) ---
+
+	// Ensure a row group key exists (empty filter). Used when recording fully excluded row groups.
 	void EnsureRowGroup(idx_t rg_idx);
+	// Mark that vector `vec_idx` within row group `rg_idx` has at least one qualifying row.
 	void SetQualifyingVector(idx_t rg_idx, idx_t vec_idx);
+	// Merge another entry's row-group filters into this entry (e.g. after parallel build).
 	void MergeFrom(const ConditionCacheEntry &other);
 
+	// Row group absent from cache, or vector has qualifying rows -> predicate may pass rows (matches scan semantics).
 	bool VectorPassesFilter(idx_t rg_idx, idx_t vec_idx) const;
+	// True iff every row group in [min_rg, max_rg] is present in the cache and has an empty filter.
 	bool StatisticsRangeIsAllEmptyCached(idx_t min_rg, idx_t max_rg) const;
 
 	idx_t RowGroupCount() const;
 	bool HasRowGroup(idx_t rg_idx) const;
 	bool RowGroupVectorHasQualifyingRows(idx_t rg_idx, idx_t vec_idx) const;
+	// True iff `rg_idx` is cached and its filter is empty (no qualifying vectors).
 	bool RowGroupIsCompletelyEmpty(idx_t rg_idx) const;
 
+	// Erase row group keys; returns (number of keys removed, whether the map is now empty).
 	pair<idx_t, bool> EraseRowGroups(const unordered_set<idx_t> &row_group_indices);
 
 private:
 	mutable concurrency::mutex lock;
-	unordered_map<idx_t, RowGroupFilter> bitvectors DUCKDB_GUARDED_BY(lock);
+	unordered_map<idx_t, RowGroupFilter> bitvectors DUCKDB_GUARDED_BY(lock); // rg_idx -> bitvector
 };
 
 // Per-table index stored in ObjectCache (non-evictable). Tracks which
@@ -97,6 +108,8 @@ private:
 // invalidation lookup when DML modifies the table.
 struct TableFilterKeyIndex : public ObjectCacheEntry {
 	concurrency::mutex lock;
+	// Keys that have been cached for this table; entries may have been evicted by LRU.
+	// Absence of a key guarantees it is not cached.
 	unordered_set<string> filter_keys DUCKDB_GUARDED_BY(lock);
 
 	static string ObjectType() {
@@ -111,12 +124,15 @@ struct TableFilterKeyIndex : public ObjectCacheEntry {
 		return optional_idx {};
 	}
 
+	// Add a filter key. No-op if it already exists.
 	void Add(const string &filter_key);
+	// Remove a filter key. Assumes the key must appear in the set.
 	void Remove(const string &filter_key);
 	bool IsEmpty();
 	unordered_set<string> GetAll();
 };
 
+// Stored in DuckDB's per-database ObjectCache
 class ConditionCacheStore : public ObjectCacheEntry {
 public:
 	static constexpr const char *CACHE_KEY = "query_condition_cache_store";
@@ -133,16 +149,28 @@ public:
 		return optional_idx {};
 	}
 
+	// Lookup by cache key; returns nullptr if not found
 	shared_ptr<ConditionCacheEntry> Lookup(ClientContext &context, const CacheKey &key);
+
+	// Upsert an entry
 	void Upsert(ClientContext &context, const CacheKey &key, shared_ptr<ConditionCacheEntry> entry);
+
+	// Remove specific row groups from all entries for a table. Returns count of row groups removed.
 	idx_t RemoveRowGroupsForTable(ClientContext &context, idx_t table_oid,
 	                              const unordered_set<idx_t> &row_group_indices);
+
+	// Check if any entries exist for a given table OID
 	bool HasEntriesForTable(ClientContext &context, idx_t table_oid);
+
+	// Clear all cache entries and filter key indices
 	void ClearAll(ClientContext &context);
+
+	// Get or create the store from a client context
 	static shared_ptr<ConditionCacheStore> GetOrCreate(ClientContext &context);
 
 private:
 	concurrency::mutex lock;
+	// Tracks all table OIDs that have been cached, for ClearAll
 	unordered_set<idx_t> cached_table_oids DUCKDB_GUARDED_BY(lock);
 
 	static string MakeCacheKeyString(const CacheKey &key);

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -61,9 +61,6 @@ struct CacheEntryStats {
 
 // A single cache entry: the bitvectors for one (table, predicate) combination.
 struct ConditionCacheEntry : public ObjectCacheEntry {
-	concurrency::mutex lock;
-	unordered_map<idx_t, RowGroupFilter> bitvectors DUCKDB_GUARDED_BY(lock); // rg_idx -> bitvector
-
 	static string ObjectType() {
 		return "query_condition_cache_entry";
 	}
@@ -72,11 +69,27 @@ struct ConditionCacheEntry : public ObjectCacheEntry {
 		return ObjectType();
 	}
 
-	// Return estimated memory usage for LRU eviction
 	optional_idx GetEstimatedCacheMemory() const override;
-
-	// Compute statistics about qualifying vectors and row groups
 	CacheEntryStats ComputeStats(idx_t total_rows) const;
+
+	// Thread-safe API (each method acquires `lock` internally).
+	void EnsureRowGroup(idx_t rg_idx);
+	void SetQualifyingVector(idx_t rg_idx, idx_t vec_idx);
+	void MergeFrom(const ConditionCacheEntry &other);
+
+	bool VectorPassesFilter(idx_t rg_idx, idx_t vec_idx) const;
+	bool StatisticsRangeIsAllEmptyCached(idx_t min_rg, idx_t max_rg) const;
+
+	idx_t RowGroupCount() const;
+	bool HasRowGroup(idx_t rg_idx) const;
+	bool RowGroupVectorHasQualifyingRows(idx_t rg_idx, idx_t vec_idx) const;
+	bool RowGroupIsCompletelyEmpty(idx_t rg_idx) const;
+
+	pair<idx_t, bool> EraseRowGroups(const unordered_set<idx_t> &row_group_indices);
+
+private:
+	mutable concurrency::mutex lock;
+	unordered_map<idx_t, RowGroupFilter> bitvectors DUCKDB_GUARDED_BY(lock);
 };
 
 // Per-table index stored in ObjectCache (non-evictable). Tracks which
@@ -84,8 +97,6 @@ struct ConditionCacheEntry : public ObjectCacheEntry {
 // invalidation lookup when DML modifies the table.
 struct TableFilterKeyIndex : public ObjectCacheEntry {
 	concurrency::mutex lock;
-	// Keys that have been cached for this table; entries may have been evicted by LRU.
-	// Absence of a key guarantees it is not cached.
 	unordered_set<string> filter_keys DUCKDB_GUARDED_BY(lock);
 
 	static string ObjectType() {
@@ -100,15 +111,12 @@ struct TableFilterKeyIndex : public ObjectCacheEntry {
 		return optional_idx {};
 	}
 
-	// Add a filter key. No-op if it already exists.
 	void Add(const string &filter_key);
-	// Remove a filter key. Assumes the key must appear in the set.
 	void Remove(const string &filter_key);
 	bool IsEmpty();
 	unordered_set<string> GetAll();
 };
 
-// Stored in DuckDB's per-database ObjectCache
 class ConditionCacheStore : public ObjectCacheEntry {
 public:
 	static constexpr const char *CACHE_KEY = "query_condition_cache_store";
@@ -125,28 +133,16 @@ public:
 		return optional_idx {};
 	}
 
-	// Lookup by cache key; returns nullptr if not found
 	shared_ptr<ConditionCacheEntry> Lookup(ClientContext &context, const CacheKey &key);
-
-	// Upsert an entry
 	void Upsert(ClientContext &context, const CacheKey &key, shared_ptr<ConditionCacheEntry> entry);
-
-	// Remove specific row groups from all entries for a table. Returns count of row groups removed.
 	idx_t RemoveRowGroupsForTable(ClientContext &context, idx_t table_oid,
 	                              const unordered_set<idx_t> &row_group_indices);
-
-	// Check if any entries exist for a given table OID
 	bool HasEntriesForTable(ClientContext &context, idx_t table_oid);
-
-	// Clear all cache entries and filter key indices
 	void ClearAll(ClientContext &context);
-
-	// Get or create the store from a client context
 	static shared_ptr<ConditionCacheStore> GetOrCreate(ClientContext &context);
 
 private:
 	concurrency::mutex lock;
-	// Tracks all table OIDs that have been cached, for ClearAll
 	unordered_set<idx_t> cached_table_oids DUCKDB_GUARDED_BY(lock);
 
 	static string MakeCacheKeyString(const CacheKey &key);

--- a/src/query_condition_cache_filter.cpp
+++ b/src/query_condition_cache_filter.cpp
@@ -19,15 +19,12 @@ bool ConditionCacheFilterBindData::Equals(const FunctionData &other_p) const {
 	return cache_entry == other.cache_entry;
 }
 
-// Returns an empty cache entry so the filter passes all rows through,
-// since the optimizer's bind data is not available during plan verification.
 unique_ptr<FunctionData> ConditionCacheFilterBind(ClientContext &context, ScalarFunction &bound_function,
                                                   vector<unique_ptr<Expression>> &arguments) {
 	auto empty_entry = make_shared_ptr<ConditionCacheEntry>();
 	return make_uniq<ConditionCacheFilterBindData>(std::move(empty_entry));
 }
 
-// Per-thread local state (placeholder for future use)
 struct ConditionCacheFilterState : public FunctionLocalState {};
 
 unique_ptr<FunctionLocalState> ConditionCacheFilterInit(ExpressionState &state, const BoundFunctionExpression &expr,
@@ -39,13 +36,10 @@ void ConditionCacheFilterFn(DataChunk &args, ExpressionState &state, Vector &res
 	D_ASSERT(args.size() > 0);
 	D_ASSERT(args.ColumnCount() > 0);
 	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<ConditionCacheFilterBindData>();
-	auto &entry = *bind_data.cache_entry;
-	concurrency::lock_guard<concurrency::mutex> guard(entry.lock);
+	auto &entry = bind_data.cache_entry;
 
 	auto &input_vec = args.data[0];
 
-	// All row_ids in a single vector belong to the same row group + vector range,
-	// so checking the first row_id is sufficient.
 	UnifiedVectorFormat vdata;
 	input_vec.ToUnifiedFormat(args.size(), vdata);
 	auto row_ids = UnifiedVectorFormat::GetData<int64_t>(vdata);
@@ -55,11 +49,7 @@ void ConditionCacheFilterFn(DataChunk &args, ExpressionState &state, Vector &res
 
 	idx_t rg_idx = NumericCast<idx_t>(first_row_id) / DEFAULT_ROW_GROUP_SIZE;
 	idx_t vec_idx = (NumericCast<idx_t>(first_row_id) % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
-	bool passes = true;
-	auto it = entry.bitvectors.find(rg_idx);
-	if (it != entry.bitvectors.end()) {
-		passes = it->second.VectorHasRows(vec_idx);
-	}
+	bool passes = entry->VectorPassesFilter(rg_idx, vec_idx);
 
 	result.Reference(Value::BOOLEAN(passes));
 }
@@ -69,7 +59,6 @@ CacheExpressionFilter::CacheExpressionFilter(unique_ptr<Expression> expr_p, shar
 }
 
 FilterPropagateResult CacheExpressionFilter::CheckStatistics(BaseStatistics &stats) const {
-	concurrency::lock_guard<concurrency::mutex> guard(cache_entry->lock);
 	if (!NumericStats::HasMinMax(stats)) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
@@ -80,12 +69,8 @@ FilterPropagateResult CacheExpressionFilter::CheckStatistics(BaseStatistics &sta
 	idx_t min_rg = NumericCast<idx_t>(min_val) / DEFAULT_ROW_GROUP_SIZE;
 	idx_t max_rg = NumericCast<idx_t>(max_val) / DEFAULT_ROW_GROUP_SIZE;
 
-	// If any row group is not in cache (e.g. newly inserted) or has matching vectors, we can't prune
-	for (idx_t rg = min_rg; rg <= max_rg; ++rg) {
-		auto it = cache_entry->bitvectors.find(rg);
-		if (it == cache_entry->bitvectors.end() || !it->second.IsEmpty()) {
-			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-		}
+	if (!cache_entry->StatisticsRangeIsAllEmptyCached(min_rg, max_rg)) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 	return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 }

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -142,8 +142,7 @@ public:
 					continue; // skip transaction-local storage rows
 				}
 				idx_t row_group_idx = first_row_id / DEFAULT_ROW_GROUP_SIZE;
-				// Access to instantiate default RowGroupFilter for this row group
-				(void)local_entry.bitvectors[row_group_idx];
+				local_entry.EnsureRowGroup(row_group_idx);
 
 				SelectionVector sel(chunk.size());
 				idx_t match_count = expr_executor.SelectExpression(chunk, sel);
@@ -156,7 +155,7 @@ public:
 					auto row_id = NumericCast<idx_t>(rowids[rowid_entry]);
 					idx_t rg_idx = row_id / DEFAULT_ROW_GROUP_SIZE;
 					idx_t vector_idx = (row_id % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
-					local_entry.bitvectors[rg_idx].SetVector(vector_idx);
+					local_entry.SetQualifyingVector(/*rg_idx=*/rg_idx, /*vec_idx=*/vector_idx);
 				}
 			}
 		}
@@ -177,6 +176,13 @@ private:
 	idx_t rowid_col_idx;
 	ConditionCacheEntry &local_entry;
 };
+
+static void MergeLocalCacheEntries(const vector<ConditionCacheEntry> &local_entries,
+                                   const shared_ptr<ConditionCacheEntry> &entry) {
+	for (const auto &local : local_entries) {
+		entry->MergeFrom(local);
+	}
+}
 
 } // namespace
 
@@ -246,13 +252,8 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 	}
 	task_executor.WorkOnTasks();
 
-	// Merge local entries into final result
 	auto entry = make_shared_ptr<ConditionCacheEntry>();
-	for (const auto &local : local_entries) {
-		for (const auto &[rg_idx, filter] : local.bitvectors) {
-			entry->bitvectors[rg_idx].MergeFrom(filter);
-		}
-	}
+	MergeLocalCacheEntries(local_entries, entry);
 
 	return entry;
 }

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -40,14 +40,14 @@ void RowGroupFilter::MergeFrom(const RowGroupFilter &other) {
 // ------- CONDITION_CACHE_ENTRY -------
 
 optional_idx ConditionCacheEntry::GetEstimatedCacheMemory() const {
-	// Rough estimate: each RowGroupFilter is ~BITVECTOR_ARRAY_SIZE * 8 bytes
-	// Plus overhead for the map structure
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
 	idx_t estimated_size = sizeof(ConditionCacheEntry);
-	estimated_size += bitvectors.size() * (sizeof(idx_t) + sizeof(RowGroupFilter) + 32); // map overhead
+	estimated_size += bitvectors.size() * (sizeof(idx_t) + sizeof(RowGroupFilter) + 32);
 	return optional_idx(estimated_size);
 }
 
 CacheEntryStats ConditionCacheEntry::ComputeStats(idx_t total_rows) const {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
 	constexpr idx_t vectors_per_row_group = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
 
 	idx_t qualifying_vectors = 0;
@@ -79,6 +79,91 @@ CacheEntryStats ConditionCacheEntry::ComputeStats(idx_t total_rows) const {
 	};
 }
 
+void ConditionCacheEntry::EnsureRowGroup(idx_t rg_idx) {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	(void)bitvectors[rg_idx];
+}
+
+void ConditionCacheEntry::SetQualifyingVector(idx_t rg_idx, idx_t vec_idx) {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	bitvectors[rg_idx].SetVector(vec_idx);
+}
+
+void ConditionCacheEntry::MergeFrom(const ConditionCacheEntry &other) {
+	if (this == &other) {
+		return;
+	}
+	vector<pair<idx_t, RowGroupFilter>> snapshot;
+	{
+		concurrency::lock_guard<concurrency::mutex> guard(other.lock);
+		snapshot.reserve(other.bitvectors.size());
+		for (const auto &kv : other.bitvectors) {
+			snapshot.push_back(kv);
+		}
+	}
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	for (const auto &[rg_idx, filter] : snapshot) {
+		bitvectors[rg_idx].MergeFrom(filter);
+	}
+}
+
+bool ConditionCacheEntry::VectorPassesFilter(idx_t rg_idx, idx_t vec_idx) const {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	auto it = bitvectors.find(rg_idx);
+	if (it == bitvectors.end()) {
+		return true;
+	}
+	return it->second.VectorHasRows(vec_idx);
+}
+
+bool ConditionCacheEntry::StatisticsRangeIsAllEmptyCached(idx_t min_rg, idx_t max_rg) const {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	for (idx_t rg = min_rg; rg <= max_rg; ++rg) {
+		auto it = bitvectors.find(rg);
+		if (it == bitvectors.end() || !it->second.IsEmpty()) {
+			return false;
+		}
+	}
+	return true;
+}
+
+idx_t ConditionCacheEntry::RowGroupCount() const {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	return bitvectors.size();
+}
+
+bool ConditionCacheEntry::HasRowGroup(idx_t rg_idx) const {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	return bitvectors.find(rg_idx) != bitvectors.end();
+}
+
+bool ConditionCacheEntry::RowGroupVectorHasQualifyingRows(idx_t rg_idx, idx_t vec_idx) const {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	auto it = bitvectors.find(rg_idx);
+	if (it == bitvectors.end()) {
+		return false;
+	}
+	return it->second.VectorHasRows(vec_idx);
+}
+
+bool ConditionCacheEntry::RowGroupIsCompletelyEmpty(idx_t rg_idx) const {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	auto it = bitvectors.find(rg_idx);
+	if (it == bitvectors.end()) {
+		return false;
+	}
+	return it->second.IsEmpty();
+}
+
+pair<idx_t, bool> ConditionCacheEntry::EraseRowGroups(const unordered_set<idx_t> &row_group_indices) {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	idx_t removed = 0;
+	for (auto rg_idx : row_group_indices) {
+		removed += bitvectors.erase(rg_idx);
+	}
+	return {removed, bitvectors.empty()};
+}
+
 // ------- TABLE_FILTER_KEY_INDEX -------
 
 void TableFilterKeyIndex::Add(const string &filter_key) {
@@ -104,7 +189,6 @@ unordered_set<string> TableFilterKeyIndex::GetAll() {
 
 // ------- CONDITION_CACHE_STORE -------
 
-// Format: "query_condition_cache_entry:{table_oid}:{filter_key}"
 string ConditionCacheStore::MakeCacheKeyString(const CacheKey &key) {
 	return StringUtil::Format("query_condition_cache_entry:%llu:%s", key.table_oid, key.filter_key);
 }
@@ -125,11 +209,9 @@ void ConditionCacheStore::Upsert(ClientContext &context, const CacheKey &key, sh
 	auto &cache = ObjectCache::GetObjectCache(context);
 	cache.Put(MakeCacheKeyString(key), std::move(entry));
 
-	// Maintain per-table index for invalidation lookup
 	auto index = cache.GetOrCreate<TableFilterKeyIndex>(MakeFilterKeyIndexKey(key.table_oid));
 	index->Add(key.filter_key);
 
-	// Track table OID for ClearAll
 	concurrency::lock_guard<concurrency::mutex> guard(lock);
 	cached_table_oids.insert(key.table_oid);
 }
@@ -151,21 +233,17 @@ idx_t ConditionCacheStore::RemoveRowGroupsForTable(ClientContext &context, idx_t
 		string cache_key = MakeCacheKeyString(key);
 		auto entry = cache.Get<ConditionCacheEntry>(cache_key);
 		if (!entry) {
-			// Entry was evicted by LRU, clean up stale index
 			index->Remove(filter_key);
 			continue;
 		}
-		concurrency::lock_guard<concurrency::mutex> entry_guard(entry->lock);
-		for (auto rg_idx : row_group_indices) {
-			removed_count += entry->bitvectors.erase(rg_idx);
-		}
-		if (entry->bitvectors.empty()) {
+		auto erased = entry->EraseRowGroups(row_group_indices);
+		removed_count += erased.first;
+		if (erased.second) {
 			cache.Delete(cache_key);
 			index->Remove(filter_key);
 		}
 	}
 
-	// Clean up cached_table_oids if all entries for this table are gone
 	if (index->IsEmpty()) {
 		cache.Delete(MakeFilterKeyIndexKey(table_oid));
 		concurrency::lock_guard<concurrency::mutex> guard(lock);

--- a/test/unittest/test_build_cache_entry.cpp
+++ b/test/unittest/test_build_cache_entry.cpp
@@ -16,7 +16,6 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 	DuckDB db(nullptr);
 	Connection con(db);
 
-	// Create table with enough rows to span multiple row groups
 	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
 
 	auto &context = *con.context;
@@ -30,14 +29,13 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
 		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-		// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN
 		bound_expr =
 		    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
 
 		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
 		REQUIRE(entry != nullptr);
-		REQUIRE(entry->bitvectors.size() == 5); // 5 row groups
+		REQUIRE(entry->RowGroupCount() == 5);
 	}
 
 	SECTION("selective predicate") {
@@ -47,18 +45,17 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
 		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-		// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN
 		bound_expr =
 		    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
 
 		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
 		REQUIRE(entry != nullptr);
-		REQUIRE(entry->bitvectors.size() == 5); // all row groups are cached
-		REQUIRE(entry->bitvectors.at(0).VectorHasRows(0));
-		REQUIRE(entry->bitvectors.at(0).VectorHasRows(1));
-		REQUIRE_FALSE(entry->bitvectors.at(0).VectorHasRows(2));
-		REQUIRE(entry->bitvectors.at(1).IsEmpty());
+		REQUIRE(entry->RowGroupCount() == 5);
+		REQUIRE(entry->RowGroupVectorHasQualifyingRows(0, 0));
+		REQUIRE(entry->RowGroupVectorHasQualifyingRows(0, 1));
+		REQUIRE_FALSE(entry->RowGroupVectorHasQualifyingRows(0, 2));
+		REQUIRE(entry->RowGroupIsCompletelyEmpty(1));
 	}
 
 	SECTION("odd values pass, even values don't") {
@@ -68,15 +65,13 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
 		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-		// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN
 		bound_expr =
 		    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
 
 		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
 		REQUIRE(entry != nullptr);
-		// Odd values exist in every row group, so all 5 row groups should be present
-		REQUIRE(entry->bitvectors.size() == 5);
+		REQUIRE(entry->RowGroupCount() == 5);
 	}
 
 	SECTION("no matching rows") {
@@ -86,16 +81,15 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		CheckBinder check_binder(*binder, context, "t", table_entry.GetColumns(), bound_columns);
 		auto bound_expr = check_binder.Bind(parsed_exprs[0]);
 
-		// CheckBinder always sets target_type = INTEGER, so re-cast to BOOLEAN
 		bound_expr =
 		    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
 
 		auto entry = BuildCacheEntry(context, table_entry, *bound_expr);
 
 		REQUIRE(entry != nullptr);
-		REQUIRE(entry->bitvectors.size() == 5);
-		REQUIRE(entry->bitvectors.at(0).IsEmpty());
-		REQUIRE(entry->bitvectors.at(4).IsEmpty());
+		REQUIRE(entry->RowGroupCount() == 5);
+		REQUIRE(entry->RowGroupIsCompletelyEmpty(0));
+		REQUIRE(entry->RowGroupIsCompletelyEmpty(4));
 	}
 }
 } // namespace duckdb

--- a/test/unittest/test_cache_invalidation.cpp
+++ b/test/unittest/test_cache_invalidation.cpp
@@ -19,9 +19,9 @@ TEST_CASE("RemoveRowGroupsForTable - basic operations", "[invalidation]") {
 
 	SECTION("removes specified row groups from matching table entries") {
 		auto entry = make_shared_ptr<ConditionCacheEntry>();
-		entry->bitvectors[0].SetVector(0);
-		entry->bitvectors[1].SetVector(0);
-		entry->bitvectors[2].SetVector(0);
+		entry->SetQualifyingVector(/*rg_idx=*/0, /*vec_idx=*/0);
+		entry->SetQualifyingVector(/*rg_idx=*/1, /*vec_idx=*/0);
+		entry->SetQualifyingVector(/*rg_idx=*/2, /*vec_idx=*/0);
 		store->Upsert(context, {/*table_oid=*/1, "val > 5"}, entry);
 
 		unordered_set<idx_t> rg_indices = {0, 2};
@@ -30,14 +30,14 @@ TEST_CASE("RemoveRowGroupsForTable - basic operations", "[invalidation]") {
 
 		auto found = store->Lookup(context, {/*table_oid=*/1, "val > 5"});
 		REQUIRE(found != nullptr);
-		REQUIRE(found->bitvectors.count(0) == 0);
-		REQUIRE(found->bitvectors.count(1) == 1);
-		REQUIRE(found->bitvectors.count(2) == 0);
+		REQUIRE_FALSE(found->HasRowGroup(0));
+		REQUIRE(found->HasRowGroup(1));
+		REQUIRE_FALSE(found->HasRowGroup(2));
 	}
 
 	SECTION("removes entire entry when all row groups are removed") {
 		auto entry = make_shared_ptr<ConditionCacheEntry>();
-		entry->bitvectors[0].SetVector(0);
+		entry->SetQualifyingVector(/*rg_idx=*/0, /*vec_idx=*/0);
 		store->Upsert(context, {/*table_oid=*/1, "val > 5"}, entry);
 
 		unordered_set<idx_t> rg_indices = {0};
@@ -48,11 +48,11 @@ TEST_CASE("RemoveRowGroupsForTable - basic operations", "[invalidation]") {
 
 	SECTION("does not affect entries for other tables") {
 		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
-		entry1->bitvectors[0].SetVector(0);
+		entry1->SetQualifyingVector(/*rg_idx=*/0, /*vec_idx=*/0);
 		store->Upsert(context, {/*table_oid=*/1, "val > 5"}, entry1);
 
 		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
-		entry2->bitvectors[0].SetVector(0);
+		entry2->SetQualifyingVector(/*rg_idx=*/0, /*vec_idx=*/0);
 		store->Upsert(context, {/*table_oid=*/2, "val > 5"}, entry2);
 
 		unordered_set<idx_t> rg_indices = {0};
@@ -61,33 +61,33 @@ TEST_CASE("RemoveRowGroupsForTable - basic operations", "[invalidation]") {
 		REQUIRE(store->Lookup(context, {/*table_oid=*/1, "val > 5"}) == nullptr);
 		auto found2 = store->Lookup(context, {/*table_oid=*/2, "val > 5"});
 		REQUIRE(found2 != nullptr);
-		REQUIRE(found2->bitvectors.count(0) == 1);
+		REQUIRE(found2->HasRowGroup(0));
 	}
 
 	SECTION("removes from multiple entries for the same table") {
 		auto entry1 = make_shared_ptr<ConditionCacheEntry>();
-		entry1->bitvectors[0].SetVector(0);
-		entry1->bitvectors[1].SetVector(0);
+		entry1->SetQualifyingVector(/*rg_idx=*/0, /*vec_idx=*/0);
+		entry1->SetQualifyingVector(/*rg_idx=*/1, /*vec_idx=*/0);
 		store->Upsert(context, {/*table_oid=*/1, "val > 5"}, entry1);
 
 		auto entry2 = make_shared_ptr<ConditionCacheEntry>();
-		entry2->bitvectors[0].SetVector(0);
-		entry2->bitvectors[1].SetVector(0);
+		entry2->SetQualifyingVector(/*rg_idx=*/0, /*vec_idx=*/0);
+		entry2->SetQualifyingVector(/*rg_idx=*/1, /*vec_idx=*/0);
 		store->Upsert(context, {/*table_oid=*/1, "val < 10"}, entry2);
 
 		unordered_set<idx_t> rg_indices = {0};
 		auto removed = store->RemoveRowGroupsForTable(context, /*table_oid=*/1, rg_indices);
-		REQUIRE(removed == 2); // one from each entry
+		REQUIRE(removed == 2);
 
 		auto found1 = store->Lookup(context, {/*table_oid=*/1, "val > 5"});
 		REQUIRE(found1 != nullptr);
-		REQUIRE(found1->bitvectors.count(0) == 0);
-		REQUIRE(found1->bitvectors.count(1) == 1);
+		REQUIRE_FALSE(found1->HasRowGroup(0));
+		REQUIRE(found1->HasRowGroup(1));
 
 		auto found2 = store->Lookup(context, {/*table_oid=*/1, "val < 10"});
 		REQUIRE(found2 != nullptr);
-		REQUIRE(found2->bitvectors.count(0) == 0);
-		REQUIRE(found2->bitvectors.count(1) == 1);
+		REQUIRE_FALSE(found2->HasRowGroup(0));
+		REQUIRE(found2->HasRowGroup(1));
 	}
 }
 } // namespace duckdb

--- a/test/unittest/test_filter.cpp
+++ b/test/unittest/test_filter.cpp
@@ -8,15 +8,12 @@
 namespace duckdb {
 
 TEST_CASE("CacheExpressionFilter - CheckStatistics", "[query_condition_cache]") {
-	// Build a cache entry with qualifying vectors in row group 0 and 2,
-	// and an explicitly cached empty row group 1.
 	auto entry = make_shared_ptr<ConditionCacheEntry>();
-	entry->bitvectors[0].SetVector(0);
-	entry->bitvectors[0].SetVector(5);
-	entry->bitvectors[1];
-	entry->bitvectors[2].SetVector(10);
+	entry->SetQualifyingVector(/*rg_idx=*/0, /*vec_idx=*/0);
+	entry->SetQualifyingVector(/*rg_idx=*/0, /*vec_idx=*/5);
+	entry->EnsureRowGroup(/*rg_idx=*/1);
+	entry->SetQualifyingVector(/*rg_idx=*/2, /*vec_idx=*/10);
 
-	// Create a dummy expression for the filter (won't be evaluated in stats check)
 	auto dummy_expr = make_uniq<BoundReferenceExpression>(LogicalType {LogicalTypeId::BIGINT}, 0);
 	CacheExpressionFilter filter(std::move(dummy_expr), entry);
 


### PR DESCRIPTION
This PR does a few things:
- Fix compilation option for thread annotation
- Apply thread annotation correctly to fix data race
- Extract a few member functions, we don't need to acquire lock outside