### PR TITLE
Improve predicate key and filter index efficiency

### DIFF
--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -129,7 +129,14 @@ struct TableFilterKeyIndex : public ObjectCacheEntry {
 	// Remove a filter key. Assumes the key must appear in the set.
 	void Remove(const string &filter_key);
 	bool IsEmpty();
-	unordered_set<string> GetAll();
+	// Invoke callback for each filter key while holding the lock.
+	template <typename Fn>
+	void ForEach(Fn &&fn) {
+		concurrency::lock_guard<concurrency::mutex> guard(lock);
+		for (const auto &key : filter_keys) {
+			fn(key);
+		}
+	}
 };
 
 // Stored in DuckDB's per-database ObjectCache

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -129,14 +129,8 @@ struct TableFilterKeyIndex : public ObjectCacheEntry {
 	// Remove a filter key. Assumes the key must appear in the set.
 	void Remove(const string &filter_key);
 	bool IsEmpty();
-	// Invoke callback for each filter key while holding the lock.
-	template <typename Fn>
-	void ForEach(Fn &&fn) {
-		concurrency::lock_guard<concurrency::mutex> guard(lock);
-		for (const auto &key : filter_keys) {
-			fn(key);
-		}
-	}
+	// Transfer ownership of all filter keys out. Clears the internal set.
+	unordered_set<string> Take();
 };
 
 // Stored in DuckDB's per-database ObjectCache

--- a/src/predicate_key_utils.cpp
+++ b/src/predicate_key_utils.cpp
@@ -58,7 +58,7 @@ void NormalizeExpressionForCacheKey(Expression &expr) {
 	// Pre-compute ToString() for each child.
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION) {
 		auto &conj = expr.Cast<BoundConjunctionExpression>();
-		vector<pair<string, idx_t>> keyed;
+		vector<pair<string, idx_t>> keyed; // (ToString() result, child index)
 		keyed.reserve(conj.children.size());
 		for (idx_t i = 0; i < conj.children.size(); ++i) {
 			keyed.emplace_back(conj.children[i]->ToString(), i);

--- a/src/predicate_key_utils.cpp
+++ b/src/predicate_key_utils.cpp
@@ -54,14 +54,23 @@ void NormalizeExpressionForCacheKey(Expression &expr) {
 		return;
 	}
 
-	// Sort conjunction children for canonical ordering
-	// TODO: ToString() is called O(NlogN) times during sort
+	// Sort conjunction children for canonical ordering.
+	// Pre-compute ToString() for each child.
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_CONJUNCTION) {
 		auto &conj = expr.Cast<BoundConjunctionExpression>();
-		sort(conj.children.begin(), conj.children.end(),
-		     [](const unique_ptr<Expression> &a, const unique_ptr<Expression> &b) {
-			     return a->ToString() < b->ToString();
-		     });
+		vector<pair<string, idx_t>> keyed;
+		keyed.reserve(conj.children.size());
+		for (idx_t i = 0; i < conj.children.size(); ++i) {
+			keyed.emplace_back(conj.children[i]->ToString(), i);
+		}
+		sort(keyed.begin(), keyed.end(),
+		     [](const pair<string, idx_t> &a, const pair<string, idx_t> &b) { return a.first < b.first; });
+		vector<unique_ptr<Expression>> sorted_children;
+		sorted_children.reserve(keyed.size());
+		for (auto &[str, idx] : keyed) {
+			sorted_children.push_back(std::move(conj.children[idx]));
+		}
+		conj.children = std::move(sorted_children);
 	}
 }
 

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -182,6 +182,11 @@ bool TableFilterKeyIndex::IsEmpty() {
 	return filter_keys.empty();
 }
 
+unordered_set<string> TableFilterKeyIndex::Take() {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	return std::move(filter_keys);
+}
+
 // ------- CONDITION_CACHE_STORE -------
 
 string ConditionCacheStore::MakeCacheKeyString(const CacheKey &key) {
@@ -220,9 +225,7 @@ idx_t ConditionCacheStore::RemoveRowGroupsForTable(ClientContext &context, idx_t
 		return 0;
 	}
 
-	// Snapshot filter keys to avoid holding index lock while mutating entries.
-	vector<string> filter_keys;
-	index->ForEach([&filter_keys](const string &key) { filter_keys.push_back(key); });
+	auto filter_keys = index->Take();
 	idx_t removed_count = 0;
 
 	for (const auto &filter_key : filter_keys) {
@@ -230,14 +233,14 @@ idx_t ConditionCacheStore::RemoveRowGroupsForTable(ClientContext &context, idx_t
 		string cache_key = MakeCacheKeyString(key);
 		auto entry = cache.Get<ConditionCacheEntry>(cache_key);
 		if (!entry) {
-			index->Remove(filter_key);
 			continue;
 		}
 		auto erased = entry->EraseRowGroups(row_group_indices);
 		removed_count += erased.first;
 		if (erased.second) {
 			cache.Delete(cache_key);
-			index->Remove(filter_key);
+		} else {
+			index->Add(filter_key);
 		}
 	}
 
@@ -265,9 +268,10 @@ void ConditionCacheStore::ClearAll(ClientContext &context) {
 		if (!index) {
 			continue;
 		}
-		index->ForEach([&](const string &filter_key) {
+		auto filter_keys = index->Take();
+		for (const auto &filter_key : filter_keys) {
 			cache.Delete(MakeCacheKeyString(CacheKey {table_oid, filter_key}));
-		});
+		}
 		cache.Delete(MakeFilterKeyIndexKey(table_oid));
 	}
 	cached_table_oids.clear();

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -182,11 +182,6 @@ bool TableFilterKeyIndex::IsEmpty() {
 	return filter_keys.empty();
 }
 
-unordered_set<string> TableFilterKeyIndex::GetAll() {
-	concurrency::lock_guard<concurrency::mutex> guard(lock);
-	return filter_keys;
-}
-
 // ------- CONDITION_CACHE_STORE -------
 
 string ConditionCacheStore::MakeCacheKeyString(const CacheKey &key) {
@@ -225,7 +220,9 @@ idx_t ConditionCacheStore::RemoveRowGroupsForTable(ClientContext &context, idx_t
 		return 0;
 	}
 
-	auto filter_keys = index->GetAll();
+	// Snapshot filter keys to avoid holding index lock while mutating entries.
+	vector<string> filter_keys;
+	index->ForEach([&filter_keys](const string &key) { filter_keys.push_back(key); });
 	idx_t removed_count = 0;
 
 	for (const auto &filter_key : filter_keys) {
@@ -268,10 +265,9 @@ void ConditionCacheStore::ClearAll(ClientContext &context) {
 		if (!index) {
 			continue;
 		}
-		auto filter_keys = index->GetAll();
-		for (const auto &filter_key : filter_keys) {
+		index->ForEach([&](const string &filter_key) {
 			cache.Delete(MakeCacheKeyString(CacheKey {table_oid, filter_key}));
-		}
+		});
 		cache.Delete(MakeFilterKeyIndexKey(table_oid));
 	}
 	cached_table_oids.clear();


### PR DESCRIPTION
## Summary

This PR improves efficiency in two areas:
- Pre-compute `ToString()` before sorting conjunction children in `NormalizeExpressionForCacheKey`, avoiding redundant calls during comparison.
- Replace `TableFilterKeyIndex::GetAll()` with `ForEach(callback)` to avoid copying the entire set on every invalidation.

## Related Issues

- None
