### PR TITLE
Replace sync cache build with recorder operator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,9 @@ include_directories(src/include)
 set(EXTENSION_SOURCES
     src/cache_invalidation_optimizer.cpp
     src/logical_cache_invalidator.cpp
+    src/logical_cache_recorder.cpp
     src/physical_cache_invalidator.cpp
+    src/physical_cache_recorder.cpp
     src/predicate_key_utils.cpp
     src/query_condition_cache_extension.cpp
     src/query_condition_cache_filter.cpp

--- a/src/include/logical_cache_recorder.hpp
+++ b/src/include/logical_cache_recorder.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "duckdb/planner/operator/logical_extension_operator.hpp"
+#include "physical_cache_recorder.hpp"
+
+namespace duckdb {
+
+// Logical wrapper for PhysicalCacheRecorder. Carries the bound predicate already
+// remapped to chunk column positions and the canonical key for the store.
+struct LogicalCacheRecorder : public LogicalExtensionOperator {
+	idx_t table_oid;
+	string canonical_key;
+	idx_t rowid_column_index;
+
+	LogicalCacheRecorder(idx_t table_oid_p, string canonical_key_p, unique_ptr<Expression> bound_predicate_p,
+	                     idx_t rowid_column_index_p);
+
+	PhysicalOperator &CreatePlan(ClientContext &context, PhysicalPlanGenerator &planner) override;
+	vector<ColumnBinding> GetColumnBindings() override;
+	string GetExtensionName() const override;
+	void Serialize(Serializer &serializer) const override;
+
+protected:
+	void ResolveTypes() override;
+};
+
+// Uses extension name "query_condition_cache_recorder" to avoid colliding with
+// CacheInvalidatorOperatorExtension's "query_condition_cache".
+class CacheRecorderOperatorExtension : public OperatorExtension {
+public:
+	CacheRecorderOperatorExtension();
+	string GetName() override;
+	unique_ptr<LogicalExtensionOperator> Deserialize(Deserializer &deserializer) override;
+};
+
+} // namespace duckdb

--- a/src/include/physical_cache_recorder.hpp
+++ b/src/include/physical_cache_recorder.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "concurrency/annotated_mutex.hpp"
+#include "concurrency/thread_annotation.hpp"
+#include "query_condition_cache_state.hpp"
+
+#include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/planner/expression.hpp"
+
+namespace duckdb {
+
+struct CacheRecorderLocalState : public OperatorState {
+	CacheRecorderLocalState(ClientContext &context, const Expression &bound_predicate);
+
+	// Co-owned with the global state so bitvectors outlive this OperatorState.
+	shared_ptr<ConditionCacheEntry> local_entry;
+	ExpressionExecutor expr_executor;
+	// rg_idx -> highest vec_idx this task has seen.
+	unordered_map<idx_t, idx_t> max_vec_per_rg;
+	optional_idx current_rg;
+};
+
+struct CacheRecorderGlobalState : public GlobalOperatorState {
+	concurrency::mutex lock;
+	vector<shared_ptr<ConditionCacheEntry>> task_local_entries DUCKDB_GUARDED_BY(lock);
+};
+
+// Pass-through operator injected above LogicalGet on cache miss. Observes scan output,
+// evaluates the predicate per chunk, and merges thread-local bitvectors into the store
+// at OperatorFinalize. The last vec each task observes is left uncommitted because it
+// may be a partial tail.
+class PhysicalCacheRecorder : public PhysicalOperator {
+public:
+	PhysicalCacheRecorder(PhysicalPlan &physical_plan, idx_t table_oid_p, string canonical_key_p,
+	                      unique_ptr<Expression> bound_predicate_p, idx_t rowid_column_index_p,
+	                      vector<LogicalType> types, idx_t estimated_cardinality);
+
+	idx_t table_oid;
+	string canonical_key;
+	unique_ptr<Expression> bound_predicate;
+	idx_t rowid_column_index;
+
+	unique_ptr<GlobalOperatorState> GetGlobalOperatorState(ClientContext &context) const override;
+	unique_ptr<OperatorState> GetOperatorState(ExecutionContext &context) const override;
+	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+	                           GlobalOperatorState &gstate, OperatorState &state) const override;
+	OperatorFinalResultType OperatorFinalize(Pipeline &pipeline, Event &event, ClientContext &context,
+	                                         OperatorFinalizeInput &input) const override;
+	bool RequiresOperatorFinalize() const override;
+	bool ParallelOperator() const override;
+	string GetName() const override;
+	InsertionOrderPreservingMap<string> ParamsToString() const override;
+
+	// Public so unit tests can drive the watermark/bitvector algorithm with synthetic
+	// (rg, vec, qualifying) tuples without a real pipeline.
+	static void RecordChunkObservation(ConditionCacheEntry &local_entry, unordered_map<idx_t, idx_t> &max_vec_per_rg,
+	                                   optional_idx &current_rg, idx_t rg_idx, idx_t vec_idx, bool has_qualifying);
+};
+
+} // namespace duckdb

--- a/src/include/physical_cache_recorder.hpp
+++ b/src/include/physical_cache_recorder.hpp
@@ -4,8 +4,6 @@
 #include "concurrency/thread_annotation.hpp"
 #include "query_condition_cache_state.hpp"
 
-#include "duckdb/common/optional_idx.hpp"
-#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/planner/expression.hpp"
@@ -18,9 +16,6 @@ struct CacheRecorderLocalState : public OperatorState {
 	// Co-owned with the global state so bitvectors outlive this OperatorState.
 	shared_ptr<ConditionCacheEntry> local_entry;
 	ExpressionExecutor expr_executor;
-	// rg_idx -> highest vec_idx this task has seen.
-	unordered_map<idx_t, idx_t> max_vec_per_rg;
-	optional_idx current_rg;
 };
 
 struct CacheRecorderGlobalState : public GlobalOperatorState {
@@ -54,10 +49,10 @@ public:
 	string GetName() const override;
 	InsertionOrderPreservingMap<string> ParamsToString() const override;
 
-	// Public so unit tests can drive the watermark/bitvector algorithm with synthetic
-	// (rg, vec, qualifying) tuples without a real pipeline.
-	static void RecordChunkObservation(ConditionCacheEntry &local_entry, unordered_map<idx_t, idx_t> &max_vec_per_rg,
-	                                   optional_idx &current_rg, idx_t rg_idx, idx_t vec_idx, bool has_qualifying);
+	// Public so unit tests can drive the algorithm with synthetic (rg, vec, qualifying) tuples
+	// without a real pipeline.
+	static void RecordChunkObservation(ConditionCacheEntry &local_entry, idx_t rg_idx, idx_t vec_idx,
+	                                   bool has_qualifying);
 };
 
 } // namespace duckdb

--- a/src/include/query_condition_cache_optimizer.hpp
+++ b/src/include/query_condition_cache_optimizer.hpp
@@ -10,17 +10,25 @@ namespace duckdb {
 class DuckTableEntry;
 class LogicalGet;
 
-// Query-scoped state for passing cache entries between pre-optimize and post-optimize phases.
-// Stored in ClientContext::registered_state; automatically cleared on QueryEnd.
+struct RecorderInjectionInfo {
+	idx_t table_oid;
+	string canonical_key;
+	// BoundColumnRefs already remapped to chunk positions for the recorder.
+	unique_ptr<Expression> predicate;
+};
+
+// Query-scoped state passed from pre-optimize to post-optimize.
 struct CacheOptimizerQueryState : public ClientContextState {
 	static constexpr const char *NAME = "qcc_optimizer_state";
 
-	// Maps table_index -> cache entry for tables matched during pre-optimize.
-	// Consumed by post-optimize to inject cache filters.
+	// table_index -> entry to bind the filter against.
 	unordered_map<idx_t, shared_ptr<ConditionCacheEntry>> cache_apply_pending;
+	// table_index -> recorder injection info, populated on cache miss only.
+	unordered_map<idx_t, RecorderInjectionInfo> cache_recorder_pending;
 
 	void QueryEnd(ClientContext &context, optional_ptr<ErrorData> error) override {
 		cache_apply_pending.clear();
+		cache_recorder_pending.clear();
 	}
 };
 
@@ -28,31 +36,25 @@ class QueryConditionCacheOptimizer : public OptimizerExtension {
 public:
 	QueryConditionCacheOptimizer();
 
-	// Pre-optimize: compute canonical predicate keys before FilterPushdown splits the WHERE clause.
-	// On cache miss, builds cache inline so the first query benefits immediately.
 	static void PreOptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
-
-	// Post-optimize: inject cache filters into LogicalGet nodes that were matched pre-optimize.
 	static void OptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
 
 private:
 	static bool IsSettingEnabled(ClientContext &context);
 
-	// Walk plan before FilterPushdown: find LogicalFilter -> LogicalGet, compute key, lookup/build cache
 	static void PreOptimizeWalk(ClientContext &context, unique_ptr<LogicalOperator> &plan, bool inside_dml,
 	                            CacheOptimizerQueryState &state);
 
-	// Build cache entry for a predicate on a table
-	static shared_ptr<ConditionCacheEntry>
-	BuildCacheForPredicate(ClientContext &context, const vector<unique_ptr<Expression>> &expressions, LogicalGet &get);
-
-	// Walk plan after built-in optimization and inject cache filters into matching table scans.
 	static void PostOptimizeWalk(ClientContext &context, unique_ptr<LogicalOperator> &plan,
 	                             CacheOptimizerQueryState &state);
 
-	// Inject a rowid-backed cache filter into a LogicalGet while preserving its visible output.
 	static void InjectCacheFilter(ClientContext &context, LogicalGet &get,
 	                              const shared_ptr<ConditionCacheEntry> &entry);
+
+	// Wraps `plan` (a LogicalGet) with a LogicalCacheRecorder; reassigns `plan` so the
+	// parent's children pointer updates transparently.
+	static void InjectCacheRecorder(ClientContext &context, unique_ptr<LogicalOperator> &plan,
+	                                RecorderInjectionInfo &&info);
 };
 
 } // namespace duckdb

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -18,21 +18,23 @@ inline constexpr idx_t BITVECTOR_ARRAY_SIZE = (VECTORS_PER_ROW_GROUP + 63) / 64;
 static_assert(DEFAULT_ROW_GROUP_SIZE % STANDARD_VECTOR_SIZE == 0,
               "DEFAULT_ROW_GROUP_SIZE must be divisible by STANDARD_VECTOR_SIZE");
 
-// Per row-group bitvector: bit[i] = 1 means vector i has at least one qualifying row,
-// for 0 <= i < VECTORS_PER_ROW_GROUP.
-// Backed by array<uint64_t, N> to support configurable row group / vector sizes.
+// Per row-group bitvector + watermark.
+//   matching_vectors[i] = 1 iff vec i observed to have at least one qualifying row.
+//   observed_vectors   = vecs in [0, observed_vectors) are fully observed; anything
+//                        at or above this index is unknown and must be scanned.
 struct RowGroupFilter {
 	array<uint64_t, BITVECTOR_ARRAY_SIZE> matching_vectors = {};
+	idx_t observed_vectors = 0;
 
 	RowGroupFilter() = default;
 
-	// Construct from vector indices that contain at least one qualifying row.
-	// Each index must be in [0, VECTORS_PER_ROW_GROUP). Duplicates are allowed.
+	// Leaves observed_vectors at 0; set it explicitly if you need pruning semantics.
 	explicit RowGroupFilter(const vector<idx_t> &qualifying_vectors);
 
 	void SetVector(idx_t vector_index);
 	bool VectorHasRows(idx_t vector_index) const;
 	bool IsEmpty() const;
+	// OR of matching_vectors, max of observed_vectors.
 	void MergeFrom(const RowGroupFilter &other);
 };
 
