### PR TITLE
Add integration and E2E tests for invalidation

### DIFF
--- a/test/sql/condition_cache_correctness.test
+++ b/test/sql/condition_cache_correctness.test
@@ -1,0 +1,314 @@
+# name: test/sql/condition_cache_correctness.test
+# description: Verify query results remain correct after DML with condition cache enabled
+# group: [sql]
+
+require query_condition_cache
+
+statement ok
+SET use_query_condition_cache = true;
+
+# UPDATE non-matching -> matching (single row)
+# Cache has bit=0 for the vector containing the updated row.
+# Without invalidation, the vector is skipped and the updated row is lost.
+
+statement ok
+CREATE TABLE t_upd1 AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_upd1 WHERE flag = 1;
+----
+11
+
+statement ok
+UPDATE t_upd1 SET flag = 1 WHERE id = 100000;
+
+query I
+SELECT count(*) FROM t_upd1 WHERE flag = 1;
+----
+12
+
+# Bulk UPDATE across many vectors
+# Updates rows spread across multiple vectors from non-matching to matching.
+
+statement ok
+CREATE TABLE t_upd2 AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_upd2 WHERE flag = 1;
+----
+11
+
+statement ok
+UPDATE t_upd2 SET flag = 1 WHERE id % 2048 = 1000 AND id > 2048;
+
+query I
+SELECT count(*) FROM t_upd2 WHERE flag = 1;
+----
+108
+
+# UPDATE matching -> non-matching (should still be correct)
+# The vector was already bit=1, so scanning it is fine; the updated row
+# just won't match the predicate anymore.
+
+statement ok
+CREATE TABLE t_upd3 AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_upd3 WHERE flag = 1;
+----
+11
+
+statement ok
+UPDATE t_upd3 SET flag = 0 WHERE id = 5;
+
+query I
+SELECT count(*) FROM t_upd3 WHERE flag = 1;
+----
+10
+
+# DELETE should not lose rows that still exist
+
+statement ok
+CREATE TABLE t_del AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_del WHERE flag = 1;
+----
+11
+
+statement ok
+DELETE FROM t_del WHERE id = 5;
+
+query I
+SELECT count(*) FROM t_del WHERE flag = 1;
+----
+10
+
+# INSERT should not hide new matching rows
+
+statement ok
+CREATE TABLE t_ins AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_ins WHERE flag = 1;
+----
+11
+
+statement ok
+INSERT INTO t_ins VALUES (999999, 1);
+
+query I
+SELECT count(*) FROM t_ins WHERE flag = 1;
+----
+12
+
+# Multiple DML operations interleaved with queries
+# Each query must return the correct count reflecting all prior DML.
+
+statement ok
+CREATE TABLE t_multi AS
+  SELECT i AS id,
+         CASE WHEN i % 50000 = 0 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_multi WHERE flag = 1;
+----
+4
+
+statement ok
+UPDATE t_multi SET flag = 1 WHERE id = 75000;
+
+query I
+SELECT count(*) FROM t_multi WHERE flag = 1;
+----
+5
+
+statement ok
+DELETE FROM t_multi WHERE id = 0;
+
+query I
+SELECT count(*) FROM t_multi WHERE flag = 1;
+----
+4
+
+statement ok
+INSERT INTO t_multi VALUES (999999, 1);
+
+query I
+SELECT count(*) FROM t_multi WHERE flag = 1;
+----
+5
+
+statement ok
+UPDATE t_multi SET flag = 0 WHERE id = 75000;
+
+query I
+SELECT count(*) FROM t_multi WHERE flag = 1;
+----
+4
+
+# SUM/actual values (not just count) to catch data correctness
+
+statement ok
+CREATE TABLE t_sum AS
+  SELECT i AS id, i AS val FROM range(200000) t(i);
+
+query I
+SELECT sum(val) FROM t_sum WHERE val < 2048;
+----
+2096128
+
+statement ok
+UPDATE t_sum SET val = 0 WHERE id BETWEEN 100 AND 199;
+
+query I
+SELECT sum(val) FROM t_sum WHERE val < 2048;
+----
+2081178
+
+# MERGE INTO -- matched rows updated, unmatched rows inserted
+# Both paths must be reflected in subsequent queries.
+
+statement ok
+CREATE TABLE t_merge_dst AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+# Prime the cache
+query I
+SELECT count(*) FROM t_merge_dst WHERE flag = 1;
+----
+11
+
+statement ok
+CREATE TABLE t_merge_src (id INTEGER, flag INTEGER);
+
+statement ok
+INSERT INTO t_merge_src VALUES (5, 0), (100000, 1), (300000, 1);
+
+statement ok
+MERGE INTO t_merge_dst AS dst
+USING t_merge_src AS src ON dst.id = src.id
+WHEN MATCHED THEN UPDATE SET flag = src.flag
+WHEN NOT MATCHED THEN INSERT VALUES (src.id, src.flag);
+
+# id=5 was flag=1, now updated to flag=0 -> -1
+# id=100000 was flag=0, now updated to flag=1 -> +1
+# id=300000 inserted with flag=1 -> +1
+# 11 - 1 + 1 + 1 = 12
+query I
+SELECT count(*) FROM t_merge_dst WHERE flag = 1;
+----
+12
+
+# TRUNCATE then query -- stale cache must not cause wrong results
+
+statement ok
+CREATE TABLE t_trunc AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+# Prime the cache
+query I
+SELECT count(*) FROM t_trunc WHERE flag = 1;
+----
+11
+
+statement ok
+TRUNCATE t_trunc;
+
+query I
+SELECT count(*) FROM t_trunc WHERE flag = 1;
+----
+0
+
+# Re-insert different data -- matching row at a different location
+statement ok
+INSERT INTO t_trunc SELECT i AS id, CASE WHEN i = 50000 THEN 1 ELSE 0 END AS flag FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_trunc WHERE flag = 1;
+----
+1
+
+# INSERT into partial tail row group -- correctness
+# Cache is built when the last row group is partially filled.
+# New rows inserted into that partial row group must still be found.
+
+statement ok
+CREATE TABLE t_partial AS
+  SELECT i AS id,
+         CASE WHEN i < 10 THEN 1 ELSE 0 END AS flag
+  FROM range(130000) t(i);
+
+# 130000 rows = 1 full RG (122880) + partial RG with 7120 rows
+# Prime the cache -- flag=1 only in the first vector of RG0
+query I
+SELECT count(*) FROM t_partial WHERE flag = 1;
+----
+10
+
+# Insert a matching row into the partial tail row group
+statement ok
+INSERT INTO t_partial VALUES (999999, 1);
+
+query I
+SELECT count(*) FROM t_partial WHERE flag = 1;
+----
+11
+
+# Insert enough to create a new row group entirely
+statement ok
+INSERT INTO t_partial SELECT i + 1000000 AS id, CASE WHEN i = 0 THEN 1 ELSE 0 END AS flag FROM range(200000) t(i);
+
+query I
+SELECT count(*) FROM t_partial WHERE flag = 1;
+----
+12
+
+# DROP TABLE and recreate -- stale cache must not interfere
+
+statement ok
+CREATE TABLE t_drop AS
+  SELECT i AS id,
+         CASE WHEN i <= 10 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+# Prime the cache
+query I
+SELECT count(*) FROM t_drop WHERE flag = 1;
+----
+11
+
+statement ok
+DROP TABLE t_drop;
+
+statement ok
+CREATE TABLE t_drop AS
+  SELECT i AS id,
+         CASE WHEN i = 50000 THEN 1 ELSE 0 END AS flag
+  FROM range(200000) t(i);
+
+# New table, different data -- must return correct result
+query I
+SELECT count(*) FROM t_drop WHERE flag = 1;
+----
+1

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -14,7 +14,9 @@ set(QUERY_CACHE_UNITTEST_OBJECTS
     test_cache_store.cpp
     test_filter.cpp
     test_helpers_invalidation.cpp
+    test_logical_cache_invalidator.cpp
     test_normalize_expression.cpp
+    test_optimizer_invalidation.cpp
     test_physical_cache_invalidator.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})

