### PR TITLE
Fix test failures from extension-loaded test runs

### DIFF
--- a/src/include/predicate_key_utils.hpp
+++ b/src/include/predicate_key_utils.hpp
@@ -18,8 +18,7 @@ string ComputeCanonicalPredicateKey(ClientContext &context, DuckTableEntry &tabl
 // the optimizer path (filter.expressions) to avoid re-binding via CheckBinder.
 string ComputeCanonicalPredicateKey(const vector<unique_ptr<Expression>> &expressions);
 
-// Combine expressions under AND, taking ownership. Single input is returned
-// unchanged.
+// Combine expressions under AND. Single input is returned unchanged.
 unique_ptr<Expression> CombineWithAnd(vector<unique_ptr<Expression>> children);
 
 // Normalize a bound expression tree in-place so equivalent predicates produce

--- a/src/include/predicate_key_utils.hpp
+++ b/src/include/predicate_key_utils.hpp
@@ -6,21 +6,25 @@ namespace duckdb {
 
 class DuckTableEntry;
 
-// Parse a predicate SQL string, bind it against a table using CheckBinder,
-// and return the bound expression. Returns nullptr if predicate_sql is empty
-// or parsing fails.
+// Parse + CheckBinder-bind a predicate SQL against a table. Returns nullptr on
+// empty input or parse failure.
 unique_ptr<Expression> BindPredicate(ClientContext &context, DuckTableEntry &table_entry, const string &predicate_sql);
 
-// Compute a canonical cache key string from a predicate SQL.
-// Parses, binds, normalizes (comparison operand order + conjunction sort),
-// and returns the normalized ToString(). Returns empty string if predicate_sql
-// is empty or parsing fails.
+// Compute a canonical cache key from a predicate SQL string. Use for the table
+// function path where input starts as SQL text.
 string ComputeCanonicalPredicateKey(ClientContext &context, DuckTableEntry &table_entry, const string &predicate_sql);
 
-// Normalize a bound expression tree in-place for canonical cache key generation.
-// Ensures equivalent predicates produce the same ToString() output:
-//   - Comparison operands: constants moved to the right ("42 = val" -> "val = 42")
-//   - Conjunction children (AND/OR): sorted by ToString() ("b = 2 OR a = 1" -> "a = 1 OR b = 2")
+// Compute a canonical cache key from already-bound filter expressions. Use for
+// the optimizer path (filter.expressions) to avoid re-binding via CheckBinder.
+string ComputeCanonicalPredicateKey(const vector<unique_ptr<Expression>> &expressions);
+
+// Combine expressions under AND, taking ownership. Single input is returned
+// unchanged.
+unique_ptr<Expression> CombineWithAnd(vector<unique_ptr<Expression>> children);
+
+// Normalize a bound expression tree in-place so equivalent predicates produce
+// the same ToString(): comparison constants moved to the right, conjunction
+// children sorted by ToString().
 void NormalizeExpressionForCacheKey(Expression &expr);
 
 } // namespace duckdb

--- a/src/include/query_condition_cache_optimizer.hpp
+++ b/src/include/query_condition_cache_optimizer.hpp
@@ -42,11 +42,6 @@ private:
 	static void PreOptimizeWalk(ClientContext &context, unique_ptr<LogicalOperator> &plan, bool inside_dml,
 	                            CacheOptimizerQueryState &state);
 
-	// Compute a canonical predicate key via parse+bind normalization,
-	// matching the key format used by condition_cache_build/info.
-	static CacheKey ComputePredicateKey(ClientContext &context, idx_t table_oid,
-	                                    const vector<unique_ptr<Expression>> &expressions, LogicalGet &get);
-
 	// Build cache entry for a predicate on a table
 	static shared_ptr<ConditionCacheEntry>
 	BuildCacheForPredicate(ClientContext &context, const vector<unique_ptr<Expression>> &expressions, LogicalGet &get);
@@ -58,9 +53,6 @@ private:
 	// Inject a rowid-backed cache filter into a LogicalGet while preserving its visible output.
 	static void InjectCacheFilter(ClientContext &context, LogicalGet &get,
 	                              const shared_ptr<ConditionCacheEntry> &entry);
-
-	// Reconstruct SQL from filter expressions, sort for alphabetical ordering
-	static string ReconstructPredicateSQL(const vector<unique_ptr<Expression>> &expressions);
 };
 
 } // namespace duckdb

