### PR TITLE
Implement cache filter injection with PostOptimizeWalk

### DIFF
--- a/src/include/query_condition_cache_filter.hpp
+++ b/src/include/query_condition_cache_filter.hpp
@@ -28,6 +28,8 @@ unique_ptr<FunctionData> ConditionCacheFilterBind(ClientContext &context, Scalar
 unique_ptr<FunctionLocalState> ConditionCacheFilterInit(ExpressionState &state, const BoundFunctionExpression &expr,
                                                         FunctionData *bind_data);
 
+ScalarFunction ConditionCacheFilterFunction();
+
 // Vector-level filter: takes a ROW_ID column as input, looks up the bitvector
 // for that row group + vector index, and returns a constant BOOLEAN for the
 // entire vector. Defaults to true for row groups not in cache.

--- a/src/include/query_condition_cache_filter.hpp
+++ b/src/include/query_condition_cache_filter.hpp
@@ -28,6 +28,7 @@ unique_ptr<FunctionData> ConditionCacheFilterBind(ClientContext &context, Scalar
 unique_ptr<FunctionLocalState> ConditionCacheFilterInit(ExpressionState &state, const BoundFunctionExpression &expr,
                                                         FunctionData *bind_data);
 
+// Factory for the internal scalar filter ConditionCacheFilterFn used by optimizer-injected cache checks.
 ScalarFunction ConditionCacheFilterFunction();
 
 // Vector-level filter: takes a ROW_ID column as input, looks up the bitvector

--- a/src/include/query_condition_cache_optimizer.hpp
+++ b/src/include/query_condition_cache_optimizer.hpp
@@ -51,6 +51,14 @@ private:
 	static shared_ptr<ConditionCacheEntry>
 	BuildCacheForPredicate(ClientContext &context, const vector<unique_ptr<Expression>> &expressions, LogicalGet &get);
 
+	// Walk plan after built-in optimization and inject cache filters into matching table scans.
+	static void PostOptimizeWalk(ClientContext &context, unique_ptr<LogicalOperator> &plan,
+	                             CacheOptimizerQueryState &state);
+
+	// Inject a rowid-backed cache filter into a LogicalGet while preserving its visible output.
+	static void InjectCacheFilter(ClientContext &context, LogicalGet &get,
+	                              const shared_ptr<ConditionCacheEntry> &entry);
+
 	// Reconstruct SQL from filter expressions, sort for alphabetical ordering
 	static string ReconstructPredicateSQL(const vector<unique_ptr<Expression>> &expressions);
 };

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -28,10 +28,7 @@ void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(ConditionCacheInfoFunction());
 
 	// Register the internal filter function so it survives plan serialization/verification
-	ScalarFunction cache_filter_func("__condition_cache_filter", {LogicalType {LogicalTypeId::BIGINT}},
-	                                 LogicalType {LogicalTypeId::BOOLEAN}, ConditionCacheFilterFn,
-	                                 ConditionCacheFilterBind, nullptr, nullptr, ConditionCacheFilterInit);
-	loader.RegisterFunction(cache_filter_func);
+	loader.RegisterFunction(ConditionCacheFilterFunction());
 
 	// Register the use_query_condition_cache setting (default: true)
 	auto &db = loader.GetDatabaseInstance();

--- a/src/query_condition_cache_filter.cpp
+++ b/src/query_condition_cache_filter.cpp
@@ -35,6 +35,12 @@ unique_ptr<FunctionLocalState> ConditionCacheFilterInit(ExpressionState &state, 
 	return make_uniq<ConditionCacheFilterState>();
 }
 
+ScalarFunction ConditionCacheFilterFunction() {
+	return ScalarFunction("__condition_cache_filter", {LogicalType {LogicalTypeId::BIGINT}},
+	                      LogicalType {LogicalTypeId::BOOLEAN}, ConditionCacheFilterFn, ConditionCacheFilterBind,
+	                      nullptr, nullptr, ConditionCacheFilterInit);
+}
+
 void ConditionCacheFilterFn(DataChunk &args, ExpressionState &state, Vector &result) {
 	D_ASSERT(args.size() > 0);
 	D_ASSERT(args.ColumnCount() > 0);

--- a/src/query_condition_cache_optimizer.cpp
+++ b/src/query_condition_cache_optimizer.cpp
@@ -9,7 +9,6 @@
 #include "duckdb/common/algorithm.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector.hpp"
-#include "duckdb/function/function_binder.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
@@ -187,22 +186,12 @@ void QueryConditionCacheOptimizer::InjectCacheFilter(ClientContext &context, Log
 		column_ids.emplace_back(COLUMN_IDENTIFIER_ROW_ID);
 	}
 
-	vector<unique_ptr<Expression>> arguments;
-	arguments.push_back(make_uniq<BoundReferenceExpression>(LogicalType::ROW_TYPE, 0U));
+	vector<unique_ptr<Expression>> children;
+	children.push_back(make_uniq<BoundReferenceExpression>(LogicalType {LogicalTypeId::BIGINT}, 0U));
 
-	FunctionBinder binder(context);
-	ErrorData error;
-	auto filter_expr =
-	    binder.BindScalarFunction(DEFAULT_SCHEMA, "__condition_cache_filter", std::move(arguments), error);
-	if (!filter_expr) {
-		error.Throw();
-	}
-	if (filter_expr->GetExpressionType() != ExpressionType::BOUND_FUNCTION) {
-		throw InternalException("Expected __condition_cache_filter to bind to a scalar function expression");
-	}
-
-	auto &function_expr = filter_expr->Cast<BoundFunctionExpression>();
-	function_expr.bind_info = make_uniq<ConditionCacheFilterBindData>(entry);
+	auto filter_expr = make_uniq<BoundFunctionExpression>(LogicalType {LogicalTypeId::BOOLEAN},
+	                                                      ConditionCacheFilterFunction(), std::move(children),
+	                                                      make_uniq<ConditionCacheFilterBindData>(entry));
 
 	get.table_filters.PushFilter(ColumnIndex(COLUMN_IDENTIFIER_ROW_ID),
 	                             make_uniq<CacheExpressionFilter>(std::move(filter_expr), entry));

--- a/src/query_condition_cache_optimizer.cpp
+++ b/src/query_condition_cache_optimizer.cpp
@@ -1,5 +1,6 @@
 #include "query_condition_cache_optimizer.hpp"
 
+#include "query_condition_cache_filter.hpp"
 #include "predicate_key_utils.hpp"
 #include "query_condition_cache_functions.hpp"
 #include "query_condition_cache_state.hpp"
@@ -8,7 +9,10 @@
 #include "duckdb/common/algorithm.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/function/function_binder.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 
@@ -143,9 +147,78 @@ shared_ptr<ConditionCacheEntry> QueryConditionCacheOptimizer::BuildCacheForPredi
 	return BuildCacheEntry(context, table_entry, *bound_expr);
 }
 
-// TODO: Implement PostOptimizeWalk + InjectCacheFilter to inject cache filters
-// into LogicalGet nodes using cache_apply_pending entries.
+void QueryConditionCacheOptimizer::PostOptimizeWalk(ClientContext &context, unique_ptr<LogicalOperator> &plan,
+                                                    CacheOptimizerQueryState &state) {
+	for (auto &child : plan->children) {
+		PostOptimizeWalk(context, child, state);
+	}
+
+	if (plan->type != LogicalOperatorType::LOGICAL_GET) {
+		return;
+	}
+
+	auto &get = plan->Cast<LogicalGet>();
+	auto entry = state.cache_apply_pending.find(get.table_index);
+	if (entry == state.cache_apply_pending.end()) {
+		return;
+	}
+
+	InjectCacheFilter(context, get, entry->second);
+	state.cache_apply_pending.erase(entry);
+}
+
+void QueryConditionCacheOptimizer::InjectCacheFilter(ClientContext &context, LogicalGet &get,
+                                                     const shared_ptr<ConditionCacheEntry> &entry) {
+	auto &column_ids = get.GetMutableColumnIds();
+	bool has_row_id = false;
+	for (const auto &column_id : column_ids) {
+		if (column_id.IsRowIdColumn()) {
+			has_row_id = true;
+			break;
+		}
+	}
+	if (!has_row_id) {
+		if (get.projection_ids.empty() && !column_ids.empty()) {
+			get.projection_ids.reserve(column_ids.size());
+			for (idx_t i = 0; i < column_ids.size(); i++) {
+				get.projection_ids.push_back(i);
+			}
+		}
+		column_ids.emplace_back(COLUMN_IDENTIFIER_ROW_ID);
+	}
+
+	vector<unique_ptr<Expression>> arguments;
+	arguments.push_back(make_uniq<BoundReferenceExpression>(LogicalType::ROW_TYPE, 0U));
+
+	FunctionBinder binder(context);
+	ErrorData error;
+	auto filter_expr =
+	    binder.BindScalarFunction(DEFAULT_SCHEMA, "__condition_cache_filter", std::move(arguments), error);
+	if (!filter_expr) {
+		error.Throw();
+	}
+	if (filter_expr->GetExpressionType() != ExpressionType::BOUND_FUNCTION) {
+		throw InternalException("Expected __condition_cache_filter to bind to a scalar function expression");
+	}
+
+	auto &function_expr = filter_expr->Cast<BoundFunctionExpression>();
+	function_expr.bind_info = make_uniq<ConditionCacheFilterBindData>(entry);
+
+	get.table_filters.PushFilter(ColumnIndex(COLUMN_IDENTIFIER_ROW_ID),
+	                             make_uniq<CacheExpressionFilter>(std::move(filter_expr), entry));
+}
+
 void QueryConditionCacheOptimizer::OptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
+	if (!IsSettingEnabled(input.context)) {
+		return;
+	}
+
+	auto query_state = input.context.registered_state->Get<CacheOptimizerQueryState>(CacheOptimizerQueryState::NAME);
+	if (!query_state || query_state->cache_apply_pending.empty()) {
+		return;
+	}
+
+	PostOptimizeWalk(input.context, plan, *query_state);
 }
 
 } // namespace duckdb