--- a/test/unittest/include/test_helpers_invalidation.hpp
+++ b/test/unittest/include/test_helpers_invalidation.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "physical_cache_invalidator.hpp"
 #include "query_condition_cache_state.hpp"
 
 #include "duckdb/main/connection.hpp"
@@ -9,6 +10,21 @@ namespace duckdb {
 idx_t GetTableOid(Connection &con, const string &table_name);
 shared_ptr<ConditionCacheStore> GetStore(Connection &con);
 shared_ptr<ConditionCacheEntry> LookupEntry(Connection &con, idx_t table_oid, const string &predicate);
+shared_ptr<ConditionCacheEntry> LookupEntry(Connection &con, const string &table_name, const string &predicate);
 void BuildCache(Connection &con, const string &table_name, const string &predicate);
+
+// Recursively search the physical plan tree for a PhysicalCacheInvalidator node.
+inline PhysicalCacheInvalidator *FindInvalidator(PhysicalOperator &op) {
+	if (op.GetName() == "CACHE_INVALIDATOR") {
+		return dynamic_cast<PhysicalCacheInvalidator *>(&op);
+	}
+	for (auto &child : op.children) {
+		auto *result = FindInvalidator(child.get());
+		if (result) {
+			return result;
+		}
+	}
+	return nullptr;
+}
 
 } // namespace duckdb

