### PR TITLE
Adopt bitset for RowGroupFilter

### DIFF
--- a/src/include/query_condition_cache_state.hpp
+++ b/src/include/query_condition_cache_state.hpp
@@ -4,8 +4,8 @@
 #include "concurrency/annotated_mutex.hpp"
 #include "concurrency/thread_annotation.hpp"
 
-#include "duckdb/common/array.hpp"
 #include "duckdb/common/atomic.hpp"
+#include "duckdb/common/bitset.hpp"
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/unordered_set.hpp"
@@ -15,15 +15,13 @@ namespace duckdb {
 
 // Derived from DuckDB's compile-time configurable constants
 inline constexpr idx_t VECTORS_PER_ROW_GROUP = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
-inline constexpr idx_t BITVECTOR_ARRAY_SIZE = (VECTORS_PER_ROW_GROUP + 63) / 64;
 static_assert(DEFAULT_ROW_GROUP_SIZE % STANDARD_VECTOR_SIZE == 0,
               "DEFAULT_ROW_GROUP_SIZE must be divisible by STANDARD_VECTOR_SIZE");
 
 // Per row-group bitvector: bit[i] = 1 means vector i has at least one qualifying row,
 // for 0 <= i < VECTORS_PER_ROW_GROUP.
-// Backed by array<uint64_t, N> to support configurable row group / vector sizes.
 struct RowGroupFilter {
-	array<uint64_t, BITVECTOR_ARRAY_SIZE> matching_vectors = {};
+	bitset<VECTORS_PER_ROW_GROUP> matching_vectors;
 
 	RowGroupFilter() = default;
 
@@ -34,6 +32,7 @@ struct RowGroupFilter {
 	void SetVector(idx_t vector_index);
 	bool VectorHasRows(idx_t vector_index) const;
 	bool IsEmpty() const;
+	idx_t QualifyingVectorCount() const;
 	void MergeFrom(const RowGroupFilter &other);
 };
 

--- a/src/query_condition_cache_state.cpp
+++ b/src/query_condition_cache_state.cpp
@@ -10,31 +10,28 @@ namespace duckdb {
 
 RowGroupFilter::RowGroupFilter(const vector<idx_t> &qualifying_vectors) {
 	for (const auto &vec_idx : qualifying_vectors) {
-		matching_vectors.at(vec_idx / 64) |= (1ULL << (vec_idx % 64));
+		matching_vectors.set(vec_idx);
 	}
 }
 
 void RowGroupFilter::SetVector(idx_t vector_index) {
-	matching_vectors.at(vector_index / 64) |= (1ULL << (vector_index % 64));
+	matching_vectors.set(vector_index);
 }
 
 bool RowGroupFilter::VectorHasRows(idx_t vector_index) const {
-	return (matching_vectors.at(vector_index / 64) >> (vector_index % 64)) & 1ULL;
+	return matching_vectors.test(vector_index);
 }
 
 bool RowGroupFilter::IsEmpty() const {
-	for (const auto &w : matching_vectors) {
-		if (w != 0) {
-			return false;
-		}
-	}
-	return true;
+	return matching_vectors.none();
+}
+
+idx_t RowGroupFilter::QualifyingVectorCount() const {
+	return matching_vectors.count();
 }
 
 void RowGroupFilter::MergeFrom(const RowGroupFilter &other) {
-	for (idx_t i = 0; i < BITVECTOR_ARRAY_SIZE; ++i) {
-		matching_vectors[i] |= other.matching_vectors[i];
-	}
+	matching_vectors |= other.matching_vectors;
 }
 
 // ------- CONDITION_CACHE_ENTRY -------
@@ -48,7 +45,6 @@ optional_idx ConditionCacheEntry::GetEstimatedCacheMemory() const {
 
 CacheEntryStats ConditionCacheEntry::ComputeStats(idx_t total_rows) const {
 	concurrency::lock_guard<concurrency::mutex> guard(lock);
-	constexpr idx_t vectors_per_row_group = DEFAULT_ROW_GROUP_SIZE / STANDARD_VECTOR_SIZE;
 
 	idx_t qualifying_vectors = 0;
 	idx_t qualifying_row_groups = 0;
@@ -56,16 +52,12 @@ CacheEntryStats ConditionCacheEntry::ComputeStats(idx_t total_rows) const {
 		if (!filter.IsEmpty()) {
 			++qualifying_row_groups;
 		}
-		for (idx_t v = 0; v < vectors_per_row_group; ++v) {
-			if (filter.VectorHasRows(v)) {
-				++qualifying_vectors;
-			}
-		}
+		qualifying_vectors += filter.QualifyingVectorCount();
 	}
 
 	idx_t full_row_groups = total_rows / DEFAULT_ROW_GROUP_SIZE;
 	idx_t remaining_rows = total_rows % DEFAULT_ROW_GROUP_SIZE;
-	idx_t total_vectors = full_row_groups * vectors_per_row_group;
+	idx_t total_vectors = full_row_groups * VECTORS_PER_ROW_GROUP;
 	if (remaining_rows > 0) {
 		total_vectors += (remaining_rows + STANDARD_VECTOR_SIZE - 1) / STANDARD_VECTOR_SIZE;
 	}


### PR DESCRIPTION
## Summary

This PR switches `RowGroupFilter` from a hand-rolled `array<uint64_t, N>`
bitvector to `duckdb/common/bitset.hpp` for safer and clearer bit operations. 
The public API is unchanged, so callers and tests
need no updates.

## Related Issues

- N/A