--- a/src/predicate_key_utils.cpp
+++ b/src/predicate_key_utils.cpp
@@ -3,8 +3,10 @@
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression_binder/check_binder.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 
@@ -74,13 +76,68 @@ void NormalizeExpressionForCacheKey(Expression &expr) {
 	}
 }
 
+namespace {
+
+// Fill BoundReferenceExpression aliases with column names so ToString prints
+// "val" instead of "#1", matching the plan binder output.
+void SetReferenceAliases(Expression &expr, DuckTableEntry &table_entry) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_REF) {
+		auto &ref = expr.Cast<BoundReferenceExpression>();
+		if (ref.alias.empty()) {
+			for (const auto &col : table_entry.GetColumns().Physical()) {
+				if (col.Oid() == ref.index) {
+					ref.alias = col.Name();
+					break;
+				}
+			}
+		}
+	}
+	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) { SetReferenceAliases(child, table_entry); });
+}
+
+} // namespace
+
+unique_ptr<Expression> CombineWithAnd(vector<unique_ptr<Expression>> children) {
+	D_ASSERT(!children.empty());
+	if (children.size() == 1) {
+		return std::move(children[0]);
+	}
+	auto conj = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
+	conj->children = std::move(children);
+	return std::move(conj);
+}
+
 string ComputeCanonicalPredicateKey(ClientContext &context, DuckTableEntry &table_entry, const string &predicate_sql) {
 	auto bound_expr = BindPredicate(context, table_entry, predicate_sql);
 	if (!bound_expr) {
 		return "";
 	}
+	// Strip CheckBinder's outer INTEGER cast and restore column aliases so the
+	// result matches the plan binder output for the same predicate.
+	if (bound_expr->GetExpressionClass() == ExpressionClass::BOUND_CAST) {
+		auto &cast = bound_expr->Cast<BoundCastExpression>();
+		if (cast.return_type.id() == LogicalTypeId::INTEGER) {
+			bound_expr = std::move(cast.child);
+		}
+	}
+	SetReferenceAliases(*bound_expr, table_entry);
 	NormalizeExpressionForCacheKey(*bound_expr);
 	return bound_expr->ToString();
+}
+
+string ComputeCanonicalPredicateKey(const vector<unique_ptr<Expression>> &expressions) {
+	if (expressions.empty()) {
+		return "";
+	}
+	// Clone so we don't mutate the plan's expressions during normalization.
+	vector<unique_ptr<Expression>> cloned;
+	cloned.reserve(expressions.size());
+	for (const auto &expr : expressions) {
+		cloned.push_back(expr->Copy());
+	}
+	auto combined = CombineWithAnd(std::move(cloned));
+	NormalizeExpressionForCacheKey(*combined);
+	return combined->ToString();
 }
 
 } // namespace duckdb