@@ -77,22 +79,27 @@ struct ConditionCacheEntry : public ObjectCacheEntry {
 
 	// --- Thread-safe API (each method acquires `lock` internally) ---
 
-	// Ensure a row group key exists (empty filter). Used when recording fully excluded row groups.
+	// Ensure a row group key exists (empty filter, observed_vectors = 0).
 	void EnsureRowGroup(idx_t rg_idx);
-	// Mark that vector `vec_idx` within row group `rg_idx` has at least one qualifying row.
 	void SetQualifyingVector(idx_t rg_idx, idx_t vec_idx);
-	// Merge another entry's row-group filters into this entry (e.g. after parallel build).
 	void MergeFrom(const ConditionCacheEntry &other);
+	// Used by manual full-table builds to declare every keyed rg fully observed.
+	void MarkAllRowGroupsFullyObserved();
+	// Absolute write; safe per-task because store-side MergeFrom takes max().
+	void SetRowGroupWatermark(idx_t rg_idx, idx_t observed);
 
-	// Row group absent from cache, or vector has qualifying rows -> predicate may pass rows (matches scan semantics).
+	// False only if rg is cached AND vec < observed_vectors AND bit = 0.
 	bool VectorPassesFilter(idx_t rg_idx, idx_t vec_idx) const;
-	// True iff every row group in [min_rg, max_rg] is present in the cache and has an empty filter.
+	// True iff every rg in range is cached, fully observed, and empty.
 	bool StatisticsRangeIsAllEmptyCached(idx_t min_rg, idx_t max_rg) const;
 
 	idx_t RowGroupCount() const;
 	bool HasRowGroup(idx_t rg_idx) const;
+	// Returns 0 if rg is not present.
+	idx_t GetObservedVectors(idx_t rg_idx) const;
+	// Raw bit, ignores observed_vectors. Test-only; production uses VectorPassesFilter.
 	bool RowGroupVectorHasQualifyingRows(idx_t rg_idx, idx_t vec_idx) const;
-	// True iff `rg_idx` is cached and its filter is empty (no qualifying vectors).
+	// Raw emptiness, ignores observed_vectors. Test-only.
 	bool RowGroupIsCompletelyEmpty(idx_t rg_idx) const;
 
 	// Erase row group keys; returns (number of keys removed, whether the map is now empty).

--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -4,7 +4,8 @@
 #include "concurrency/annotated_mutex.hpp"
 #include "concurrency/thread_annotation.hpp"
 
-#include "duckdb/common/array.hpp"
+#include <bitset>
+
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/unordered_set.hpp"
@@ -14,27 +15,29 @@ namespace duckdb {
 
 // Derived from DuckDB's compile-time configurable constants
 inline constexpr idx_t VECTORS_PER_ROW_GROUP = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
-inline constexpr idx_t BITVECTOR_ARRAY_SIZE = (VECTORS_PER_ROW_GROUP + 63) / 64;
 static_assert(DEFAULT_ROW_GROUP_SIZE % STANDARD_VECTOR_SIZE == 0,
               "DEFAULT_ROW_GROUP_SIZE must be divisible by STANDARD_VECTOR_SIZE");
 
-// Per row-group bitvector + watermark.
+// Per row-group pair of bitsets.
 //   matching_vectors[i] = 1 iff vec i observed to have at least one qualifying row.
-//   observed_vectors   = vecs in [0, observed_vectors) are fully observed; anything
-//                        at or above this index is unknown and must be scanned.
+//   observed[i]         = 1 iff vec i has been observed. An unobserved vec is
+//                         "unknown" and must be scanned.
 struct RowGroupFilter {
-	array<uint64_t, BITVECTOR_ARRAY_SIZE> matching_vectors = {};
-	idx_t observed_vectors = 0;
+	std::bitset<VECTORS_PER_ROW_GROUP> matching_vectors;
+	std::bitset<VECTORS_PER_ROW_GROUP> observed;
 
 	RowGroupFilter() = default;
 
-	// Leaves observed_vectors at 0; set it explicitly if you need pruning semantics.
+	// Leaves observed all-zero; set bits explicitly if you need pruning semantics.
 	explicit RowGroupFilter(const vector<idx_t> &qualifying_vectors);
 
 	void SetVector(idx_t vector_index);
 	bool VectorHasRows(idx_t vector_index) const;
 	bool IsEmpty() const;
-	// OR of matching_vectors, max of observed_vectors.
+	void SetObserved(idx_t vector_index);
+	bool IsObserved(idx_t vector_index) const;
+	bool IsFullyObserved() const;
+	// OR-merge of both bitsets.
 	void MergeFrom(const RowGroupFilter &other);
 };
 
@@ -79,27 +82,27 @@ struct ConditionCacheEntry : public ObjectCacheEntry {
 
 	// --- Thread-safe API (each method acquires `lock` internally) ---
 
-	// Ensure a row group key exists (empty filter, observed_vectors = 0).
+	// Ensure a row group key exists (empty matching, no observed bits set).
 	void EnsureRowGroup(idx_t rg_idx);
 	void SetQualifyingVector(idx_t rg_idx, idx_t vec_idx);
 	void MergeFrom(const ConditionCacheEntry &other);
 	// Used by manual full-table builds to declare every keyed rg fully observed.
 	void MarkAllRowGroupsFullyObserved();
-	// Absolute write; safe per-task because store-side MergeFrom takes max().
-	void SetRowGroupWatermark(idx_t rg_idx, idx_t observed);
+	// Mark a single vec as observed. Safe per-task because store-side MergeFrom ORs observed.
+	void SetObservedVector(idx_t rg_idx, idx_t vec_idx);
 
-	// False only if rg is cached AND vec < observed_vectors AND bit = 0.
+	// False only if rg is cached AND vec is observed AND matching bit = 0.
 	bool VectorPassesFilter(idx_t rg_idx, idx_t vec_idx) const;
 	// True iff every rg in range is cached, fully observed, and empty.
 	bool StatisticsRangeIsAllEmptyCached(idx_t min_rg, idx_t max_rg) const;
 
 	idx_t RowGroupCount() const;
 	bool HasRowGroup(idx_t rg_idx) const;
-	// Returns 0 if rg is not present.
-	idx_t GetObservedVectors(idx_t rg_idx) const;
-	// Raw bit, ignores observed_vectors. Test-only; production uses VectorPassesFilter.
+	// Popcount of the rg's observed bitmask; 0 if rg is not present.
+	idx_t GetObservedVectorCount(idx_t rg_idx) const;
+	// Raw matching bit, ignores observed. Test-only; production uses VectorPassesFilter.
 	bool RowGroupVectorHasQualifyingRows(idx_t rg_idx, idx_t vec_idx) const;
-	// Raw emptiness, ignores observed_vectors. Test-only.
+	// Raw emptiness of matching bits, ignores observed. Test-only.
 	bool RowGroupIsCompletelyEmpty(idx_t rg_idx) const;
 
 	// Erase row group keys; returns (number of keys removed, whether the map is now empty).

--- a/src/logical_cache_recorder.cpp
+++ b/src/logical_cache_recorder.cpp
@@ -1,0 +1,78 @@
+#include "logical_cache_recorder.hpp"
+
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+
+namespace duckdb {
+
+LogicalCacheRecorder::LogicalCacheRecorder(idx_t table_oid_p, string canonical_key_p,
+                                           unique_ptr<Expression> bound_predicate_p, idx_t rowid_column_index_p)
+    : table_oid(table_oid_p), canonical_key(std::move(canonical_key_p)), rowid_column_index(rowid_column_index_p) {
+	expressions.push_back(std::move(bound_predicate_p));
+}
+
+PhysicalOperator &LogicalCacheRecorder::CreatePlan(ClientContext &context, PhysicalPlanGenerator &planner) {
+	auto &child_plan = planner.CreatePlan(*children[0]);
+	auto bound_predicate = std::move(expressions[0]);
+	auto &op = planner.Make<PhysicalCacheRecorder>(table_oid, canonical_key, std::move(bound_predicate),
+	                                               rowid_column_index, child_plan.types, estimated_cardinality);
+	op.children.push_back(child_plan);
+	return op;
+}
+
+vector<ColumnBinding> LogicalCacheRecorder::GetColumnBindings() {
+	return children[0]->GetColumnBindings();
+}
+
+void LogicalCacheRecorder::ResolveTypes() {
+	types = children[0]->types;
+}
+
+string LogicalCacheRecorder::GetExtensionName() const {
+	return "query_condition_cache_recorder";
+}
+
+void LogicalCacheRecorder::Serialize(Serializer &serializer) const {
+	LogicalExtensionOperator::Serialize(serializer);
+	serializer.WriteProperty(400, "table_oid", table_oid);
+	serializer.WriteProperty(401, "canonical_key", canonical_key);
+	serializer.WriteProperty(402, "rowid_column_index", rowid_column_index);
+	serializer.WritePropertyWithDefault(403, "expressions", expressions);
+}
+
+namespace {
+
+BoundStatement CacheRecorderBind(ClientContext &context, Binder &binder, OperatorExtensionInfo *info,
+                                 SQLStatement &statement) {
+	return BoundStatement();
+}
+
+} // namespace
+
+CacheRecorderOperatorExtension::CacheRecorderOperatorExtension() {
+	Bind = CacheRecorderBind;
+}
+
+string CacheRecorderOperatorExtension::GetName() {
+	return "query_condition_cache_recorder";
+}
+
+unique_ptr<LogicalExtensionOperator> CacheRecorderOperatorExtension::Deserialize(Deserializer &deserializer) {
+	auto oid = deserializer.ReadProperty<idx_t>(400, "table_oid");
+	auto key = deserializer.ReadProperty<string>(401, "canonical_key");
+	auto rowid_col = deserializer.ReadProperty<idx_t>(402, "rowid_column_index");
+	auto exprs = deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(403, "expressions");
+
+	unique_ptr<Expression> bound_predicate;
+	if (!exprs.empty()) {
+		bound_predicate = std::move(exprs[0]);
+	} else {
+		// Placeholder keeps the operator structurally intact for verification round-trips.
+		bound_predicate = make_uniq<BoundReferenceExpression>(LogicalType {LogicalTypeId::BOOLEAN}, 0);
+	}
+	return make_uniq<LogicalCacheRecorder>(oid, std::move(key), std::move(bound_predicate), rowid_col);
+}
+
+} // namespace duckdb

--- a/src/physical_cache_recorder.cpp
+++ b/src/physical_cache_recorder.cpp
@@ -1,0 +1,163 @@
+#include "physical_cache_recorder.hpp"
+
+#include "concurrency/annotated_lock.hpp"
+
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/types/selection_vector.hpp"
+#include "duckdb/main/client_context.hpp"
+
+namespace duckdb {
+
+CacheRecorderLocalState::CacheRecorderLocalState(ClientContext &context, const Expression &bound_predicate)
+    : expr_executor(context, bound_predicate) {
+}
+
+PhysicalCacheRecorder::PhysicalCacheRecorder(PhysicalPlan &physical_plan, idx_t table_oid_p, string canonical_key_p,
+                                             unique_ptr<Expression> bound_predicate_p, idx_t rowid_column_index_p,
+                                             vector<LogicalType> types, idx_t estimated_cardinality)
+    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, std::move(types), estimated_cardinality),
+      table_oid(table_oid_p), canonical_key(std::move(canonical_key_p)), bound_predicate(std::move(bound_predicate_p)),
+      rowid_column_index(rowid_column_index_p) {
+}
+
+unique_ptr<GlobalOperatorState> PhysicalCacheRecorder::GetGlobalOperatorState(ClientContext &context) const {
+	return make_uniq<CacheRecorderGlobalState>();
+}
+
+unique_ptr<OperatorState> PhysicalCacheRecorder::GetOperatorState(ExecutionContext &context) const {
+	return make_uniq<CacheRecorderLocalState>(context.client, *bound_predicate);
+}
+
+namespace {
+
+// Register so the entry outlives this OperatorState (destroyed before OperatorFinalize).
+void RegisterLocalIfNeeded(CacheRecorderLocalState &local_state, CacheRecorderGlobalState &global_state) {
+	if (local_state.local_entry) {
+		return;
+	}
+	auto entry = make_shared_ptr<ConditionCacheEntry>();
+	{
+		concurrency::lock_guard<concurrency::mutex> guard(global_state.lock);
+		global_state.task_local_entries.push_back(entry);
+	}
+	local_state.local_entry = std::move(entry);
+}
+
+} // namespace
+
+OperatorResultType PhysicalCacheRecorder::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                  GlobalOperatorState &gstate, OperatorState &state) const {
+	D_ASSERT(rowid_column_index < input.ColumnCount());
+
+	chunk.Reference(input);
+
+	auto &local_state = state.Cast<CacheRecorderLocalState>();
+	auto &global_state = gstate.Cast<CacheRecorderGlobalState>();
+	RegisterLocalIfNeeded(local_state, global_state);
+
+	if (input.size() == 0) {
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	auto &rowid_vec = input.data[rowid_column_index];
+	UnifiedVectorFormat rowid_data;
+	rowid_vec.ToUnifiedFormat(input.size(), rowid_data);
+	auto rowids = UnifiedVectorFormat::GetData<row_t>(rowid_data);
+
+	auto first_idx = rowid_data.sel->get_index(0);
+	if (!rowid_data.validity.RowIsValid(first_idx)) {
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+	auto first_row_id = NumericCast<idx_t>(rowids[first_idx]);
+	if (first_row_id >= NumericCast<idx_t>(MAX_ROW_ID)) {
+		// Transaction-local storage rows have no stable cache identity.
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	idx_t rg_idx = first_row_id / DEFAULT_ROW_GROUP_SIZE;
+	idx_t vec_idx = (first_row_id % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
+
+	SelectionVector sel(input.size());
+	idx_t match_count = local_state.expr_executor.SelectExpression(input, sel);
+
+	RecordChunkObservation(*local_state.local_entry, local_state.max_vec_per_rg, local_state.current_rg, rg_idx,
+	                       vec_idx, /*has_qualifying=*/match_count > 0);
+
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+// TODO: advance the watermark aggressively on vec_idx jumps (intermediate vecs filtered
+// out by column filters) and on rg transitions (close rg to its true vec count from
+// storage) instead of the current +1-per-transition policy.
+void PhysicalCacheRecorder::RecordChunkObservation(ConditionCacheEntry &local_entry,
+                                                   unordered_map<idx_t, idx_t> &max_vec_per_rg,
+                                                   optional_idx &current_rg, idx_t rg_idx, idx_t vec_idx,
+                                                   bool has_qualifying) {
+	if (current_rg.IsValid() && current_rg.GetIndex() != rg_idx) {
+		idx_t prev_rg = current_rg.GetIndex();
+		local_entry.SetRowGroupWatermark(prev_rg, max_vec_per_rg[prev_rg] + 1);
+	}
+
+	auto it = max_vec_per_rg.find(rg_idx);
+	bool first_chunk_for_rg = it == max_vec_per_rg.end();
+	if (first_chunk_for_rg) {
+		local_entry.EnsureRowGroup(rg_idx);
+	} else if (vec_idx > it->second) {
+		local_entry.SetRowGroupWatermark(rg_idx, it->second + 1);
+	}
+	max_vec_per_rg[rg_idx] = vec_idx;
+	current_rg = optional_idx(rg_idx);
+
+	if (has_qualifying) {
+		local_entry.SetQualifyingVector(rg_idx, vec_idx);
+	}
+}
+
+OperatorFinalResultType PhysicalCacheRecorder::OperatorFinalize(Pipeline &pipeline, Event &event,
+                                                                ClientContext &context,
+                                                                OperatorFinalizeInput &input) const {
+	auto &global_state = input.global_state.Cast<CacheRecorderGlobalState>();
+
+	// TODO: backfill rgs scan fully skipped (zone-map or column-filter prune) by consulting
+	// storage for the rg count and keying missing entries with bit=0 + watermark=FULL. Only
+	// safe when scan ran to completion; pair with LogicalLimit detection in the optimizer.
+	auto store = ConditionCacheStore::GetOrCreate(context);
+	CacheKey key {table_oid, canonical_key};
+	auto destination = store->Lookup(context, key);
+	if (!destination) {
+		destination = make_shared_ptr<ConditionCacheEntry>();
+	}
+
+	{
+		concurrency::lock_guard<concurrency::mutex> guard(global_state.lock);
+		for (const auto &task_entry : global_state.task_local_entries) {
+			destination->MergeFrom(*task_entry);
+		}
+	}
+
+	store->Upsert(context, key, std::move(destination));
+	return OperatorFinalResultType::FINISHED;
+}
+
+bool PhysicalCacheRecorder::RequiresOperatorFinalize() const {
+	return true;
+}
+
+bool PhysicalCacheRecorder::ParallelOperator() const {
+	return true;
+}
+
+string PhysicalCacheRecorder::GetName() const {
+	return "CACHE_RECORDER";
+}
+
+InsertionOrderPreservingMap<string> PhysicalCacheRecorder::ParamsToString() const {
+	InsertionOrderPreservingMap<string> result;
+	result["Table OID"] = to_string(table_oid);
+	result["Filter Key"] = canonical_key;
+	result["Row ID Column"] = to_string(rowid_column_index);
+	return result;
+}
+
+} // namespace duckdb

--- a/src/physical_cache_recorder.cpp
+++ b/src/physical_cache_recorder.cpp
@@ -81,34 +81,15 @@ OperatorResultType PhysicalCacheRecorder::Execute(ExecutionContext &context, Dat
 	SelectionVector sel(input.size());
 	idx_t match_count = local_state.expr_executor.SelectExpression(input, sel);
 
-	RecordChunkObservation(*local_state.local_entry, local_state.max_vec_per_rg, local_state.current_rg, rg_idx,
-	                       vec_idx, /*has_qualifying=*/match_count > 0);
+	RecordChunkObservation(*local_state.local_entry, rg_idx, vec_idx, /*has_qualifying=*/match_count > 0);
 
 	return OperatorResultType::NEED_MORE_INPUT;
 }
 
-// TODO: advance the watermark aggressively on vec_idx jumps (intermediate vecs filtered
-// out by column filters) and on rg transitions (close rg to its true vec count from
-// storage) instead of the current +1-per-transition policy.
-void PhysicalCacheRecorder::RecordChunkObservation(ConditionCacheEntry &local_entry,
-                                                   unordered_map<idx_t, idx_t> &max_vec_per_rg,
-                                                   optional_idx &current_rg, idx_t rg_idx, idx_t vec_idx,
+void PhysicalCacheRecorder::RecordChunkObservation(ConditionCacheEntry &local_entry, idx_t rg_idx, idx_t vec_idx,
                                                    bool has_qualifying) {
-	if (current_rg.IsValid() && current_rg.GetIndex() != rg_idx) {
-		idx_t prev_rg = current_rg.GetIndex();
-		local_entry.SetRowGroupWatermark(prev_rg, max_vec_per_rg[prev_rg] + 1);
-	}
-
-	auto it = max_vec_per_rg.find(rg_idx);
-	bool first_chunk_for_rg = it == max_vec_per_rg.end();
-	if (first_chunk_for_rg) {
-		local_entry.EnsureRowGroup(rg_idx);
-	} else if (vec_idx > it->second) {
-		local_entry.SetRowGroupWatermark(rg_idx, it->second + 1);
-	}
-	max_vec_per_rg[rg_idx] = vec_idx;
-	current_rg = optional_idx(rg_idx);
-
+	local_entry.EnsureRowGroup(rg_idx);
+	local_entry.SetObservedVector(rg_idx, vec_idx);
 	if (has_qualifying) {
 		local_entry.SetQualifyingVector(rg_idx, vec_idx);
 	}

--- a/src/query_condition_cache_extension.cpp
+++ b/src/query_condition_cache_extension.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/optimizer/optimizer_extension.hpp"
 #include "cache_invalidation_optimizer.hpp"
 #include "logical_cache_invalidator.hpp"
+#include "logical_cache_recorder.hpp"
 #include "query_condition_cache_filter.hpp"
 #include "query_condition_cache_functions.hpp"
 #include "query_condition_cache_optimizer.hpp"
@@ -43,6 +44,7 @@ void LoadInternal(ExtensionLoader &loader) {
 	OptimizerExtension::Register(config, QueryConditionCacheOptimizer());
 	OptimizerExtension::Register(config, CacheInvalidationOptimizer());
 	OperatorExtension::Register(config, make_shared_ptr<CacheInvalidatorOperatorExtension>());
+	OperatorExtension::Register(config, make_shared_ptr<CacheRecorderOperatorExtension>());
 }
 } // namespace
 

--- a/src/query_condition_cache_functions.cpp
+++ b/src/query_condition_cache_functions.cpp
@@ -254,6 +254,8 @@ shared_ptr<ConditionCacheEntry> BuildCacheEntry(ClientContext &context, DuckTabl
 
 	auto entry = make_shared_ptr<ConditionCacheEntry>();
 	MergeLocalCacheEntries(local_entries, entry);
+	// Full-table build observes every rg end-to-end; trust bits for pruning.
+	entry->MarkAllRowGroupsFullyObserved();
 
 	return entry;
 }

--- a/src/query_condition_cache_optimizer.cpp
+++ b/src/query_condition_cache_optimizer.cpp
@@ -1,5 +1,6 @@
 #include "query_condition_cache_optimizer.hpp"
 
+#include "logical_cache_recorder.hpp"
 #include "query_condition_cache_filter.hpp"
 #include "predicate_key_utils.hpp"
 #include "query_condition_cache_functions.hpp"
@@ -42,13 +43,31 @@ void QueryConditionCacheOptimizer::PreOptimizeFunction(OptimizerExtensionInput &
 	auto query_state =
 	    input.context.registered_state->GetOrCreate<CacheOptimizerQueryState>(CacheOptimizerQueryState::NAME);
 	query_state->cache_apply_pending.clear();
+	query_state->cache_recorder_pending.clear();
 	try {
 		PreOptimizeWalk(input.context, plan, /*inside_dml=*/false, *query_state);
 	} catch (...) {
 		// Defense in depth: skip cache optimization rather than failing the query.
 		query_state->cache_apply_pending.clear();
+		query_state->cache_recorder_pending.clear();
 	}
 }
+
+namespace {
+
+// BoundColumnRef.column_index == chunk position at runtime, so we can rewrite directly
+// to BoundReference(column_index).
+void ConvertColumnRefsToChunkRefs(unique_ptr<Expression> &expr) {
+	if (expr->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+		auto &colref = expr->Cast<BoundColumnRefExpression>();
+		expr = make_uniq<BoundReferenceExpression>(colref.alias, colref.return_type, colref.binding.column_index);
+		return;
+	}
+	ExpressionIterator::EnumerateChildren(*expr,
+	                                      [&](unique_ptr<Expression> &child) { ConvertColumnRefsToChunkRefs(child); });
+}
+
+} // namespace
 
 void QueryConditionCacheOptimizer::PreOptimizeWalk(ClientContext &context, unique_ptr<LogicalOperator> &plan,
                                                    bool inside_dml, CacheOptimizerQueryState &state) {
@@ -103,62 +122,30 @@ void QueryConditionCacheOptimizer::PreOptimizeWalk(ClientContext &context, uniqu
 	auto entry = store->Lookup(context, key);
 
 	if (!entry) {
-		// TODO: Consider building cache in the background and syncing later
-		// to avoid blocking the first query.
-		entry = BuildCacheForPredicate(context, filter.expressions, get);
-		if (entry) {
-			store->Upsert(context, key, entry);
+		// Upsert the empty entry up front so the cache filter's bind_data and the recorder's
+		// Finalize Lookup resolve to the same shared_ptr.
+		entry = make_shared_ptr<ConditionCacheEntry>();
+		store->Upsert(context, key, entry);
+
+		// TODO: Also inject the recorder on a partial cache hit so the watermark can
+		// advance on later queries and DML-dropped rgs get re-observed. Must skip under
+		// LogicalLimit: a truncated scan cannot distinguish "unobserved" from "no match".
+		vector<unique_ptr<Expression>> cloned;
+		cloned.reserve(filter.expressions.size());
+		for (const auto &expr : filter.expressions) {
+			auto copy = expr->Copy();
+			ConvertColumnRefsToChunkRefs(copy);
+			cloned.push_back(std::move(copy));
 		}
+		auto predicate = CombineWithAnd(std::move(cloned));
+		predicate =
+		    BoundCastExpression::AddCastToType(context, std::move(predicate), LogicalType {LogicalTypeId::BOOLEAN});
+
+		state.cache_recorder_pending[get.table_index] =
+		    RecorderInjectionInfo {table->oid, key.filter_key, std::move(predicate)};
 	}
 
-	if (entry) {
-		state.cache_apply_pending[get.table_index] = std::move(entry);
-	}
-}
-
-namespace {
-
-// Rewrite BoundColumnRefExpression -> BoundReferenceExpression(storage OID),
-// the shape BuildCacheEntry expects. The source column_index is a position
-// into LogicalGet::column_ids, which maps to the storage OID.
-void ConvertColumnRefsToScanRefs(unique_ptr<Expression> &expr, const LogicalGet &get) {
-	if (expr->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
-		auto &colref = expr->Cast<BoundColumnRefExpression>();
-		auto &column_ids = get.GetColumnIds();
-		auto col_idx = colref.binding.column_index;
-		ALWAYS_ASSERT(col_idx < column_ids.size());
-		auto storage_oid = column_ids[col_idx].GetPrimaryIndex();
-		expr = make_uniq<BoundReferenceExpression>(colref.alias, colref.return_type, storage_oid);
-		return;
-	}
-	ExpressionIterator::EnumerateChildren(
-	    *expr, [&](unique_ptr<Expression> &child) { ConvertColumnRefsToScanRefs(child, get); });
-}
-
-} // namespace
-
-shared_ptr<ConditionCacheEntry> QueryConditionCacheOptimizer::BuildCacheForPredicate(
-    ClientContext &context, const vector<unique_ptr<Expression>> &expressions, LogicalGet &get) {
-	auto table_ptr = get.GetTable();
-	if (!table_ptr) {
-		return nullptr;
-	}
-	auto &table_entry = table_ptr->Cast<DuckTableEntry>();
-
-	// Clone the plan's already-bound filter expressions and remap column refs
-	// to storage OIDs.
-	vector<unique_ptr<Expression>> cloned;
-	cloned.reserve(expressions.size());
-	for (const auto &expr : expressions) {
-		auto copy = expr->Copy();
-		ConvertColumnRefsToScanRefs(copy, get);
-		cloned.push_back(std::move(copy));
-	}
-
-	auto predicate = CombineWithAnd(std::move(cloned));
-	predicate = BoundCastExpression::AddCastToType(context, std::move(predicate), LogicalType {LogicalTypeId::BOOLEAN});
-
-	return BuildCacheEntry(context, table_entry, *predicate);
+	state.cache_apply_pending[get.table_index] = std::move(entry);
 }
 
 void QueryConditionCacheOptimizer::PostOptimizeWalk(ClientContext &context, unique_ptr<LogicalOperator> &plan,
@@ -179,6 +166,13 @@ void QueryConditionCacheOptimizer::PostOptimizeWalk(ClientContext &context, uniq
 
 	InjectCacheFilter(context, get, entry->second);
 	state.cache_apply_pending.erase(entry);
+
+	auto recorder_it = state.cache_recorder_pending.find(get.table_index);
+	if (recorder_it != state.cache_recorder_pending.end()) {
+		auto info = std::move(recorder_it->second);
+		state.cache_recorder_pending.erase(recorder_it);
+		InjectCacheRecorder(context, plan, std::move(info));
+	}
 }
 
 void QueryConditionCacheOptimizer::InjectCacheFilter(ClientContext &context, LogicalGet &get,
@@ -212,13 +206,57 @@ void QueryConditionCacheOptimizer::InjectCacheFilter(ClientContext &context, Log
 	                             make_uniq<CacheExpressionFilter>(std::move(filter_expr), entry));
 }
 
+void QueryConditionCacheOptimizer::InjectCacheRecorder(ClientContext &context, unique_ptr<LogicalOperator> &plan,
+                                                       RecorderInjectionInfo &&info) {
+	D_ASSERT(plan->type == LogicalOperatorType::LOGICAL_GET);
+	auto &get = plan->Cast<LogicalGet>();
+	auto &column_ids = get.GetMutableColumnIds();
+
+	// ROW_ID was added to column_ids by InjectCacheFilter; we also surface it through
+	// projection_ids so it reaches the recorder's input chunk.
+	idx_t rowid_column_ids_pos = column_ids.size();
+	for (idx_t ii = 0; ii < column_ids.size(); ++ii) {
+		if (column_ids[ii].IsRowIdColumn()) {
+			rowid_column_ids_pos = ii;
+			break;
+		}
+	}
+	D_ASSERT(rowid_column_ids_pos < column_ids.size());
+
+	// Chunk-level position = column_ids position if no projection, otherwise the matching
+	// (or newly appended) projection_ids slot.
+	idx_t rowid_chunk_idx;
+	if (get.projection_ids.empty()) {
+		rowid_chunk_idx = rowid_column_ids_pos;
+	} else {
+		idx_t found = get.projection_ids.size();
+		for (idx_t ii = 0; ii < get.projection_ids.size(); ++ii) {
+			if (get.projection_ids[ii] == rowid_column_ids_pos) {
+				found = ii;
+				break;
+			}
+		}
+		if (found < get.projection_ids.size()) {
+			rowid_chunk_idx = found;
+		} else {
+			get.projection_ids.push_back(rowid_column_ids_pos);
+			rowid_chunk_idx = get.projection_ids.size() - 1;
+		}
+	}
+
+	auto recorder = make_uniq<LogicalCacheRecorder>(info.table_oid, std::move(info.canonical_key),
+	                                                std::move(info.predicate), rowid_chunk_idx);
+	recorder->children.push_back(std::move(plan));
+	plan = std::move(recorder);
+}
+
 void QueryConditionCacheOptimizer::OptimizeFunction(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
 	if (!IsSettingEnabled(input.context)) {
 		return;
 	}
 
 	auto query_state = input.context.registered_state->Get<CacheOptimizerQueryState>(CacheOptimizerQueryState::NAME);
-	if (!query_state || query_state->cache_apply_pending.empty()) {
+	if (!query_state || (query_state->cache_apply_pending.empty() && query_state->cache_recorder_pending.empty())) {
 		return;
 	}
 

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -1,6 +1,7 @@
 #include "query_condition_cache_state.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/helper.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/storage/object_cache.hpp"
 
@@ -35,6 +36,7 @@ void RowGroupFilter::MergeFrom(const RowGroupFilter &other) {
 	for (idx_t i = 0; i < BITVECTOR_ARRAY_SIZE; ++i) {
 		matching_vectors[i] |= other.matching_vectors[i];
 	}
+	observed_vectors = MaxValue(observed_vectors, other.observed_vectors);
 }
 
 // ------- CONDITION_CACHE_ENTRY -------
@@ -107,10 +109,25 @@ void ConditionCacheEntry::MergeFrom(const ConditionCacheEntry &other) {
 	}
 }
 
+void ConditionCacheEntry::MarkAllRowGroupsFullyObserved() {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	for (auto &[rg_idx, filter] : bitvectors) {
+		filter.observed_vectors = VECTORS_PER_ROW_GROUP;
+	}
+}
+
+void ConditionCacheEntry::SetRowGroupWatermark(idx_t rg_idx, idx_t observed) {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	bitvectors[rg_idx].observed_vectors = observed;
+}
+
 bool ConditionCacheEntry::VectorPassesFilter(idx_t rg_idx, idx_t vec_idx) const {
 	concurrency::lock_guard<concurrency::mutex> guard(lock);
 	auto it = bitvectors.find(rg_idx);
 	if (it == bitvectors.end()) {
+		return true;
+	}
+	if (vec_idx >= it->second.observed_vectors) {
 		return true;
 	}
 	return it->second.VectorHasRows(vec_idx);
@@ -121,6 +138,9 @@ bool ConditionCacheEntry::StatisticsRangeIsAllEmptyCached(idx_t min_rg, idx_t ma
 	for (idx_t rg = min_rg; rg <= max_rg; ++rg) {
 		auto it = bitvectors.find(rg);
 		if (it == bitvectors.end() || !it->second.IsEmpty()) {
+			return false;
+		}
+		if (it->second.observed_vectors < VECTORS_PER_ROW_GROUP) {
 			return false;
 		}
 	}
@@ -135,6 +155,15 @@ idx_t ConditionCacheEntry::RowGroupCount() const {
 bool ConditionCacheEntry::HasRowGroup(idx_t rg_idx) const {
 	concurrency::lock_guard<concurrency::mutex> guard(lock);
 	return bitvectors.find(rg_idx) != bitvectors.end();
+}
+
+idx_t ConditionCacheEntry::GetObservedVectors(idx_t rg_idx) const {
+	concurrency::lock_guard<concurrency::mutex> guard(lock);
+	auto it = bitvectors.find(rg_idx);
+	if (it == bitvectors.end()) {
+		return 0;
+	}
+	return it->second.observed_vectors;
 }
 
 bool ConditionCacheEntry::RowGroupVectorHasQualifyingRows(idx_t rg_idx, idx_t vec_idx) const {

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -1,7 +1,6 @@
 #include "query_condition_cache_state.hpp"
 
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/helper.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/storage/object_cache.hpp"
 
@@ -11,32 +10,37 @@ namespace duckdb {
 
 RowGroupFilter::RowGroupFilter(const vector<idx_t> &qualifying_vectors) {
 	for (const auto &vec_idx : qualifying_vectors) {
-		matching_vectors.at(vec_idx / 64) |= (1ULL << (vec_idx % 64));
+		matching_vectors.set(vec_idx);
 	}
 }
 
 void RowGroupFilter::SetVector(idx_t vector_index) {
-	matching_vectors.at(vector_index / 64) |= (1ULL << (vector_index % 64));
+	matching_vectors.set(vector_index);
 }
 
 bool RowGroupFilter::VectorHasRows(idx_t vector_index) const {
-	return (matching_vectors.at(vector_index / 64) >> (vector_index % 64)) & 1ULL;
+	return matching_vectors.test(vector_index);
 }
 
 bool RowGroupFilter::IsEmpty() const {
-	for (const auto &w : matching_vectors) {
-		if (w != 0) {
-			return false;
-		}
-	}
-	return true;
+	return matching_vectors.none();
+}
+
+void RowGroupFilter::SetObserved(idx_t vector_index) {
+	observed.set(vector_index);
+}
+
+bool RowGroupFilter::IsObserved(idx_t vector_index) const {
+	return observed.test(vector_index);
+}
+
+bool RowGroupFilter::IsFullyObserved() const {
+	return observed.all();
 }
 
 void RowGroupFilter::MergeFrom(const RowGroupFilter &other) {
-	for (idx_t i = 0; i < BITVECTOR_ARRAY_SIZE; ++i) {
-		matching_vectors[i] |= other.matching_vectors[i];
-	}
-	observed_vectors = MaxValue(observed_vectors, other.observed_vectors);
+	matching_vectors |= other.matching_vectors;
+	observed |= other.observed;
 }
 
 // ------- CONDITION_CACHE_ENTRY -------
@@ -58,11 +62,7 @@ CacheEntryStats ConditionCacheEntry::ComputeStats(idx_t total_rows) const {
 		if (!filter.IsEmpty()) {
 			++qualifying_row_groups;
 		}
-		for (idx_t v = 0; v < vectors_per_row_group; ++v) {
-			if (filter.VectorHasRows(v)) {
-				++qualifying_vectors;
-			}
-		}
+		qualifying_vectors += filter.matching_vectors.count();
 	}
 
 	idx_t full_row_groups = total_rows / DEFAULT_ROW_GROUP_SIZE;
@@ -112,13 +112,13 @@ void ConditionCacheEntry::MergeFrom(const ConditionCacheEntry &other) {
 void ConditionCacheEntry::MarkAllRowGroupsFullyObserved() {
 	concurrency::lock_guard<concurrency::mutex> guard(lock);
 	for (auto &[rg_idx, filter] : bitvectors) {
-		filter.observed_vectors = VECTORS_PER_ROW_GROUP;
+		filter.observed.set();
 	}
 }
 
-void ConditionCacheEntry::SetRowGroupWatermark(idx_t rg_idx, idx_t observed) {
+void ConditionCacheEntry::SetObservedVector(idx_t rg_idx, idx_t vec_idx) {
 	concurrency::lock_guard<concurrency::mutex> guard(lock);
-	bitvectors[rg_idx].observed_vectors = observed;
+	bitvectors[rg_idx].SetObserved(vec_idx);
 }
 
 bool ConditionCacheEntry::VectorPassesFilter(idx_t rg_idx, idx_t vec_idx) const {
@@ -127,7 +127,7 @@ bool ConditionCacheEntry::VectorPassesFilter(idx_t rg_idx, idx_t vec_idx) const 
 	if (it == bitvectors.end()) {
 		return true;
 	}
-	if (vec_idx >= it->second.observed_vectors) {
+	if (!it->second.IsObserved(vec_idx)) {
 		return true;
 	}
 	return it->second.VectorHasRows(vec_idx);
@@ -140,7 +140,7 @@ bool ConditionCacheEntry::StatisticsRangeIsAllEmptyCached(idx_t min_rg, idx_t ma
 		if (it == bitvectors.end() || !it->second.IsEmpty()) {
 			return false;
 		}
-		if (it->second.observed_vectors < VECTORS_PER_ROW_GROUP) {
+		if (!it->second.IsFullyObserved()) {
 			return false;
 		}
 	}
@@ -157,13 +157,13 @@ bool ConditionCacheEntry::HasRowGroup(idx_t rg_idx) const {
 	return bitvectors.find(rg_idx) != bitvectors.end();
 }
 
-idx_t ConditionCacheEntry::GetObservedVectors(idx_t rg_idx) const {
+idx_t ConditionCacheEntry::GetObservedVectorCount(idx_t rg_idx) const {
 	concurrency::lock_guard<concurrency::mutex> guard(lock);
 	auto it = bitvectors.find(rg_idx);
 	if (it == bitvectors.end()) {
 		return 0;
 	}
-	return it->second.observed_vectors;
+	return static_cast<idx_t>(it->second.observed.count());
 }
 
 bool ConditionCacheEntry::RowGroupVectorHasQualifyingRows(idx_t rg_idx, idx_t vec_idx) const {

--- a/test/sql/condition_cache_incremental.test
+++ b/test/sql/condition_cache_incremental.test
@@ -1,0 +1,95 @@
+# name: test/sql/condition_cache_incremental.test
+# description: Optimizer injects recorder on miss; cache builds as a query side-effect.
+# group: [sql]
+
+require query_condition_cache
+
+statement ok
+CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i);
+
+# Empty cache.
+query IIII
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+0	0	0	0
+
+# First query populates cache via recorder side-effect.
+query I
+SELECT count(*) FROM t WHERE val = 42;
+----
+5000
+
+query IIII
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+5	5	245	245
+
+# Repeat: hit, no re-injection.
+query I
+SELECT count(*) FROM t WHERE val = 42;
+----
+5000
+
+query IIII
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+5	5	245	245
+
+# Selective predicate: only rg 0 has matches; rgs 1..4 keyed as empty for pruning.
+query I
+SELECT count(*) FROM t WHERE id < 3000;
+----
+3000
+
+query IIII
+SELECT * FROM condition_cache_info('t', 'id < 3000');
+----
+1	5	2	245
+
+query I
+SELECT count(*) FROM t WHERE id < 3000;
+----
+3000
+
+# Predicate matching nothing still keys every rg as observed empty.
+query I
+SELECT count(*) FROM t WHERE id < 0;
+----
+0
+
+query IIII
+SELECT * FROM condition_cache_info('t', 'id < 0');
+----
+0	5	0	245
+
+query I
+SELECT count(*) FROM t WHERE id < 0;
+----
+0
+
+# Disable clears cache; re-enable starts from a clean slate.
+statement ok
+SET use_query_condition_cache = false;
+
+query I
+SELECT count(*) FROM t WHERE val = 42;
+----
+5000
+
+query IIII
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+0	0	0	0
+
+statement ok
+SET use_query_condition_cache = true;
+
+query I
+SELECT count(*) FROM t WHERE val = 42;
+----
+5000
+
+query IIII
+SELECT * FROM condition_cache_info('t', 'val = 42');
+----
+5	5	245	245

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -17,7 +17,8 @@ set(QUERY_CACHE_UNITTEST_OBJECTS
     test_logical_cache_invalidator.cpp
     test_normalize_expression.cpp
     test_optimizer_invalidation.cpp
-    test_physical_cache_invalidator.cpp)
+    test_physical_cache_invalidator.cpp
+    test_physical_cache_recorder.cpp)
 
 add_executable(unittest_query_condition_cache ${QUERY_CACHE_UNITTEST_OBJECTS})
 

--- a/test/unittest/test_bitvector.cpp
+++ b/test/unittest/test_bitvector.cpp
@@ -56,4 +56,42 @@ TEST_CASE("RowGroupFilter - basic operations", "[bitvector]") {
 		REQUIRE_FALSE(a.VectorHasRows(0));
 	}
 }
+
+TEST_CASE("RowGroupFilter - observed_vectors watermark", "[bitvector]") {
+	SECTION("default constructor leaves observed_vectors at 0") {
+		RowGroupFilter bv;
+		REQUIRE(bv.observed_vectors == 0);
+	}
+
+	SECTION("vector-of-indices constructor leaves observed_vectors at 0") {
+		RowGroupFilter bv({0, 5});
+		REQUIRE(bv.observed_vectors == 0);
+	}
+
+	SECTION("MergeFrom takes max of watermarks") {
+		RowGroupFilter a;
+		a.observed_vectors = 3;
+		RowGroupFilter b;
+		b.observed_vectors = 7;
+		a.MergeFrom(b);
+		REQUIRE(a.observed_vectors == 7);
+	}
+
+	SECTION("MergeFrom keeps higher watermark when other is lower") {
+		RowGroupFilter a;
+		a.observed_vectors = 10;
+		RowGroupFilter b;
+		b.observed_vectors = 4;
+		a.MergeFrom(b);
+		REQUIRE(a.observed_vectors == 10);
+	}
+
+	SECTION("MergeFrom from a default-watermark filter preserves existing watermark") {
+		RowGroupFilter a;
+		a.observed_vectors = 5;
+		RowGroupFilter empty;
+		a.MergeFrom(empty);
+		REQUIRE(a.observed_vectors == 5);
+	}
+}
 } // namespace duckdb

--- a/test/unittest/test_bitvector.cpp
+++ b/test/unittest/test_bitvector.cpp
@@ -57,41 +57,58 @@ TEST_CASE("RowGroupFilter - basic operations", "[bitvector]") {
 	}
 }
 
-TEST_CASE("RowGroupFilter - observed_vectors watermark", "[bitvector]") {
-	SECTION("default constructor leaves observed_vectors at 0") {
+TEST_CASE("RowGroupFilter - observed bitmask", "[bitvector]") {
+	SECTION("default constructor leaves observed bits all zero") {
 		RowGroupFilter bv;
-		REQUIRE(bv.observed_vectors == 0);
+		for (idx_t i = 0; i < VECTORS_PER_ROW_GROUP; ++i) {
+			REQUIRE_FALSE(bv.IsObserved(i));
+		}
+		REQUIRE_FALSE(bv.IsFullyObserved());
 	}
 
-	SECTION("vector-of-indices constructor leaves observed_vectors at 0") {
+	SECTION("vector-of-indices constructor leaves observed bits all zero") {
 		RowGroupFilter bv({0, 5});
-		REQUIRE(bv.observed_vectors == 0);
+		REQUIRE_FALSE(bv.IsObserved(0));
+		REQUIRE_FALSE(bv.IsObserved(5));
 	}
 
-	SECTION("MergeFrom takes max of watermarks") {
+	SECTION("SetObserved sets the bit") {
+		RowGroupFilter bv;
+		bv.SetObserved(3);
+		bv.SetObserved(7);
+		REQUIRE(bv.IsObserved(3));
+		REQUIRE(bv.IsObserved(7));
+		REQUIRE_FALSE(bv.IsObserved(4));
+	}
+
+	SECTION("IsFullyObserved true only when every vec bit set") {
+		RowGroupFilter bv;
+		for (idx_t i = 0; i < VECTORS_PER_ROW_GROUP; ++i) {
+			bv.SetObserved(i);
+		}
+		REQUIRE(bv.IsFullyObserved());
+	}
+
+	SECTION("MergeFrom ORs observed bits") {
 		RowGroupFilter a;
-		a.observed_vectors = 3;
+		a.SetObserved(1);
+		a.SetObserved(3);
 		RowGroupFilter b;
-		b.observed_vectors = 7;
+		b.SetObserved(2);
+		b.SetObserved(3);
 		a.MergeFrom(b);
-		REQUIRE(a.observed_vectors == 7);
+		REQUIRE(a.IsObserved(1));
+		REQUIRE(a.IsObserved(2));
+		REQUIRE(a.IsObserved(3));
+		REQUIRE_FALSE(a.IsObserved(0));
 	}
 
-	SECTION("MergeFrom keeps higher watermark when other is lower") {
+	SECTION("MergeFrom from an empty filter preserves existing observed bits") {
 		RowGroupFilter a;
-		a.observed_vectors = 10;
-		RowGroupFilter b;
-		b.observed_vectors = 4;
-		a.MergeFrom(b);
-		REQUIRE(a.observed_vectors == 10);
-	}
-
-	SECTION("MergeFrom from a default-watermark filter preserves existing watermark") {
-		RowGroupFilter a;
-		a.observed_vectors = 5;
+		a.SetObserved(5);
 		RowGroupFilter empty;
 		a.MergeFrom(empty);
-		REQUIRE(a.observed_vectors == 5);
+		REQUIRE(a.IsObserved(5));
 	}
 }
 } // namespace duckdb

--- a/test/unittest/test_build_cache_entry.cpp
+++ b/test/unittest/test_build_cache_entry.cpp
@@ -1,5 +1,6 @@
 #include "catch/catch.hpp"
 #include "query_condition_cache_functions.hpp"
+#include "query_condition_cache_state.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
@@ -36,6 +37,11 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 
 		REQUIRE(entry != nullptr);
 		REQUIRE(entry->RowGroupCount() == 5);
+		// BuildCacheEntry must finalise the watermark so VectorPassesFilter / CheckStatistics
+		// trust the bitvectors for pruning.
+		for (idx_t rg = 0; rg < 5; ++rg) {
+			REQUIRE(entry->GetObservedVectors(rg) == VECTORS_PER_ROW_GROUP);
+		}
 	}
 
 	SECTION("selective predicate") {
@@ -56,6 +62,9 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		REQUIRE(entry->RowGroupVectorHasQualifyingRows(0, 1));
 		REQUIRE_FALSE(entry->RowGroupVectorHasQualifyingRows(0, 2));
 		REQUIRE(entry->RowGroupIsCompletelyEmpty(1));
+		for (idx_t rg = 0; rg < 5; ++rg) {
+			REQUIRE(entry->GetObservedVectors(rg) == VECTORS_PER_ROW_GROUP);
+		}
 	}
 
 	SECTION("odd values pass, even values don't") {
@@ -72,6 +81,9 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 
 		REQUIRE(entry != nullptr);
 		REQUIRE(entry->RowGroupCount() == 5);
+		for (idx_t rg = 0; rg < 5; ++rg) {
+			REQUIRE(entry->GetObservedVectors(rg) == VECTORS_PER_ROW_GROUP);
+		}
 	}
 
 	SECTION("no matching rows") {
@@ -90,6 +102,11 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		REQUIRE(entry->RowGroupCount() == 5);
 		REQUIRE(entry->RowGroupIsCompletelyEmpty(0));
 		REQUIRE(entry->RowGroupIsCompletelyEmpty(4));
+		// Even when no rows match, every observed row group must be marked fully observed so
+		// CheckStatistics can prune them.
+		for (idx_t rg = 0; rg < 5; ++rg) {
+			REQUIRE(entry->GetObservedVectors(rg) == VECTORS_PER_ROW_GROUP);
+		}
 	}
 }
 } // namespace duckdb

--- a/test/unittest/test_build_cache_entry.cpp
+++ b/test/unittest/test_build_cache_entry.cpp
@@ -40,7 +40,7 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		// BuildCacheEntry must finalise the watermark so VectorPassesFilter / CheckStatistics
 		// trust the bitvectors for pruning.
 		for (idx_t rg = 0; rg < 5; ++rg) {
-			REQUIRE(entry->GetObservedVectors(rg) == VECTORS_PER_ROW_GROUP);
+			REQUIRE(entry->GetObservedVectorCount(rg) == VECTORS_PER_ROW_GROUP);
 		}
 	}
 
@@ -63,7 +63,7 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		REQUIRE_FALSE(entry->RowGroupVectorHasQualifyingRows(0, 2));
 		REQUIRE(entry->RowGroupIsCompletelyEmpty(1));
 		for (idx_t rg = 0; rg < 5; ++rg) {
-			REQUIRE(entry->GetObservedVectors(rg) == VECTORS_PER_ROW_GROUP);
+			REQUIRE(entry->GetObservedVectorCount(rg) == VECTORS_PER_ROW_GROUP);
 		}
 	}
 
@@ -82,7 +82,7 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		REQUIRE(entry != nullptr);
 		REQUIRE(entry->RowGroupCount() == 5);
 		for (idx_t rg = 0; rg < 5; ++rg) {
-			REQUIRE(entry->GetObservedVectors(rg) == VECTORS_PER_ROW_GROUP);
+			REQUIRE(entry->GetObservedVectorCount(rg) == VECTORS_PER_ROW_GROUP);
 		}
 	}
 
@@ -105,7 +105,7 @@ TEST_CASE("BuildCacheEntry - basic predicate", "[build_cache_entry]") {
 		// Even when no rows match, every observed row group must be marked fully observed so
 		// CheckStatistics can prune them.
 		for (idx_t rg = 0; rg < 5; ++rg) {
-			REQUIRE(entry->GetObservedVectors(rg) == VECTORS_PER_ROW_GROUP);
+			REQUIRE(entry->GetObservedVectorCount(rg) == VECTORS_PER_ROW_GROUP);
 		}
 	}
 }

--- a/test/unittest/test_filter.cpp
+++ b/test/unittest/test_filter.cpp
@@ -36,6 +36,9 @@ TEST_CASE("CacheExpressionFilter - CheckStatistics", "[query_condition_cache]") 
 	entry->SetQualifyingVector(/*rg_idx=*/0, /*vec_idx=*/5);
 	entry->EnsureRowGroup(/*rg_idx=*/1);
 	entry->SetQualifyingVector(/*rg_idx=*/2, /*vec_idx=*/10);
+	// CheckStatistics requires every row group in range to be fully observed before it can
+	// confidently report FILTER_ALWAYS_FALSE; emulate the full-build state for these tests.
+	entry->MarkAllRowGroupsFullyObserved();
 
 	auto dummy_expr = make_uniq<BoundReferenceExpression>(LogicalType {LogicalTypeId::BIGINT}, 0);
 	CacheExpressionFilter filter(std::move(dummy_expr), entry);
@@ -63,6 +66,51 @@ TEST_CASE("CacheExpressionFilter - CheckStatistics", "[query_condition_cache]") 
 
 	SECTION("stats without min/max: no pruning") {
 		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
+		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::NO_PRUNING_POSSIBLE);
+	}
+}
+
+TEST_CASE("CacheExpressionFilter - watermark gating", "[query_condition_cache]") {
+	SECTION("empty row group with watermark < full: no pruning") {
+		auto entry = make_shared_ptr<ConditionCacheEntry>();
+		entry->EnsureRowGroup(/*rg_idx=*/1); // observed_vectors defaults to 0
+
+		auto dummy_expr = make_uniq<BoundReferenceExpression>(LogicalType {LogicalTypeId::BIGINT}, 0);
+		CacheExpressionFilter filter(std::move(dummy_expr), entry);
+
+		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
+		NumericStats::SetMin(stats, Value::BIGINT(122880));
+		NumericStats::SetMax(stats, Value::BIGINT(200000));
+		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::NO_PRUNING_POSSIBLE);
+	}
+
+	SECTION("empty row group becomes prunable once marked fully observed") {
+		auto entry = make_shared_ptr<ConditionCacheEntry>();
+		entry->EnsureRowGroup(/*rg_idx=*/1);
+		entry->MarkAllRowGroupsFullyObserved();
+
+		auto dummy_expr = make_uniq<BoundReferenceExpression>(LogicalType {LogicalTypeId::BIGINT}, 0);
+		CacheExpressionFilter filter(std::move(dummy_expr), entry);
+
+		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
+		NumericStats::SetMin(stats, Value::BIGINT(122880));
+		NumericStats::SetMax(stats, Value::BIGINT(200000));
+		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::FILTER_ALWAYS_FALSE);
+	}
+
+	SECTION("range with one fully-observed empty rg and one absent rg: no pruning") {
+		auto entry = make_shared_ptr<ConditionCacheEntry>();
+		entry->EnsureRowGroup(/*rg_idx=*/1);
+		entry->MarkAllRowGroupsFullyObserved();
+		// rg 2 is intentionally absent: a range spanning rg 1 and rg 2 cannot be pruned because
+		// the cache has no information about rg 2.
+
+		auto dummy_expr = make_uniq<BoundReferenceExpression>(LogicalType {LogicalTypeId::BIGINT}, 0);
+		CacheExpressionFilter filter(std::move(dummy_expr), entry);
+
+		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
+		NumericStats::SetMin(stats, Value::BIGINT(122880));
+		NumericStats::SetMax(stats, Value::BIGINT(300000));
 		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::NO_PRUNING_POSSIBLE);
 	}
 }

--- a/test/unittest/test_filter.cpp
+++ b/test/unittest/test_filter.cpp
@@ -70,10 +70,10 @@ TEST_CASE("CacheExpressionFilter - CheckStatistics", "[query_condition_cache]") 
 	}
 }
 
-TEST_CASE("CacheExpressionFilter - watermark gating", "[query_condition_cache]") {
-	SECTION("empty row group with watermark < full: no pruning") {
+TEST_CASE("CacheExpressionFilter - observed-bit gating", "[query_condition_cache]") {
+	SECTION("empty row group with no observed bits: no pruning") {
 		auto entry = make_shared_ptr<ConditionCacheEntry>();
-		entry->EnsureRowGroup(/*rg_idx=*/1); // observed_vectors defaults to 0
+		entry->EnsureRowGroup(/*rg_idx=*/1); // observed bits all zero
 
 		auto dummy_expr = make_uniq<BoundReferenceExpression>(LogicalType {LogicalTypeId::BIGINT}, 0);
 		CacheExpressionFilter filter(std::move(dummy_expr), entry);

--- a/test/unittest/test_physical_cache_recorder.cpp
+++ b/test/unittest/test_physical_cache_recorder.cpp
@@ -1,0 +1,190 @@
+#include "catch/catch.hpp"
+
+#include "logical_cache_recorder.hpp"
+#include "physical_cache_recorder.hpp"
+#include "query_condition_cache_state.hpp"
+
+namespace duckdb {
+
+namespace {
+
+// Two idx_t fields — designated initializers prevent arg-swap mistakes.
+struct RecorderObservation {
+	idx_t rg_idx;
+	idx_t vec_idx;
+	bool has_qualifying;
+};
+
+void RecordSequence(ConditionCacheEntry &local_entry, unordered_map<idx_t, idx_t> &max_vec_per_rg,
+                    optional_idx &current_rg, const vector<RecorderObservation> &observations) {
+	for (const auto &obs : observations) {
+		PhysicalCacheRecorder::RecordChunkObservation(local_entry, max_vec_per_rg, current_rg, obs.rg_idx, obs.vec_idx,
+		                                              obs.has_qualifying);
+	}
+}
+
+} // namespace
+
+TEST_CASE("PhysicalCacheRecorder - watermark advances on within-rg vec transition", "[physical_recorder]") {
+	ConditionCacheEntry local_entry;
+	unordered_map<idx_t, idx_t> max_vec_per_rg;
+	optional_idx current_rg;
+
+	// Observe vecs 0, 1, 2 of rg 5 in order. After each transition, the previous vec is "confirmed".
+	RecordSequence(local_entry, max_vec_per_rg, current_rg,
+	               {{.rg_idx = 5, .vec_idx = 0, .has_qualifying = true},
+	                {.rg_idx = 5, .vec_idx = 1, .has_qualifying = false},
+	                {.rg_idx = 5, .vec_idx = 2, .has_qualifying = true}});
+
+	// Watermark should be 2: vecs [0, 2) confirmed observed (vecs 0 and 1).
+	// Vec 2 is the last seen and stays uncommitted (might be partial).
+	REQUIRE(local_entry.GetObservedVectors(5) == 2);
+	REQUIRE(local_entry.HasRowGroup(5));
+	// Bits for vec 0 (qualifying), vec 1 (not), vec 2 (qualifying) should all be recorded.
+	REQUIRE(local_entry.RowGroupVectorHasQualifyingRows(5, 0));
+	REQUIRE_FALSE(local_entry.RowGroupVectorHasQualifyingRows(5, 1));
+	REQUIRE(local_entry.RowGroupVectorHasQualifyingRows(5, 2));
+}
+
+TEST_CASE("PhysicalCacheRecorder - rg transition advances previous rg's watermark to max + 1", "[physical_recorder]") {
+	ConditionCacheEntry local_entry;
+	unordered_map<idx_t, idx_t> max_vec_per_rg;
+	optional_idx current_rg;
+
+	// Process rg 3 with vecs 0..4, then transition to rg 7 with vec 0.
+	RecordSequence(local_entry, max_vec_per_rg, current_rg,
+	               {{.rg_idx = 3, .vec_idx = 0, .has_qualifying = false},
+	                {.rg_idx = 3, .vec_idx = 1, .has_qualifying = true},
+	                {.rg_idx = 3, .vec_idx = 2, .has_qualifying = false},
+	                {.rg_idx = 3, .vec_idx = 3, .has_qualifying = true},
+	                {.rg_idx = 3, .vec_idx = 4, .has_qualifying = false},
+	                {.rg_idx = 7, .vec_idx = 0, .has_qualifying = true}});
+
+	// rg 3 fully observed in this task: watermark = max + 1 = 4 + 1 = 5.
+	REQUIRE(local_entry.GetObservedVectors(3) == 5);
+	// rg 7 is the new "last" rg: watermark stays at 0 (its vec 0 is the last seen, uncommitted).
+	REQUIRE(local_entry.GetObservedVectors(7) == 0);
+	REQUIRE(local_entry.HasRowGroup(7));
+}
+
+TEST_CASE("PhysicalCacheRecorder - single chunk leaves last vec uncommitted", "[physical_recorder]") {
+	ConditionCacheEntry local_entry;
+	unordered_map<idx_t, idx_t> max_vec_per_rg;
+	optional_idx current_rg;
+
+	RecordSequence(local_entry, max_vec_per_rg, current_rg, {{.rg_idx = 0, .vec_idx = 0, .has_qualifying = true}});
+
+	// Only one chunk seen for rg 0: watermark stays at 0 (vec 0 uncommitted).
+	// The qualifying bit is recorded so future merges retain the observation.
+	REQUIRE(local_entry.GetObservedVectors(0) == 0);
+	REQUIRE(local_entry.HasRowGroup(0));
+	REQUIRE(local_entry.RowGroupVectorHasQualifyingRows(0, 0));
+}
+
+TEST_CASE("PhysicalCacheRecorder - empty rg keyed even with no qualifying rows", "[physical_recorder]") {
+	ConditionCacheEntry local_entry;
+	unordered_map<idx_t, idx_t> max_vec_per_rg;
+	optional_idx current_rg;
+
+	// rg 2 observed with no qualifying rows in any vec.
+	RecordSequence(local_entry, max_vec_per_rg, current_rg,
+	               {{.rg_idx = 2, .vec_idx = 0, .has_qualifying = false},
+	                {.rg_idx = 2, .vec_idx = 1, .has_qualifying = false},
+	                {.rg_idx = 2, .vec_idx = 2, .has_qualifying = false},
+	                {.rg_idx = 9, .vec_idx = 0, .has_qualifying = false}});
+
+	REQUIRE(local_entry.HasRowGroup(2));
+	// rg 2 transitioned to rg 9, so rg 2's watermark = max + 1 = 3.
+	REQUIRE(local_entry.GetObservedVectors(2) == 3);
+	// Bitvector for rg 2 should be empty (no qualifying rows).
+	REQUIRE(local_entry.RowGroupIsCompletelyEmpty(2));
+}
+
+TEST_CASE("PhysicalCacheRecorder - merging two task-local entries takes max watermark and OR of bits",
+          "[physical_recorder]") {
+	// Simulate two tasks each scanning a different subset of rgs, then merge into a destination.
+	ConditionCacheEntry task_a;
+	unordered_map<idx_t, idx_t> max_a;
+	optional_idx cur_a;
+	RecordSequence(task_a, max_a, cur_a,
+	               {{.rg_idx = 0, .vec_idx = 0, .has_qualifying = true},
+	                {.rg_idx = 0, .vec_idx = 1, .has_qualifying = false},
+	                {.rg_idx = 0, .vec_idx = 2, .has_qualifying = true},
+	                {.rg_idx = 1, .vec_idx = 0, .has_qualifying = false},
+	                {.rg_idx = 1, .vec_idx = 1, .has_qualifying = true},
+	                {.rg_idx = 1, .vec_idx = 2, .has_qualifying = false}});
+	// task_a finishes on rg 1: rg 0 watermark = 3 (closed), rg 1 watermark = 2 (last vec uncommitted).
+
+	ConditionCacheEntry task_b;
+	unordered_map<idx_t, idx_t> max_b;
+	optional_idx cur_b;
+	RecordSequence(task_b, max_b, cur_b,
+	               {{.rg_idx = 2, .vec_idx = 0, .has_qualifying = true},
+	                {.rg_idx = 2, .vec_idx = 1, .has_qualifying = true},
+	                {.rg_idx = 3, .vec_idx = 0, .has_qualifying = false}});
+	// task_b finishes on rg 3: rg 2 watermark = 2 (closed), rg 3 watermark = 0.
+
+	auto destination = make_shared_ptr<ConditionCacheEntry>();
+	destination->MergeFrom(task_a);
+	destination->MergeFrom(task_b);
+
+	REQUIRE(destination->GetObservedVectors(0) == 3);
+	REQUIRE(destination->GetObservedVectors(1) == 2);
+	REQUIRE(destination->GetObservedVectors(2) == 2);
+	REQUIRE(destination->GetObservedVectors(3) == 0);
+
+	REQUIRE(destination->RowGroupVectorHasQualifyingRows(0, 0));
+	REQUIRE_FALSE(destination->RowGroupVectorHasQualifyingRows(0, 1));
+	REQUIRE(destination->RowGroupVectorHasQualifyingRows(0, 2));
+	REQUIRE_FALSE(destination->RowGroupVectorHasQualifyingRows(1, 0));
+	REQUIRE(destination->RowGroupVectorHasQualifyingRows(1, 1));
+	REQUIRE(destination->RowGroupVectorHasQualifyingRows(2, 0));
+	REQUIRE(destination->RowGroupVectorHasQualifyingRows(2, 1));
+	REQUIRE(destination->RowGroupIsCompletelyEmpty(3));
+}
+
+TEST_CASE("PhysicalCacheRecorder - second pass over same rg advances watermark via max merge", "[physical_recorder]") {
+	// Two passes (e.g. two queries) observing different prefixes of rg 0 should merge into the
+	// higher watermark, demonstrating that incremental observations accumulate over time.
+	ConditionCacheEntry pass1;
+	unordered_map<idx_t, idx_t> max1;
+	optional_idx cur1;
+	RecordSequence(pass1, max1, cur1,
+	               {{.rg_idx = 0, .vec_idx = 0, .has_qualifying = true},
+	                {.rg_idx = 0, .vec_idx = 1, .has_qualifying = false},
+	                {.rg_idx = 0, .vec_idx = 2, .has_qualifying = true}});
+	// pass1 is the only rg this task; watermark stays at 2.
+	REQUIRE(pass1.GetObservedVectors(0) == 2);
+
+	ConditionCacheEntry pass2;
+	unordered_map<idx_t, idx_t> max2;
+	optional_idx cur2;
+	RecordSequence(pass2, max2, cur2,
+	               {{.rg_idx = 0, .vec_idx = 0, .has_qualifying = true},
+	                {.rg_idx = 0, .vec_idx = 1, .has_qualifying = false},
+	                {.rg_idx = 0, .vec_idx = 2, .has_qualifying = true},
+	                {.rg_idx = 0, .vec_idx = 3, .has_qualifying = false},
+	                {.rg_idx = 0, .vec_idx = 4, .has_qualifying = false}});
+	REQUIRE(pass2.GetObservedVectors(0) == 4);
+
+	auto store = make_shared_ptr<ConditionCacheEntry>();
+	store->MergeFrom(pass1);
+	REQUIRE(store->GetObservedVectors(0) == 2);
+	store->MergeFrom(pass2);
+	REQUIRE(store->GetObservedVectors(0) == 4);
+
+	// Bit-wise OR: vecs 0 and 2 (qualifying in both passes), 4 (not qualifying), 1 and 3 not set.
+	REQUIRE(store->RowGroupVectorHasQualifyingRows(0, 0));
+	REQUIRE_FALSE(store->RowGroupVectorHasQualifyingRows(0, 1));
+	REQUIRE(store->RowGroupVectorHasQualifyingRows(0, 2));
+	REQUIRE_FALSE(store->RowGroupVectorHasQualifyingRows(0, 3));
+	REQUIRE_FALSE(store->RowGroupVectorHasQualifyingRows(0, 4));
+}
+
+TEST_CASE("CacheRecorderOperatorExtension - GetName matches recorder's GetExtensionName", "[physical_recorder]") {
+	// Ensures the deserialization dispatch picks up recorder plans correctly.
+	CacheRecorderOperatorExtension ext;
+	REQUIRE(ext.GetName() == "query_condition_cache_recorder");
+}
+
+} // namespace duckdb

--- a/test/unittest/test_physical_cache_recorder.cpp
+++ b/test/unittest/test_physical_cache_recorder.cpp
@@ -15,174 +15,115 @@ struct RecorderObservation {
 	bool has_qualifying;
 };
 
-void RecordSequence(ConditionCacheEntry &local_entry, unordered_map<idx_t, idx_t> &max_vec_per_rg,
-                    optional_idx &current_rg, const vector<RecorderObservation> &observations) {
+void RecordSequence(ConditionCacheEntry &local_entry, const vector<RecorderObservation> &observations) {
 	for (const auto &obs : observations) {
-		PhysicalCacheRecorder::RecordChunkObservation(local_entry, max_vec_per_rg, current_rg, obs.rg_idx, obs.vec_idx,
-		                                              obs.has_qualifying);
+		PhysicalCacheRecorder::RecordChunkObservation(local_entry, obs.rg_idx, obs.vec_idx, obs.has_qualifying);
 	}
 }
 
 } // namespace
 
-TEST_CASE("PhysicalCacheRecorder - watermark advances on within-rg vec transition", "[physical_recorder]") {
+TEST_CASE("PhysicalCacheRecorder - marks observed bit and qualifying bit per chunk", "[physical_recorder]") {
 	ConditionCacheEntry local_entry;
-	unordered_map<idx_t, idx_t> max_vec_per_rg;
-	optional_idx current_rg;
 
-	// Observe vecs 0, 1, 2 of rg 5 in order. After each transition, the previous vec is "confirmed".
-	RecordSequence(local_entry, max_vec_per_rg, current_rg,
-	               {{.rg_idx = 5, .vec_idx = 0, .has_qualifying = true},
-	                {.rg_idx = 5, .vec_idx = 1, .has_qualifying = false},
-	                {.rg_idx = 5, .vec_idx = 2, .has_qualifying = true}});
+	RecordSequence(local_entry, {{.rg_idx = 5, .vec_idx = 0, .has_qualifying = true},
+	                             {.rg_idx = 5, .vec_idx = 1, .has_qualifying = false},
+	                             {.rg_idx = 5, .vec_idx = 2, .has_qualifying = true}});
 
-	// Watermark should be 2: vecs [0, 2) confirmed observed (vecs 0 and 1).
-	// Vec 2 is the last seen and stays uncommitted (might be partial).
-	REQUIRE(local_entry.GetObservedVectors(5) == 2);
 	REQUIRE(local_entry.HasRowGroup(5));
-	// Bits for vec 0 (qualifying), vec 1 (not), vec 2 (qualifying) should all be recorded.
+	REQUIRE(local_entry.GetObservedVectorCount(5) == 3);
 	REQUIRE(local_entry.RowGroupVectorHasQualifyingRows(5, 0));
 	REQUIRE_FALSE(local_entry.RowGroupVectorHasQualifyingRows(5, 1));
 	REQUIRE(local_entry.RowGroupVectorHasQualifyingRows(5, 2));
 }
 
-TEST_CASE("PhysicalCacheRecorder - rg transition advances previous rg's watermark to max + 1", "[physical_recorder]") {
+TEST_CASE("PhysicalCacheRecorder - non-contiguous vecs set bits exactly where observed", "[physical_recorder]") {
 	ConditionCacheEntry local_entry;
-	unordered_map<idx_t, idx_t> max_vec_per_rg;
-	optional_idx current_rg;
 
-	// Process rg 3 with vecs 0..4, then transition to rg 7 with vec 0.
-	RecordSequence(local_entry, max_vec_per_rg, current_rg,
-	               {{.rg_idx = 3, .vec_idx = 0, .has_qualifying = false},
-	                {.rg_idx = 3, .vec_idx = 1, .has_qualifying = true},
-	                {.rg_idx = 3, .vec_idx = 2, .has_qualifying = false},
-	                {.rg_idx = 3, .vec_idx = 3, .has_qualifying = true},
-	                {.rg_idx = 3, .vec_idx = 4, .has_qualifying = false},
-	                {.rg_idx = 7, .vec_idx = 0, .has_qualifying = true}});
+	// Simulating column-filter-induced gaps: scan emits chunks only for vecs 0, 3, 7.
+	RecordSequence(local_entry, {{.rg_idx = 0, .vec_idx = 0, .has_qualifying = true},
+	                             {.rg_idx = 0, .vec_idx = 3, .has_qualifying = false},
+	                             {.rg_idx = 0, .vec_idx = 7, .has_qualifying = true}});
 
-	// rg 3 fully observed in this task: watermark = max + 1 = 4 + 1 = 5.
-	REQUIRE(local_entry.GetObservedVectors(3) == 5);
-	// rg 7 is the new "last" rg: watermark stays at 0 (its vec 0 is the last seen, uncommitted).
-	REQUIRE(local_entry.GetObservedVectors(7) == 0);
-	REQUIRE(local_entry.HasRowGroup(7));
+	REQUIRE(local_entry.GetObservedVectorCount(0) == 3);
+	// Observed bits only where chunks arrived; intermediate vecs are NOT claimed observed.
+	REQUIRE(local_entry.VectorPassesFilter(0, 0) == true);  // observed + qualifying -> pass
+	REQUIRE(local_entry.VectorPassesFilter(0, 1) == true);  // unobserved -> pass-through
+	REQUIRE(local_entry.VectorPassesFilter(0, 3) == false); // observed + non-qualifying -> prune
+	REQUIRE(local_entry.VectorPassesFilter(0, 4) == true);  // unobserved
+	REQUIRE(local_entry.VectorPassesFilter(0, 7) == true);  // observed + qualifying -> pass
 }
 
-TEST_CASE("PhysicalCacheRecorder - single chunk leaves last vec uncommitted", "[physical_recorder]") {
+TEST_CASE("PhysicalCacheRecorder - single chunk keys rg and sets one bit", "[physical_recorder]") {
 	ConditionCacheEntry local_entry;
-	unordered_map<idx_t, idx_t> max_vec_per_rg;
-	optional_idx current_rg;
+	RecordSequence(local_entry, {{.rg_idx = 0, .vec_idx = 0, .has_qualifying = true}});
 
-	RecordSequence(local_entry, max_vec_per_rg, current_rg, {{.rg_idx = 0, .vec_idx = 0, .has_qualifying = true}});
-
-	// Only one chunk seen for rg 0: watermark stays at 0 (vec 0 uncommitted).
-	// The qualifying bit is recorded so future merges retain the observation.
-	REQUIRE(local_entry.GetObservedVectors(0) == 0);
 	REQUIRE(local_entry.HasRowGroup(0));
+	REQUIRE(local_entry.GetObservedVectorCount(0) == 1);
 	REQUIRE(local_entry.RowGroupVectorHasQualifyingRows(0, 0));
 }
 
-TEST_CASE("PhysicalCacheRecorder - empty rg keyed even with no qualifying rows", "[physical_recorder]") {
+TEST_CASE("PhysicalCacheRecorder - rg with no qualifying rows is keyed with observed bits set", "[physical_recorder]") {
 	ConditionCacheEntry local_entry;
-	unordered_map<idx_t, idx_t> max_vec_per_rg;
-	optional_idx current_rg;
 
-	// rg 2 observed with no qualifying rows in any vec.
-	RecordSequence(local_entry, max_vec_per_rg, current_rg,
-	               {{.rg_idx = 2, .vec_idx = 0, .has_qualifying = false},
-	                {.rg_idx = 2, .vec_idx = 1, .has_qualifying = false},
-	                {.rg_idx = 2, .vec_idx = 2, .has_qualifying = false},
-	                {.rg_idx = 9, .vec_idx = 0, .has_qualifying = false}});
+	RecordSequence(local_entry, {{.rg_idx = 2, .vec_idx = 0, .has_qualifying = false},
+	                             {.rg_idx = 2, .vec_idx = 1, .has_qualifying = false},
+	                             {.rg_idx = 2, .vec_idx = 2, .has_qualifying = false}});
 
 	REQUIRE(local_entry.HasRowGroup(2));
-	// rg 2 transitioned to rg 9, so rg 2's watermark = max + 1 = 3.
-	REQUIRE(local_entry.GetObservedVectors(2) == 3);
-	// Bitvector for rg 2 should be empty (no qualifying rows).
+	REQUIRE(local_entry.GetObservedVectorCount(2) == 3);
 	REQUIRE(local_entry.RowGroupIsCompletelyEmpty(2));
 }
 
-TEST_CASE("PhysicalCacheRecorder - merging two task-local entries takes max watermark and OR of bits",
+TEST_CASE("PhysicalCacheRecorder - merging two task-local entries ORs observed and qualifying bits",
           "[physical_recorder]") {
-	// Simulate two tasks each scanning a different subset of rgs, then merge into a destination.
 	ConditionCacheEntry task_a;
-	unordered_map<idx_t, idx_t> max_a;
-	optional_idx cur_a;
-	RecordSequence(task_a, max_a, cur_a,
-	               {{.rg_idx = 0, .vec_idx = 0, .has_qualifying = true},
-	                {.rg_idx = 0, .vec_idx = 1, .has_qualifying = false},
-	                {.rg_idx = 0, .vec_idx = 2, .has_qualifying = true},
-	                {.rg_idx = 1, .vec_idx = 0, .has_qualifying = false},
-	                {.rg_idx = 1, .vec_idx = 1, .has_qualifying = true},
-	                {.rg_idx = 1, .vec_idx = 2, .has_qualifying = false}});
-	// task_a finishes on rg 1: rg 0 watermark = 3 (closed), rg 1 watermark = 2 (last vec uncommitted).
+	RecordSequence(task_a, {{.rg_idx = 0, .vec_idx = 0, .has_qualifying = true},
+	                        {.rg_idx = 0, .vec_idx = 2, .has_qualifying = true},
+	                        {.rg_idx = 1, .vec_idx = 1, .has_qualifying = true}});
 
 	ConditionCacheEntry task_b;
-	unordered_map<idx_t, idx_t> max_b;
-	optional_idx cur_b;
-	RecordSequence(task_b, max_b, cur_b,
-	               {{.rg_idx = 2, .vec_idx = 0, .has_qualifying = true},
-	                {.rg_idx = 2, .vec_idx = 1, .has_qualifying = true},
-	                {.rg_idx = 3, .vec_idx = 0, .has_qualifying = false}});
-	// task_b finishes on rg 3: rg 2 watermark = 2 (closed), rg 3 watermark = 0.
+	RecordSequence(task_b, {{.rg_idx = 0, .vec_idx = 1, .has_qualifying = false},
+	                        {.rg_idx = 2, .vec_idx = 0, .has_qualifying = true}});
 
 	auto destination = make_shared_ptr<ConditionCacheEntry>();
 	destination->MergeFrom(task_a);
 	destination->MergeFrom(task_b);
 
-	REQUIRE(destination->GetObservedVectors(0) == 3);
-	REQUIRE(destination->GetObservedVectors(1) == 2);
-	REQUIRE(destination->GetObservedVectors(2) == 2);
-	REQUIRE(destination->GetObservedVectors(3) == 0);
+	// observed bits: union of tasks' observations.
+	REQUIRE(destination->GetObservedVectorCount(0) == 3); // vecs 0, 1, 2
+	REQUIRE(destination->GetObservedVectorCount(1) == 1); // vec 1
+	REQUIRE(destination->GetObservedVectorCount(2) == 1); // vec 0
 
 	REQUIRE(destination->RowGroupVectorHasQualifyingRows(0, 0));
 	REQUIRE_FALSE(destination->RowGroupVectorHasQualifyingRows(0, 1));
 	REQUIRE(destination->RowGroupVectorHasQualifyingRows(0, 2));
-	REQUIRE_FALSE(destination->RowGroupVectorHasQualifyingRows(1, 0));
 	REQUIRE(destination->RowGroupVectorHasQualifyingRows(1, 1));
 	REQUIRE(destination->RowGroupVectorHasQualifyingRows(2, 0));
-	REQUIRE(destination->RowGroupVectorHasQualifyingRows(2, 1));
-	REQUIRE(destination->RowGroupIsCompletelyEmpty(3));
 }
 
-TEST_CASE("PhysicalCacheRecorder - second pass over same rg advances watermark via max merge", "[physical_recorder]") {
-	// Two passes (e.g. two queries) observing different prefixes of rg 0 should merge into the
-	// higher watermark, demonstrating that incremental observations accumulate over time.
+TEST_CASE("PhysicalCacheRecorder - second pass accumulates observations across queries", "[physical_recorder]") {
 	ConditionCacheEntry pass1;
-	unordered_map<idx_t, idx_t> max1;
-	optional_idx cur1;
-	RecordSequence(pass1, max1, cur1,
-	               {{.rg_idx = 0, .vec_idx = 0, .has_qualifying = true},
-	                {.rg_idx = 0, .vec_idx = 1, .has_qualifying = false},
-	                {.rg_idx = 0, .vec_idx = 2, .has_qualifying = true}});
-	// pass1 is the only rg this task; watermark stays at 2.
-	REQUIRE(pass1.GetObservedVectors(0) == 2);
+	RecordSequence(pass1, {{.rg_idx = 0, .vec_idx = 0, .has_qualifying = true},
+	                       {.rg_idx = 0, .vec_idx = 1, .has_qualifying = false}});
 
 	ConditionCacheEntry pass2;
-	unordered_map<idx_t, idx_t> max2;
-	optional_idx cur2;
-	RecordSequence(pass2, max2, cur2,
-	               {{.rg_idx = 0, .vec_idx = 0, .has_qualifying = true},
-	                {.rg_idx = 0, .vec_idx = 1, .has_qualifying = false},
-	                {.rg_idx = 0, .vec_idx = 2, .has_qualifying = true},
-	                {.rg_idx = 0, .vec_idx = 3, .has_qualifying = false},
-	                {.rg_idx = 0, .vec_idx = 4, .has_qualifying = false}});
-	REQUIRE(pass2.GetObservedVectors(0) == 4);
+	RecordSequence(pass2, {{.rg_idx = 0, .vec_idx = 2, .has_qualifying = true},
+	                       {.rg_idx = 0, .vec_idx = 3, .has_qualifying = false}});
 
 	auto store = make_shared_ptr<ConditionCacheEntry>();
 	store->MergeFrom(pass1);
-	REQUIRE(store->GetObservedVectors(0) == 2);
+	REQUIRE(store->GetObservedVectorCount(0) == 2);
 	store->MergeFrom(pass2);
-	REQUIRE(store->GetObservedVectors(0) == 4);
+	REQUIRE(store->GetObservedVectorCount(0) == 4);
 
-	// Bit-wise OR: vecs 0 and 2 (qualifying in both passes), 4 (not qualifying), 1 and 3 not set.
 	REQUIRE(store->RowGroupVectorHasQualifyingRows(0, 0));
 	REQUIRE_FALSE(store->RowGroupVectorHasQualifyingRows(0, 1));
 	REQUIRE(store->RowGroupVectorHasQualifyingRows(0, 2));
 	REQUIRE_FALSE(store->RowGroupVectorHasQualifyingRows(0, 3));
-	REQUIRE_FALSE(store->RowGroupVectorHasQualifyingRows(0, 4));
 }
 
 TEST_CASE("CacheRecorderOperatorExtension - GetName matches recorder's GetExtensionName", "[physical_recorder]") {
-	// Ensures the deserialization dispatch picks up recorder plans correctly.
 	CacheRecorderOperatorExtension ext;
 	REQUIRE(ext.GetName() == "query_condition_cache_recorder");
 }


### PR DESCRIPTION
Closes: #75

## Summary

This PR replaces the synchronous full-table build that the optimizer used to
run on cache miss with a `PhysicalCacheRecorder` operator that observes the
user's own query and builds the cache as a side-effect. The first query on
a new predicate no longer pays an extra full-table scan.

An `observed_vectors` watermark is added to `RowGroupFilter` so the cache
can distinguish "observed empty" (safe to prune) from "not yet observed"
(must scan). Recorder injection is narrow: it only runs on a full cache
miss. Partial refill and scan-skipped row groups are tracked as TODOs.

## Operator Hierarchy

Cache miss — optimizer injects the recorder above `LogicalGet`:

```
LogicalFilter (user's predicate)
  └─ LogicalCacheRecorder                ← new; evaluates predicate, records
       └─ LogicalGet
            ├─ column_ids: [..., ROW_ID]
            ├─ projection_ids: [..., ROW_ID]   ← surfaced for recorder
            └─ table_filters[ROW_ID] = CacheExpressionFilter
```

Cache hit — no recorder, filter only:

```
LogicalFilter (user's predicate)
  └─ LogicalGet
       ├─ column_ids: [..., ROW_ID]
       ├─ projection_ids: [...]           ← ROW_ID read but not projected
       └─ table_filters[ROW_ID] = CacheExpressionFilter
```

Runtime flow for the cache-miss case:

```
PhysicalTableScan
  │ emits chunks (post zone-map / table filter)
  ▼
PhysicalCacheRecorder::Execute
  ├─ compute (rg_idx, vec_idx) from first row_id
  ├─ expr_executor.SelectExpression(chunk)
  └─ RecordChunkObservation -> task-local bitvector + watermark
  │ chunk.Reference(input)   (pass-through)
  ▼
PhysicalFilter / downstream ops

... at query end ...

PhysicalCacheRecorder::OperatorFinalize
  ├─ merge all task-local entries -> destination
  └─ store->Upsert(key, destination)
```