--- a/src/query_condition_cache_optimizer.cpp
+++ b/src/query_condition_cache_optimizer.cpp
@@ -189,9 +189,9 @@ void QueryConditionCacheOptimizer::InjectCacheFilter(ClientContext &context, Log
 	vector<unique_ptr<Expression>> children;
 	children.push_back(make_uniq<BoundReferenceExpression>(LogicalType {LogicalTypeId::BIGINT}, 0U));
 
-	auto filter_expr = make_uniq<BoundFunctionExpression>(LogicalType {LogicalTypeId::BOOLEAN},
-	                                                      ConditionCacheFilterFunction(), std::move(children),
-	                                                      make_uniq<ConditionCacheFilterBindData>(entry));
+	auto filter_expr =
+	    make_uniq<BoundFunctionExpression>(LogicalType {LogicalTypeId::BOOLEAN}, ConditionCacheFilterFunction(),
+	                                       std::move(children), make_uniq<ConditionCacheFilterBindData>(entry));
 
 	get.table_filters.PushFilter(ColumnIndex(COLUMN_IDENTIFIER_ROW_ID),
 	                             make_uniq<CacheExpressionFilter>(std::move(filter_expr), entry));

--- a/test/unittest/test_filter.cpp
+++ b/test/unittest/test_filter.cpp
@@ -13,7 +13,9 @@
 
 namespace duckdb {
 
-static optional_ptr<LogicalGet> FindLogicalGet(LogicalOperator &op) {
+namespace {
+
+optional_ptr<LogicalGet> FindLogicalGet(LogicalOperator &op) {
 	if (op.type == LogicalOperatorType::LOGICAL_GET) {
 		return op.Cast<LogicalGet>();
 	}
@@ -25,6 +27,8 @@ static optional_ptr<LogicalGet> FindLogicalGet(LogicalOperator &op) {
 	}
 	return nullptr;
 }
+
+} // namespace
 
 TEST_CASE("CacheExpressionFilter - CheckStatistics", "[query_condition_cache]") {
 	// Build a cache entry with qualifying vectors in row group 0 and 2,

--- a/test/unittest/test_filter.cpp
+++ b/test/unittest/test_filter.cpp
@@ -2,10 +2,29 @@
 #include "query_condition_cache_filter.hpp"
 #include "query_condition_cache_state.hpp"
 
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/storage/statistics/numeric_stats.hpp"
+#include "test_helpers.hpp"
 
 namespace duckdb {
+
+static optional_ptr<LogicalGet> FindLogicalGet(LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_GET) {
+		return op.Cast<LogicalGet>();
+	}
+	for (auto &child : op.children) {
+		auto result = FindLogicalGet(*child);
+		if (result) {
+			return result;
+		}
+	}
+	return nullptr;
+}
 
 TEST_CASE("CacheExpressionFilter - CheckStatistics", "[query_condition_cache]") {
 	// Build a cache entry with qualifying vectors in row group 0 and 2,
@@ -44,6 +63,69 @@ TEST_CASE("CacheExpressionFilter - CheckStatistics", "[query_condition_cache]") 
 	SECTION("stats without min/max: no pruning") {
 		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
 		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::NO_PRUNING_POSSIBLE);
+	}
+}
+
+TEST_CASE("Optimizer injects cache filter into LogicalGet", "[query_condition_cache]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("LOAD query_condition_cache"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(1000) t(i)"));
+	REQUIRE_NO_FAIL(con.Query("SELECT status FROM condition_cache_build('t', 'val = 42')"));
+
+	auto require_rowid_cache_filter = [&](const string &query) {
+		auto plan = con.ExtractPlan(query);
+		REQUIRE(plan != nullptr);
+
+		auto get = FindLogicalGet(*plan);
+		REQUIRE(get);
+
+		auto rowid_filter = get->table_filters.filters.find(COLUMN_IDENTIFIER_ROW_ID);
+		REQUIRE(rowid_filter != get->table_filters.filters.end());
+
+		auto &expr_filter = rowid_filter->second->Cast<ExpressionFilter>();
+		REQUIRE(expr_filter.expr->GetExpressionType() == ExpressionType::BOUND_FUNCTION);
+
+		auto &function_expr = expr_filter.expr->Cast<BoundFunctionExpression>();
+		REQUIRE(function_expr.function.name == "__condition_cache_filter");
+		REQUIRE(function_expr.bind_info != nullptr);
+
+		auto &bind_data = function_expr.bind_info->Cast<ConditionCacheFilterBindData>();
+		REQUIRE(bind_data.cache_entry != nullptr);
+		return plan;
+	};
+
+	SECTION("count(*) query appends hidden rowid column") {
+		auto plan = require_rowid_cache_filter("SELECT count(*) FROM t WHERE val = 42");
+		auto get = FindLogicalGet(*plan);
+		REQUIRE(get);
+		REQUIRE(get->table_filters.filters.count(COLUMN_IDENTIFIER_ROW_ID) == 1);
+	}
+
+	SECTION("query selecting rowid still receives cache filter") {
+		auto plan = require_rowid_cache_filter("SELECT rowid FROM t WHERE val = 42");
+		auto get = FindLogicalGet(*plan);
+		REQUIRE(get);
+		REQUIRE(get->table_filters.filters.count(COLUMN_IDENTIFIER_ROW_ID) == 1);
+	}
+
+	SECTION("regular projection query still receives cache filter") {
+		auto plan = require_rowid_cache_filter("SELECT id FROM t WHERE val = 42");
+		auto get = FindLogicalGet(*plan);
+		REQUIRE(get);
+		REQUIRE(get->table_filters.filters.count(COLUMN_IDENTIFIER_ROW_ID) == 1);
+	}
+
+	SECTION("setting disabled skips injection") {
+		REQUIRE_NO_FAIL(con.Query("SET use_query_condition_cache = false"));
+
+		auto plan = con.ExtractPlan("SELECT count(*) FROM t WHERE val = 42");
+		REQUIRE(plan != nullptr);
+
+		auto get = FindLogicalGet(*plan);
+		REQUIRE(get);
+		REQUIRE(get->table_filters.filters.find(COLUMN_IDENTIFIER_ROW_ID) == get->table_filters.filters.end());
 	}
 }
 } // namespace duckdb


### PR DESCRIPTION
Take the `CacheOptimizerQueryState` that is cooked during pre-optimize from query context, use its data to create the `CacheExpressionFilter` function expression and then push it to `row id column`'s filter

We got up to 150x faster on the  S3-Q2 query of HDFS Logs Benchmark Suite.

<img width="3134" height="1039" alt="image" src="https://github.com/user-attachments/assets/ecf1d5da-5294-4850-a31d-be1a9b452ea2" />
