### PR TITLE
Fix cache filter alignment across row groups

### DIFF
--- a/src/query_condition_cache_filter.cpp
+++ b/src/query_condition_cache_filter.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {
@@ -42,23 +43,58 @@ ScalarFunction ConditionCacheFilterFunction() {
 void ConditionCacheFilterFn(DataChunk &args, ExpressionState &state, Vector &result) {
 	ALWAYS_ASSERT(args.size() > 0);
 	ALWAYS_ASSERT(args.ColumnCount() > 0);
-	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<ConditionCacheFilterBindData>();
-	auto &entry = bind_data.cache_entry;
+	const auto &bind_data = state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<ConditionCacheFilterBindData>();
+	const auto &entry = bind_data.cache_entry;
 
 	auto &input_vec = args.data[0];
 
 	UnifiedVectorFormat vdata;
 	input_vec.ToUnifiedFormat(args.size(), vdata);
-	auto row_ids = UnifiedVectorFormat::GetData<int64_t>(vdata);
+	const auto row_ids = UnifiedVectorFormat::GetData<int64_t>(vdata);
 
-	auto first_idx = vdata.sel->get_index(0);
-	int64_t first_row_id = row_ids[first_idx];
+	const auto first_idx = vdata.sel->get_index(0);
+	const int64_t first_row_id = row_ids[first_idx];
 
-	idx_t rg_idx = NumericCast<idx_t>(first_row_id) / DEFAULT_ROW_GROUP_SIZE;
-	idx_t vec_idx = (NumericCast<idx_t>(first_row_id) % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
-	bool passes = entry->VectorPassesFilter(rg_idx, vec_idx);
+	const auto row_id_passes = [&](int64_t row_id) {
+		const auto numeric_row_id = NumericCast<idx_t>(row_id);
+		const auto rg_idx = numeric_row_id / DEFAULT_ROW_GROUP_SIZE;
+		const auto vec_idx = (numeric_row_id % DEFAULT_ROW_GROUP_SIZE) / STANDARD_VECTOR_SIZE;
+		return entry->VectorPassesFilter(rg_idx, vec_idx);
+	};
 
-	result.Reference(Value::BOOLEAN(passes));
+	const bool passes = row_id_passes(first_row_id);
+
+	// DuckDB scan vectors are aligned relative to their physical row group. A
+	// physical row group can contain fewer than DEFAULT_ROW_GROUP_SIZE rows, so
+	// one scan vector can overlap two cache vectors derived from absolute ROW_IDs.
+	const auto first_cache_vector = NumericCast<idx_t>(first_row_id) / STANDARD_VECTOR_SIZE;
+	const auto last_idx = vdata.sel->get_index(args.size() - 1);
+	const auto last_row_id = row_ids[last_idx];
+	const auto last_cache_vector = NumericCast<idx_t>(last_row_id) / STANDARD_VECTOR_SIZE;
+
+	if (first_cache_vector == last_cache_vector) {
+		result.Reference(Value::BOOLEAN(passes));
+		return;
+	}
+
+	// A native table-filter invocation covers at most one physical scan vector,
+	// and its selection remains ordered. It can therefore overlap at most two
+	// adjacent cache vectors. Look up both decisions once, then classify rows by
+	// their absolute cache-vector index without taking the entry lock per row.
+	if (last_cache_vector == first_cache_vector + 1) {
+		const auto last_passes = row_id_passes(last_row_id);
+		if (last_passes == passes) {
+			result.Reference(Value::BOOLEAN(passes));
+			return;
+		}
+		UnaryExecutor::Execute<int64_t, bool>(input_vec, result, args.size(), [&](int64_t row_id) {
+			return NumericCast<idx_t>(row_id) / STANDARD_VECTOR_SIZE == first_cache_vector ? passes : last_passes;
+		});
+		return;
+	}
+
+	// Conservative fallback for unexpected, non-contiguous input.
+	UnaryExecutor::Execute<int64_t, bool>(input_vec, result, args.size(), row_id_passes);
 }
 
 CacheExpressionFilter::CacheExpressionFilter(unique_ptr<Expression> expr_p, shared_ptr<ConditionCacheEntry> entry)

--- a/test/sql/condition_cache_alignment.test
+++ b/test/sql/condition_cache_alignment.test
@@ -1,0 +1,71 @@
+# name: test/sql/condition_cache_alignment.test
+# description: Test cache filtering across misaligned physical row groups
+# group: [sql]
+
+require query_condition_cache
+
+# Parallel CSV ingestion can produce intermediate partial physical row groups.
+# Preserve input order so the stored predicate pattern remains deterministic.
+statement ok
+SET threads = 8;
+
+statement ok
+SET preserve_insertion_order = true;
+
+statement ok
+COPY (
+    SELECT
+        i AS id,
+        CASE WHEN (i // 2048) % 2 = 0
+             THEN 'needle-' || i::VARCHAR
+             ELSE 'ordinary-' || i::VARCHAR
+        END AS content
+    FROM range(750000) r(i)
+) TO '__TEST_DIR__/condition_cache_alignment.csv' (HEADER);
+
+statement ok
+CREATE TABLE alignment_t AS
+SELECT *
+FROM read_csv_auto('__TEST_DIR__/condition_cache_alignment.csv', header = true);
+
+statement ok
+CHECKPOINT;
+
+# Ensure the table contains multiple intermediate partial row groups. Their
+# scan vectors are aligned to physical row-group starts, which need not align
+# with cache vectors derived from absolute ROW_IDs.
+query I
+SELECT count(*) >= 2
+FROM (
+    SELECT row_group_id, max(start + count) AS row_count
+    FROM pragma_storage_info('alignment_t')
+    GROUP BY row_group_id
+) row_groups
+WHERE row_count < 122880;
+----
+true
+
+# Establish the exact result without the condition cache.
+statement ok
+SET use_query_condition_cache = false;
+
+query I
+SELECT count(*) FROM alignment_t WHERE content LIKE '%needle%';
+----
+375216
+
+# A cache miss builds the entry and applies it to the original query.
+statement ok
+SET use_query_condition_cache = true;
+
+query I
+SELECT count(*) FROM alignment_t WHERE content LIKE '%needle%';
+----
+375216
+
+# Reusing the entry must preserve rows when a scan vector crosses a cache
+# boundary.
+query I
+SELECT count(*) FROM alignment_t WHERE content LIKE '%needle%';
+----
+375216

--- a/test/sql/condition_cache_auto.test
+++ b/test/sql/condition_cache_auto.test
@@ -7,9 +7,11 @@ require query_condition_cache
 statement ok
 CREATE TABLE t AS SELECT i AS id, i % 100 AS val FROM range(500000) t(i);
 
-# Cache enabled by default, query triggers auto cache build
-statement ok
+# Auto-build preserves the query result
+query I
 SELECT count(*) FROM t WHERE val = 42;
+----
+5000
 
 # Cache was built automatically
 query IIII
@@ -17,9 +19,11 @@ SELECT * FROM condition_cache_info('t', 'val = 42');
 ----
 5	5	245	245
 
-# Different predicate gets its own cache entry
-statement ok
+# A different predicate builds a separate cache entry
+query I
 SELECT count(*) FROM t WHERE id < 3000;
+----
+3000
 
 query IIII
 SELECT * FROM condition_cache_info('t', 'id < 3000');

--- a/test/unittest/test_filter.cpp
+++ b/test/unittest/test_filter.cpp
@@ -100,10 +100,10 @@ TEST_CASE("ConditionCacheFilterFn handles scan vectors crossing cache-vector bou
 	executor.ExecuteExpression(input, result);
 
 	for (idx_t idx = 0; idx < 512; idx++) {
-		REQUIRE(result.GetValue(idx).GetValue<bool>() == false);
+		REQUIRE(!result.GetValue(idx).GetValue<bool>());
 	}
 	for (idx_t idx = 512; idx < STANDARD_VECTOR_SIZE; idx++) {
-		REQUIRE(result.GetValue(idx).GetValue<bool>() == true);
+		REQUIRE(result.GetValue(idx).GetValue<bool>());
 	}
 }
 

--- a/test/unittest/test_filter.cpp
+++ b/test/unittest/test_filter.cpp
@@ -2,11 +2,17 @@
 #include "query_condition_cache_filter.hpp"
 #include "query_condition_cache_state.hpp"
 
+#include "duckdb/common/allocator.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
-#include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/storage/statistics/numeric_stats.hpp"
 #include "test_helpers.hpp"
@@ -64,6 +70,40 @@ TEST_CASE("CacheExpressionFilter - CheckStatistics", "[query_condition_cache]") 
 	SECTION("stats without min/max: no pruning") {
 		auto stats = NumericStats::CreateUnknown(LogicalType {LogicalTypeId::BIGINT});
 		REQUIRE(filter.CheckStatistics(stats) == FilterPropagateResult::NO_PRUNING_POSSIBLE);
+	}
+}
+
+TEST_CASE("ConditionCacheFilterFn handles scan vectors crossing cache-vector boundaries", "[query_condition_cache]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	const auto entry = make_shared_ptr<ConditionCacheEntry>();
+	entry->EnsureRowGroup(/*rg_idx=*/0);
+	entry->SetQualifyingVector(/*rg_idx=*/0, /*vec_idx=*/1);
+
+	vector<unique_ptr<Expression>> children;
+	children.push_back(make_uniq<BoundReferenceExpression>(LogicalType {LogicalTypeId::BIGINT}, 0));
+	const auto expression =
+	    make_uniq<BoundFunctionExpression>(LogicalType {LogicalTypeId::BOOLEAN}, ConditionCacheFilterFunction(),
+	                                       std::move(children), make_uniq<ConditionCacheFilterBindData>(entry));
+	ExpressionExecutor executor(*con.context, *expression);
+
+	DataChunk input;
+	input.Initialize(Allocator::Get(*con.context), {LogicalType {LogicalTypeId::BIGINT}});
+	input.SetCardinality(STANDARD_VECTOR_SIZE);
+	const auto row_ids = FlatVector::GetData<int64_t>(input.data[0]);
+	for (idx_t idx = 0; idx < STANDARD_VECTOR_SIZE; idx++) {
+		row_ids[idx] = NumericCast<int64_t>(1536 + idx);
+	}
+
+	Vector result(LogicalType {LogicalTypeId::BOOLEAN});
+	executor.ExecuteExpression(input, result);
+
+	for (idx_t idx = 0; idx < 512; idx++) {
+		REQUIRE(result.GetValue(idx).GetValue<bool>() == false);
+	}
+	for (idx_t idx = 512; idx < STANDARD_VECTOR_SIZE; idx++) {
+		REQUIRE(result.GetValue(idx).GetValue<bool>() == true);
 	}
 }
 


### PR DESCRIPTION
 ## Summary

  The cache originally assumed that every DuckDB scan vector aligned with a
  cache boundary derived from `STANDARD_VECTOR_SIZE`. Based on that assumption,
  the filter checked only the first row ID and reused its cache decision for the
  entire scan vector.

  This assumption fails when a physical row group contains fewer than
  `DEFAULT_ROW_GROUP_SIZE` rows. The next row group can begin between two cache
  boundaries, causing one scan vector to overlap two cache vectors. Reusing only
  the first decision can then incorrectly discard qualifying rows.

  This change checks the first and last row IDs of each scan vector. When the
  vector crosses a cache boundary, each row receives the decision for its
  corresponding cache vector.

  Regression tests cover misaligned scan vectors and automatic cache builds.

  ## Related issues

  None.