--- a/test/unittest/test_helpers_invalidation.cpp
+++ b/test/unittest/test_helpers_invalidation.cpp
@@ -1,5 +1,7 @@
 #include "test_helpers_invalidation.hpp"
 
+#include "predicate_key_utils.hpp"
+
 #include "catch/catch.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
@@ -7,12 +9,17 @@
 #include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
+namespace {
+
+DuckTableEntry &GetDuckTableEntry(ClientContext &context, const string &table_name) {
+	return Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, table_name);
+}
+
+} // namespace
 
 idx_t GetTableOid(Connection &con, const string &table_name) {
 	con.BeginTransaction();
-	auto &context = *con.context;
-	auto &table_entry = Catalog::GetEntry<DuckTableEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, table_name);
-	auto oid = table_entry.oid;
+	auto oid = GetDuckTableEntry(*con.context, table_name).oid;
 	con.Commit();
 	return oid;
 }
@@ -24,6 +31,17 @@ shared_ptr<ConditionCacheStore> GetStore(Connection &con) {
 shared_ptr<ConditionCacheEntry> LookupEntry(Connection &con, idx_t table_oid, const string &predicate) {
 	auto store = GetStore(con);
 	return store->Lookup(*con.context, {table_oid, predicate});
+}
+
+shared_ptr<ConditionCacheEntry> LookupEntry(Connection &con, const string &table_name, const string &predicate) {
+	auto &context = *con.context;
+	con.BeginTransaction();
+	auto &table_entry = GetDuckTableEntry(context, table_name);
+	auto table_oid = table_entry.oid;
+	auto canonical_key = ComputeCanonicalPredicateKey(context, table_entry, predicate);
+	con.Commit();
+	auto store = GetStore(con);
+	return store->Lookup(context, {table_oid, canonical_key});
 }
 
 void BuildCache(Connection &con, const string &table_name, const string &predicate) {

--- a/test/unittest/test_logical_cache_invalidator.cpp
+++ b/test/unittest/test_logical_cache_invalidator.cpp
@@ -1,0 +1,53 @@
+#include "catch/catch.hpp"
+#include "logical_cache_invalidator.hpp"
+
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+
+namespace duckdb {
+
+TEST_CASE("LogicalCacheInvalidator - INVALIDATE mode constructor", "[logical_invalidator]") {
+	auto row_id_expr = make_uniq<BoundReferenceExpression>(LogicalType {LogicalTypeId::BIGINT}, 3);
+	LogicalCacheInvalidator op(42, std::move(row_id_expr));
+
+	REQUIRE(op.table_oid == 42);
+	REQUIRE(op.mode == CacheInvalidatorMode::INVALIDATE);
+	REQUIRE(op.row_id_column_index == 0);
+	REQUIRE(op.pre_insert_row_count == 0);
+	REQUIRE(op.expressions.size() == 1);
+
+	auto &ref = op.expressions[0]->Cast<BoundReferenceExpression>();
+	REQUIRE(ref.index == 3);
+	REQUIRE(ref.return_type == LogicalType {LogicalTypeId::BIGINT});
+}
+
+TEST_CASE("LogicalCacheInvalidator - INSERT mode constructor", "[logical_invalidator]") {
+	LogicalCacheInvalidator op(100, static_cast<idx_t>(50000));
+
+	REQUIRE(op.table_oid == 100);
+	REQUIRE(op.mode == CacheInvalidatorMode::INSERT);
+	REQUIRE(op.row_id_column_index == 0);
+	REQUIRE(op.pre_insert_row_count == 50000);
+	REQUIRE(op.expressions.empty());
+}
+
+TEST_CASE("LogicalCacheInvalidator - MERGE mode constructor", "[logical_invalidator]") {
+	LogicalCacheInvalidator op(200, static_cast<idx_t>(5), static_cast<idx_t>(10000));
+
+	REQUIRE(op.table_oid == 200);
+	REQUIRE(op.mode == CacheInvalidatorMode::MERGE);
+	REQUIRE(op.row_id_column_index == 5);
+	REQUIRE(op.pre_insert_row_count == 10000);
+	REQUIRE(op.expressions.empty());
+}
+
+TEST_CASE("LogicalCacheInvalidator - GetExtensionName", "[logical_invalidator]") {
+	LogicalCacheInvalidator op(1, static_cast<idx_t>(0));
+	REQUIRE(op.GetExtensionName() == "query_condition_cache");
+}
+
+TEST_CASE("CacheInvalidatorOperatorExtension - GetName", "[logical_invalidator]") {
+	CacheInvalidatorOperatorExtension ext;
+	REQUIRE(ext.GetName() == "query_condition_cache");
+}
+
+} // namespace duckdb

--- a/test/unittest/test_optimizer_invalidation.cpp
+++ b/test/unittest/test_optimizer_invalidation.cpp
@@ -1,0 +1,470 @@
+#include "catch/catch.hpp"
+#include "physical_cache_invalidator.hpp"
+#include "query_condition_cache_extension.hpp"
+#include "test_helpers_invalidation.hpp"
+
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/prepared_statement.hpp"
+#include "duckdb/main/prepared_statement_data.hpp"
+
+namespace duckdb {
+
+TEST_CASE("Optimizer invalidation - DELETE removes affected row groups from cache", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	// Create table spanning multiple row groups (122880 rows per RG -> 5 RGs for 500000 rows)
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+
+	// Build cache with a selective predicate (only hits RG0: ids 0..2999)
+	BuildCache(con, "t", "id < 3000");
+	auto entry = LookupEntry(con, "t", "id < 3000");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->RowGroupCount() == 5);
+	REQUIRE(entry->HasRowGroup(0)); // only RG0
+
+	// Also build a broad predicate that hits all RGs
+	BuildCache(con, "t", "val = 42");
+	auto broad_entry = LookupEntry(con, "t", "val = 42");
+	REQUIRE(broad_entry != nullptr);
+	REQUIRE(broad_entry->RowGroupCount() == 5);
+
+	// DELETE rows in RG0 only
+	auto del_result = con.Query("DELETE FROM t WHERE id < 100");
+	REQUIRE_FALSE(del_result->HasError());
+
+	// The selective entry (only had RG0) should be fully removed
+	auto after_del = LookupEntry(con, "t", "id < 3000");
+	REQUIRE(after_del != nullptr);
+	REQUIRE(after_del->RowGroupCount() == 4);
+	REQUIRE(after_del->HasRowGroup(0) == false);
+	REQUIRE(after_del->HasRowGroup(1));
+	REQUIRE(after_del->HasRowGroup(2));
+	REQUIRE(after_del->HasRowGroup(3));
+	REQUIRE(after_del->HasRowGroup(4));
+
+	// The broad entry should have RG0 removed but RGs 1-4 preserved
+	auto broad_after = LookupEntry(con, "t", "val = 42");
+	REQUIRE(broad_after != nullptr);
+	REQUIRE(broad_after->RowGroupCount() == 4);
+	REQUIRE(broad_after->HasRowGroup(0) == false);
+	REQUIRE(broad_after->HasRowGroup(1));
+	REQUIRE(broad_after->HasRowGroup(2));
+	REQUIRE(broad_after->HasRowGroup(3));
+	REQUIRE(broad_after->HasRowGroup(4));
+}
+
+TEST_CASE("Optimizer invalidation - UPDATE removes affected row groups from cache", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+
+	BuildCache(con, "t", "val = 42");
+	auto entry = LookupEntry(con, "t", "val = 42");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->RowGroupCount() == 5);
+
+	// UPDATE a row in RG0 (id=200 is in the first row group)
+	auto upd_result = con.Query("UPDATE t SET val = 999 WHERE id = 200");
+	REQUIRE_FALSE(upd_result->HasError());
+
+	// RG0 should be invalidated, others preserved
+	auto after_upd = LookupEntry(con, "t", "val = 42");
+	REQUIRE(after_upd != nullptr);
+	REQUIRE(after_upd->RowGroupCount() == 4);
+	REQUIRE(after_upd->HasRowGroup(0) == false);
+}
+
+TEST_CASE("Optimizer invalidation - INSERT only invalidates affected row groups", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	// 500000 rows = 5 row groups (122880 per RG). Last RG (RG4) starts at row 491520.
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+	// Build cache with a selective predicate (only RG0)
+	BuildCache(con, "t", "id < 3000");
+	auto selective = LookupEntry(con, "t", "id < 3000");
+	REQUIRE(selective != nullptr);
+	REQUIRE(selective->RowGroupCount() == 5);
+	REQUIRE(selective->HasRowGroup(0));
+
+	// Build cache with a broad predicate (all RGs)
+	BuildCache(con, "t", "val = 42");
+	auto broad = LookupEntry(con, "t", "val = 42");
+	REQUIRE(broad != nullptr);
+	REQUIRE(broad->RowGroupCount() == 5);
+
+	// INSERT a single row -- appended at the end, affects only the last RG (RG4)
+	auto ins_result = con.Query("INSERT INTO t VALUES (999999, 0)");
+	REQUIRE_FALSE(ins_result->HasError());
+
+	// Selective entry (RG0 only) should be preserved -- INSERT didn't touch RG0
+	auto selective_after = LookupEntry(con, "t", "id < 3000");
+	REQUIRE(selective_after != nullptr);
+	REQUIRE(selective_after->RowGroupCount() == 4);
+	REQUIRE(selective_after->HasRowGroup(0));
+
+	// Broad entry should have RG4 invalidated, RGs 0-3 preserved
+	auto broad_after = LookupEntry(con, "t", "val = 42");
+	REQUIRE(broad_after != nullptr);
+	REQUIRE(broad_after->RowGroupCount() == 4);
+	REQUIRE(broad_after->HasRowGroup(0));
+	REQUIRE(broad_after->HasRowGroup(1));
+	REQUIRE(broad_after->HasRowGroup(2));
+	REQUIRE(broad_after->HasRowGroup(3));
+	REQUIRE(broad_after->HasRowGroup(4) == false);
+}
+
+TEST_CASE("Optimizer invalidation - INSERT spanning multiple new row groups", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	// Start with a small table (1 row group)
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(100000) t(i)");
+	BuildCache(con, "t", "val = 42");
+	auto entry = LookupEntry(con, "t", "val = 42");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->RowGroupCount() == 1); // 1 RG
+	REQUIRE(entry->HasRowGroup(0));
+
+	// INSERT enough rows to create new row groups (add 300000 rows -> spans RG0 tail + RG1 + RG2)
+	auto ins_result = con.Query("INSERT INTO t SELECT i AS id, i % 100 AS val FROM range(300000) t(i)");
+	REQUIRE_FALSE(ins_result->HasError());
+
+	// RG0 should be invalidated (new rows appended into it), original entry gone
+	auto after = LookupEntry(con, "t", "val = 42");
+	REQUIRE(after == nullptr); // only had RG0, which got invalidated
+}
+
+TEST_CASE("Optimizer invalidation - INSERT ON CONFLICT DO UPDATE invalidates per row group",
+          "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t (id INTEGER PRIMARY KEY, val INTEGER)");
+	con.Query("INSERT INTO t SELECT i, i % 100 FROM range(500000) t(i)");
+	BuildCache(con, "t", "val = 42");
+	auto entry = LookupEntry(con, "t", "val = 42");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->RowGroupCount() == 5);
+
+	// ON CONFLICT DO UPDATE: row 200 is in RG0 (200 / 122880 = 0)
+	auto ins_result = con.Query("INSERT INTO t VALUES (200, 999) ON CONFLICT (id) DO UPDATE SET val = 999");
+	REQUIRE_FALSE(ins_result->HasError());
+
+	// Only RG0 should be invalidated; RGs 1-4 remain
+	auto after = LookupEntry(con, "t", "val = 42");
+	REQUIRE(after != nullptr);
+	REQUIRE(after->RowGroupCount() == 4);
+	REQUIRE(after->HasRowGroup(0) == false); // RG0 invalidated
+	REQUIRE(after->HasRowGroup(1));
+	REQUIRE(after->HasRowGroup(2));
+	REQUIRE(after->HasRowGroup(3));
+	REQUIRE(after->HasRowGroup(4));
+}
+
+TEST_CASE("Optimizer invalidation - cross-table isolation", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t1 AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+	con.Query("CREATE TABLE t2 AS SELECT i AS id, i % 10 AS val FROM range(1000) t(i)");
+	// Build cache for t1
+	BuildCache(con, "t1", "val = 42");
+	auto t1_entry = LookupEntry(con, "t1", "val = 42");
+	REQUIRE(t1_entry != nullptr);
+	REQUIRE(t1_entry->RowGroupCount() == 5);
+
+	// DML on t2 should not affect t1's cache
+	con.Query("DELETE FROM t2 WHERE id < 100");
+	con.Query("UPDATE t2 SET val = 0 WHERE id = 500");
+	con.Query("INSERT INTO t2 VALUES (9999, 0)");
+
+	auto t1_after = LookupEntry(con, "t1", "val = 42");
+	REQUIRE(t1_after != nullptr);
+	REQUIRE(t1_after->RowGroupCount() == 5);
+}
+
+TEST_CASE("Optimizer invalidation - DELETE across multiple row groups", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+	BuildCache(con, "t", "val = 42");
+	auto entry = LookupEntry(con, "t", "val = 42");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->RowGroupCount() == 5);
+
+	// DELETE rows spanning RG0 and RG2 (RG size = 122880)
+	// RG0: ids 0..122879, RG2: ids 245760..368639
+	auto del_result = con.Query("DELETE FROM t WHERE id < 100 OR (id >= 250000 AND id < 250100)");
+	REQUIRE_FALSE(del_result->HasError());
+
+	// RG0 and RG2 should be invalidated
+	auto after = LookupEntry(con, "t", "val = 42");
+	REQUIRE(after != nullptr);
+	REQUIRE(after->RowGroupCount() == 3);
+	REQUIRE(after->HasRowGroup(0) == false);
+	REQUIRE(after->HasRowGroup(1));
+	REQUIRE(after->HasRowGroup(2) == false);
+	REQUIRE(after->HasRowGroup(3));
+	REQUIRE(after->HasRowGroup(4));
+}
+
+TEST_CASE("Optimizer invalidation - MERGE invalidates matched and inserted row groups", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	// Create target table spanning multiple row groups
+	con.Query("CREATE TABLE dst AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+	BuildCache(con, "dst", "val = 42");
+	auto entry = LookupEntry(con, "dst", "val = 42");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->RowGroupCount() == 5);
+
+	// Create source table with:
+	// - id=200 matches an existing row in RG0 (update path)
+	// - id=600000 does not exist (insert path, appended after last RG)
+	con.Query("CREATE TABLE src (id INTEGER, val INTEGER)");
+	con.Query("INSERT INTO src VALUES (200, 999), (600000, 42)");
+
+	auto merge_result = con.Query("MERGE INTO dst USING src ON dst.id = src.id "
+	                              "WHEN MATCHED THEN UPDATE SET val = src.val "
+	                              "WHEN NOT MATCHED THEN INSERT VALUES (src.id, src.val)");
+	REQUIRE_FALSE(merge_result->HasError());
+
+	// RG0 should be invalidated (matched update of id=200)
+	// Last RG (RG4) should be invalidated (insert of id=600000 appended there)
+	auto after = LookupEntry(con, "dst", "val = 42");
+	REQUIRE(after != nullptr);
+	// RG0 and RG4 invalidated, RGs 1-3 remain
+	REQUIRE(after->HasRowGroup(0) == false);
+	REQUIRE(after->HasRowGroup(1));
+	REQUIRE(after->HasRowGroup(2));
+	REQUIRE(after->HasRowGroup(3));
+	REQUIRE(after->HasRowGroup(4) == false);
+}
+
+TEST_CASE("Optimizer invalidation - TRUNCATE does not crash with stale cache", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+	BuildCache(con, "t", "val = 42");
+	auto entry = LookupEntry(con, "t", "val = 42");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->RowGroupCount() == 5);
+
+	// TRUNCATE removes all rows -- stale cache entries remain but are harmless
+	auto trunc_result = con.Query("TRUNCATE t");
+	REQUIRE_FALSE(trunc_result->HasError());
+
+	// Query on empty table should return 0 rows regardless of stale cache
+	auto count_result = con.Query("SELECT count(*) FROM t WHERE val = 42");
+	REQUIRE_FALSE(count_result->HasError());
+	auto chunk = count_result->Fetch();
+	REQUIRE(chunk->GetValue(0, 0).GetValue<int64_t>() == 0);
+}
+
+TEST_CASE("Optimizer invalidation - DROP TABLE does not crash with stale cache", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i)");
+	BuildCache(con, "t", "val = 42");
+	auto entry = LookupEntry(con, "t", "val = 42");
+	REQUIRE(entry != nullptr);
+
+	// DROP TABLE -- stale cache entries become orphaned
+	auto drop_result = con.Query("DROP TABLE t");
+	REQUIRE_FALSE(drop_result->HasError());
+
+	// Recreate table (gets new OID) and query -- must work correctly
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 10 AS val FROM range(1000) t(i)");
+
+	auto count_result = con.Query("SELECT count(*) FROM t WHERE val = 5");
+	REQUIRE_FALSE(count_result->HasError());
+	auto chunk = count_result->Fetch();
+	REQUIRE(chunk->GetValue(0, 0).GetValue<int64_t>() == 100);
+}
+
+TEST_CASE("Optimizer invalidation - INSERT into partial tail row group", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	// 130000 rows = 1 full RG (122880) + partial RG with 7120 rows
+	con.Query("CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(130000) t(i)");
+	BuildCache(con, "t", "val = 42");
+	auto entry = LookupEntry(con, "t", "val = 42");
+	REQUIRE(entry != nullptr);
+	REQUIRE(entry->RowGroupCount() == 2); // RG0 (full) + RG1 (partial)
+
+	// INSERT a single row -- goes into the partial tail RG (RG1)
+	auto ins_result = con.Query("INSERT INTO t VALUES (999999, 42)");
+	REQUIRE_FALSE(ins_result->HasError());
+
+	// RG1 (partial tail) should be invalidated, RG0 preserved
+	auto after = LookupEntry(con, "t", "val = 42");
+	REQUIRE(after != nullptr);
+	REQUIRE(after->RowGroupCount() == 1);
+	REQUIRE(after->HasRowGroup(0));
+	REQUIRE(after->HasRowGroup(1) == false);
+
+	// Query must still return correct results including the new row
+	auto count_result = con.Query("SELECT count(*) FROM t WHERE val = 42");
+	REQUIRE_FALSE(count_result->HasError());
+	auto chunk = count_result->Fetch();
+	// 130000 / 100 = 1300 rows with val=42, plus 1 inserted
+	REQUIRE(chunk->GetValue(0, 0).GetValue<int64_t>() == 1301);
+}
+
+// --- Plan injection tests (verify optimizer injects PhysicalCacheInvalidator with correct fields) ---
+
+TEST_CASE("Optimizer invalidation - injects ROW_ID invalidator for DELETE", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id FROM range(100) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	auto prepared = con.Prepare("DELETE FROM t WHERE id < 10");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::INVALIDATE);
+	REQUIRE(invalidator->table_oid == table_oid);
+}
+
+TEST_CASE("Optimizer invalidation - injects ROW_ID invalidator for UPDATE", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id, i AS val FROM range(100) t(i)");
+	auto table_oid = GetTableOid(con, "t");
+
+	auto prepared = con.Prepare("UPDATE t SET val = 999 WHERE id = 5");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::INVALIDATE);
+	REQUIRE(invalidator->table_oid == table_oid);
+}
+
+TEST_CASE("Optimizer invalidation - injects INSERT invalidator for INSERT", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t (id INTEGER, val INTEGER)");
+	auto table_oid = GetTableOid(con, "t");
+
+	auto prepared = con.Prepare("INSERT INTO t VALUES (1, 2)");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::INSERT);
+	REQUIRE(invalidator->table_oid == table_oid);
+	REQUIRE(invalidator->pre_insert_row_count == 0);
+}
+
+TEST_CASE("Optimizer invalidation - no invalidator for SELECT", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id FROM range(100) t(i)");
+
+	auto prepared = con.Prepare("SELECT * FROM t WHERE id < 10");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE_FALSE(invalidator);
+}
+
+TEST_CASE("Optimizer invalidation - injects MERGE invalidator for INSERT ON CONFLICT", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t (id INTEGER PRIMARY KEY, val INTEGER)");
+	con.Query("INSERT INTO t VALUES (1, 10)");
+	auto table_oid = GetTableOid(con, "t");
+
+	auto prepared = con.Prepare("INSERT INTO t VALUES (1, 20) ON CONFLICT (id) DO UPDATE SET val = 20");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::MERGE);
+	REQUIRE(invalidator->table_oid == table_oid);
+	REQUIRE(invalidator->pre_insert_row_count == 1);
+}
+
+TEST_CASE("Optimizer invalidation - injects MERGE invalidator for MERGE", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE dst AS SELECT i AS id, i AS val FROM range(100) t(i)");
+	con.Query("CREATE TABLE src AS SELECT i AS id, i * 10 AS val FROM range(50, 150) t(i)");
+	auto table_oid = GetTableOid(con, "dst");
+
+	auto prepared = con.Prepare("MERGE INTO dst USING src ON dst.id = src.id "
+	                            "WHEN MATCHED THEN UPDATE SET val = src.val "
+	                            "WHEN NOT MATCHED THEN INSERT VALUES (src.id, src.val)");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::MERGE);
+	REQUIRE(invalidator->table_oid == table_oid);
+	REQUIRE(invalidator->pre_insert_row_count == 100);
+}
+
+TEST_CASE("Optimizer invalidation - injects INSERT invalidator for INSERT SELECT", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE src AS SELECT i AS id FROM range(100) t(i)");
+	con.Query("CREATE TABLE dst (id INTEGER)");
+	auto table_oid = GetTableOid(con, "dst");
+
+	auto prepared = con.Prepare("INSERT INTO dst SELECT * FROM src WHERE id < 50");
+	REQUIRE_FALSE(prepared->HasError());
+	auto *invalidator = FindInvalidator(prepared->data->physical_plan->Root());
+	REQUIRE(invalidator);
+	REQUIRE(invalidator->mode == CacheInvalidatorMode::INSERT);
+	REQUIRE(invalidator->table_oid == table_oid);
+	REQUIRE(invalidator->pre_insert_row_count == 0);
+}
+
+TEST_CASE("Optimizer invalidation - DML on empty cache is no-op", "[invalidation][optimizer]") {
+	DuckDB db(nullptr);
+	db.LoadStaticExtension<QueryConditionCacheExtension>();
+	Connection con(db);
+
+	con.Query("CREATE TABLE t AS SELECT i AS id FROM range(1000) t(i)");
+
+	// DML without any cache built should not crash
+	auto del_result = con.Query("DELETE FROM t WHERE id < 10");
+	REQUIRE_FALSE(del_result->HasError());
+
+	auto upd_result = con.Query("UPDATE t SET id = id + 1 WHERE id < 10");
+	REQUIRE_FALSE(upd_result->HasError());
+
+	auto ins_result = con.Query("INSERT INTO t VALUES (9999)");
+	REQUIRE_FALSE(ins_result->HasError());
+}
+} // namespace duckdb


### PR DESCRIPTION
## Summary

This PR adds integration and E2E tests for cache invalidation, covering logical invalidator constructors, optimizer invalidation with DML operations (DELETE/UPDATE/INSERT/MERGE/TRUNCATE/DROP), and SQL correctness verification ensuring query results remain accurate after DML with cache enabled.