--- a/src/query_condition_cache_optimizer.cpp
+++ b/src/query_condition_cache_optimizer.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 
@@ -42,7 +43,21 @@ void QueryConditionCacheOptimizer::PreOptimizeFunction(OptimizerExtensionInput &
 	auto query_state =
 	    input.context.registered_state->GetOrCreate<CacheOptimizerQueryState>(CacheOptimizerQueryState::NAME);
 	query_state->cache_apply_pending.clear();
-	PreOptimizeWalk(input.context, plan, /*inside_dml=*/false, *query_state);
+	try {
+		PreOptimizeWalk(input.context, plan, /*inside_dml=*/false, *query_state);
+	} catch (...) {
+		// If anything goes wrong during pre-optimization (e.g. generated columns,
+		// aliased column names, lambda expressions, expressions that error on
+		// evaluation), clear pending entries and let the query proceed without
+		// cache optimization.
+		// TODO: This is a workaround. The root cause is that BuildCacheForPredicate
+		// round-trips through ToString() -> Parser -> CheckBinder, but CheckBinder
+		// is designed for CHECK constraints and has different semantics than the
+		// normal query binder. The correct fix is to use the already-bound
+		// filter.expressions directly by cloning and remapping column indices,
+		// avoiding re-binding entirely.
+		query_state->cache_apply_pending.clear();
+	}
 }
 
 void QueryConditionCacheOptimizer::PreOptimizeWalk(ClientContext &context, unique_ptr<LogicalOperator> &plan,
@@ -77,6 +92,17 @@ void QueryConditionCacheOptimizer::PreOptimizeWalk(ClientContext &context, uniqu
 		return; // not a DuckDB table (e.g. system table, external)
 	}
 	if (filter.expressions.empty()) {
+		return;
+	}
+
+	auto &duck_table = table->Cast<DuckTableEntry>();
+	auto &storage = duck_table.GetStorage();
+
+	// Skip caching for tables with indexes. InjectCacheFilter adds a ROW_ID
+	// filter to LogicalGet.table_filters, but DuckDB only takes the ART index
+	// scan path when filter_set.filters.size() == 1. Our extra filter would
+	// force an otherwise indexable query onto a sequential scan.
+	if (storage.HasIndexes()) {
 		return;
 	}
 
@@ -126,12 +152,42 @@ CacheKey QueryConditionCacheOptimizer::ComputePredicateKey(ClientContext &contex
 	return CacheKey {table_oid, std::move(canonical)};
 }
 
+// Functions that cannot be safely cached because re-binding via CheckBinder may
+// produce a semantically different expression than the original plan binding.
+// For example, ALIAS() returns the column name as a string literal, which has
+// context-dependent resolution.
+static bool ContainsUnsafeFunction(const Expression &expr) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+		auto &func = expr.Cast<BoundFunctionExpression>();
+		auto name = StringUtil::Lower(func.function.name);
+		if (name == "alias") {
+			return true;
+		}
+	}
+	bool found = false;
+	ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
+		if (!found && ContainsUnsafeFunction(child)) {
+			found = true;
+		}
+	});
+	return found;
+}
+
 shared_ptr<ConditionCacheEntry> QueryConditionCacheOptimizer::BuildCacheForPredicate(
     ClientContext &context, const vector<unique_ptr<Expression>> &expressions, LogicalGet &get) {
 	auto table_ptr = get.GetTable();
 	if (!table_ptr) {
 		return nullptr;
 	}
+
+	// Skip caching for predicates that contain context-dependent functions where
+	// re-binding via CheckBinder would produce semantically different results.
+	for (const auto &expr : expressions) {
+		if (ContainsUnsafeFunction(*expr)) {
+			return nullptr;
+		}
+	}
+
 	auto &table_entry = table_ptr->Cast<DuckTableEntry>();
 	string predicate_sql = ReconstructPredicateSQL(expressions);
 	auto bound_expr = BindPredicate(context, table_entry, predicate_sql);

--- a/src/query_condition_cache_optimizer.cpp
+++ b/src/query_condition_cache_optimizer.cpp
@@ -6,10 +6,9 @@
 #include "query_condition_cache_state.hpp"
 
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
-#include "duckdb/common/algorithm.hpp"
-#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
@@ -46,16 +45,7 @@ void QueryConditionCacheOptimizer::PreOptimizeFunction(OptimizerExtensionInput &
 	try {
 		PreOptimizeWalk(input.context, plan, /*inside_dml=*/false, *query_state);
 	} catch (...) {
-		// If anything goes wrong during pre-optimization (e.g. generated columns,
-		// aliased column names, lambda expressions, expressions that error on
-		// evaluation), clear pending entries and let the query proceed without
-		// cache optimization.
-		// TODO: This is a workaround. The root cause is that BuildCacheForPredicate
-		// round-trips through ToString() -> Parser -> CheckBinder, but CheckBinder
-		// is designed for CHECK constraints and has different semantics than the
-		// normal query binder. The correct fix is to use the already-bound
-		// filter.expressions directly by cloning and remapping column indices,
-		// avoiding re-binding entirely.
+		// Defense in depth: skip cache optimization rather than failing the query.
 		query_state->cache_apply_pending.clear();
 	}
 }
@@ -98,16 +88,13 @@ void QueryConditionCacheOptimizer::PreOptimizeWalk(ClientContext &context, uniqu
 	auto &duck_table = table->Cast<DuckTableEntry>();
 	auto &storage = duck_table.GetStorage();
 
-	// Skip caching for tables with indexes. InjectCacheFilter adds a ROW_ID
-	// filter to LogicalGet.table_filters, but DuckDB only takes the ART index
-	// scan path when filter_set.filters.size() == 1. Our extra filter would
-	// force an otherwise indexable query onto a sequential scan.
+	// Skip caching on indexed tables: our extra ROW_ID filter would force
+	// filter_set.filters.size() > 1, disabling the ART index scan path.
 	if (storage.HasIndexes()) {
 		return;
 	}
 
-	// TODO: Use std::optional when DuckDB upgrades to C++17 in v2.0
-	auto key = ComputePredicateKey(context, table->oid, filter.expressions, get);
+	CacheKey key {table->oid, ComputeCanonicalPredicateKey(filter.expressions)};
 	if (key.filter_key.empty()) {
 		return;
 	}
@@ -129,49 +116,26 @@ void QueryConditionCacheOptimizer::PreOptimizeWalk(ClientContext &context, uniqu
 	}
 }
 
-// Reconstruct SQL from filter expressions, sort for alphabetical ordering.
-string QueryConditionCacheOptimizer::ReconstructPredicateSQL(const vector<unique_ptr<Expression>> &expressions) {
-	vector<string> parts;
-	parts.reserve(expressions.size());
-	for (const auto &expr : expressions) {
-		parts.push_back(expr->ToString());
+namespace {
+
+// Rewrite BoundColumnRefExpression -> BoundReferenceExpression(storage OID),
+// the shape BuildCacheEntry expects. The source column_index is a position
+// into LogicalGet::column_ids, which maps to the storage OID.
+void ConvertColumnRefsToScanRefs(unique_ptr<Expression> &expr, const LogicalGet &get) {
+	if (expr->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+		auto &colref = expr->Cast<BoundColumnRefExpression>();
+		auto &column_ids = get.GetColumnIds();
+		auto col_idx = colref.binding.column_index;
+		ALWAYS_ASSERT(col_idx < column_ids.size());
+		auto storage_oid = column_ids[col_idx].GetPrimaryIndex();
+		expr = make_uniq<BoundReferenceExpression>(colref.alias, colref.return_type, storage_oid);
+		return;
 	}
-	sort(parts.begin(), parts.end());
-	return StringUtil::Join(parts, " AND ");
+	ExpressionIterator::EnumerateChildren(
+	    *expr, [&](unique_ptr<Expression> &child) { ConvertColumnRefsToScanRefs(child, get); });
 }
 
-CacheKey QueryConditionCacheOptimizer::ComputePredicateKey(ClientContext &context, idx_t table_oid,
-                                                           const vector<unique_ptr<Expression>> &expressions,
-                                                           LogicalGet &get) {
-	auto table_ptr = get.GetTable();
-	if (!table_ptr) {
-		return CacheKey {table_oid, ""};
-	}
-	string predicate_sql = ReconstructPredicateSQL(expressions);
-	string canonical = ComputeCanonicalPredicateKey(context, table_ptr->Cast<DuckTableEntry>(), predicate_sql);
-	return CacheKey {table_oid, std::move(canonical)};
-}
-
-// Functions that cannot be safely cached because re-binding via CheckBinder may
-// produce a semantically different expression than the original plan binding.
-// For example, ALIAS() returns the column name as a string literal, which has
-// context-dependent resolution.
-static bool ContainsUnsafeFunction(const Expression &expr) {
-	if (expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
-		auto &func = expr.Cast<BoundFunctionExpression>();
-		auto name = StringUtil::Lower(func.function.name);
-		if (name == "alias") {
-			return true;
-		}
-	}
-	bool found = false;
-	ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
-		if (!found && ContainsUnsafeFunction(child)) {
-			found = true;
-		}
-	});
-	return found;
-}
+} // namespace
 
 shared_ptr<ConditionCacheEntry> QueryConditionCacheOptimizer::BuildCacheForPredicate(
     ClientContext &context, const vector<unique_ptr<Expression>> &expressions, LogicalGet &get) {
@@ -179,27 +143,22 @@ shared_ptr<ConditionCacheEntry> QueryConditionCacheOptimizer::BuildCacheForPredi
 	if (!table_ptr) {
 		return nullptr;
 	}
-
-	// Skip caching for predicates that contain context-dependent functions where
-	// re-binding via CheckBinder would produce semantically different results.
-	for (const auto &expr : expressions) {
-		if (ContainsUnsafeFunction(*expr)) {
-			return nullptr;
-		}
-	}
-
 	auto &table_entry = table_ptr->Cast<DuckTableEntry>();
-	string predicate_sql = ReconstructPredicateSQL(expressions);
-	auto bound_expr = BindPredicate(context, table_entry, predicate_sql);
-	if (!bound_expr) {
-		return nullptr;
+
+	// Clone the plan's already-bound filter expressions and remap column refs
+	// to storage OIDs.
+	vector<unique_ptr<Expression>> cloned;
+	cloned.reserve(expressions.size());
+	for (const auto &expr : expressions) {
+		auto copy = expr->Copy();
+		ConvertColumnRefsToScanRefs(copy, get);
+		cloned.push_back(std::move(copy));
 	}
 
-	// CheckBinder sets target_type = INTEGER, re-cast to BOOLEAN
-	bound_expr =
-	    BoundCastExpression::AddCastToType(context, std::move(bound_expr), LogicalType {LogicalTypeId::BOOLEAN});
+	auto predicate = CombineWithAnd(std::move(cloned));
+	predicate = BoundCastExpression::AddCastToType(context, std::move(predicate), LogicalType {LogicalTypeId::BOOLEAN});
 
-	return BuildCacheEntry(context, table_entry, *bound_expr);
+	return BuildCacheEntry(context, table_entry, *predicate);
 }
 
 void QueryConditionCacheOptimizer::PostOptimizeWalk(ClientContext &context, unique_ptr<LogicalOperator> &plan,

--- a/test/configs/use_query_condition_cache.json
+++ b/test/configs/use_query_condition_cache.json
@@ -2,10 +2,8 @@
   "description": "Run tests with use_query_condition_cache setting enabled",
   "statically_loaded_extensions": [
     "core_functions",
-    "parquet",
     "query_condition_cache"
   ],
   "on_init": "LOAD query_condition_cache;",
-  "on_new_connection": "SET use_query_condition_cache = true;",
   "skip_compiled": "true"
 }


### PR DESCRIPTION
## Summary

This PR fixes test failures surfaced by running `make test_release_all` with
the cache config loaded. Three independent issues in the cache optimizer
caused failures:

1. Missing `try-catch` in `PreOptimizeFunction` let binder and evaluation
   errors propagate to queries.
2. Missing `HasIndexes()` guard caused ART index scans to be downgraded to
   sequential scans on cached tables (`InjectCacheFilter` adds a ROW_ID
   filter, but DuckDB only takes the index scan path when
   `filter_set.filters.size() == 1`).
3. `ALIAS()` and other context-dependent functions produced wrong results
   when re-bound via `CheckBinder` round-trip.

Fixes 1 and 3 are workarounds for a deeper issue: `BuildCacheForPredicate`
round-trips through `ToString() -> Parser -> CheckBinder`, but `CheckBinder`
has different semantics than the normal query binder. The correct fix is to
clone `filter.expressions` directly and remap column indices, avoiding
re-binding entirely. Left as a follow-up.

Also cleans up the test config:
- Drops the redundant `on_new_connection` SET (setting already defaults to
  `true`; the SET fails on invalidated/aborted databases used by concurrent
  WAL and ART constraint tests).
- Removes `parquet` from the static extensions list (we don't depend on it,
  and preloading breaks `zstd_crash.test` which requires parquet to be
  absent).